### PR TITLE
Add context_include and context_exclude to project configuration

### DIFF
--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -46,6 +46,19 @@ type ProjectConfig struct {
 	// Source code is handled separately by GoSourceDirs.
 	ContextSources string `yaml:"context_sources"`
 
+	// ContextInclude is a newline-delimited list of glob patterns. When
+	// set, these patterns replace the standard document discovery
+	// (resolveStandardFiles). Only matching files are loaded into the
+	// project context. ContextSources still adds extras on top.
+	// When empty, the default standard file discovery applies.
+	ContextInclude string `yaml:"context_include"`
+
+	// ContextExclude is a newline-delimited list of glob patterns. Files
+	// matching any pattern (or under a matching directory) are excluded
+	// from the project context. Applied to docs, context sources, and
+	// source code. Use "." to exclude everything.
+	ContextExclude string `yaml:"context_exclude"`
+
 	// Release is the target release version (e.g., "01.0"). When set,
 	// use cases and test suites are filtered to only include files whose
 	// release version is <= this value. PRDs are filtered to only those

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -348,7 +348,7 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 
 	planningConst := orDefault(o.cfg.Cobbler.PlanningConstitution, planningConstitution)
 
-	projectCtx, ctxErr := buildProjectContext(existingIssues, o.cfg.Project.GoSourceDirs, o.cfg.Project.ContextSources, o.cfg.Project.Release)
+	projectCtx, ctxErr := buildProjectContext(existingIssues, o.cfg.Project)
 	if ctxErr != nil {
 		logf("buildMeasurePrompt: buildProjectContext error: %v", ctxErr)
 		projectCtx = &ProjectContext{}

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -562,7 +562,7 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 			logf("buildStitchPrompt: chdir to worktree error: %v", err)
 		} else {
 			defer os.Chdir(orig)
-			ctx, ctxErr := buildProjectContext("", o.cfg.Project.GoSourceDirs, o.cfg.Project.ContextSources, o.cfg.Project.Release)
+			ctx, ctxErr := buildProjectContext("", o.cfg.Project)
 			if ctxErr != nil {
 				logf("buildStitchPrompt: buildProjectContext error: %v", ctxErr)
 			} else {


### PR DESCRIPTION
## Summary
- Add `context_include` and `context_exclude` fields to `ProjectConfig` for controlling which files are assembled into the measure/stitch project context
- `context_include` replaces standard document discovery with explicit glob patterns; `context_exclude` removes matching files from docs, context sources, and source code
- Enables alternative prompt strategies (e.g., make-work/do-work with `context_exclude: "."` and `go_source_dirs: []` for empty project context)
- Refactor `buildProjectContext` to accept `ProjectConfig` instead of individual parameters
- Add `resolveFileSet` helper and "extra" case in `loadContextFileInto`

## Test plan
- [x] `go build ./...` compiles clean
- [x] `go test ./...` all tests pass
- [x] New tests: `TestContextExclude`, `TestContextIncludeReplacesStandard`, `TestContextExcludeDirectory`, `TestContextIncludeWithExclude`, `TestContextExcludeEverything`
- [ ] Manual: default config (empty include/exclude) produces identical behavior
- [ ] Manual: `context_exclude: "."` + `go_source_dirs: []` produces empty project context

🤖 Generated with [Claude Code](https://claude.com/claude-code)