### PR TITLE
GH-121: generator:run should accept cycle count argument

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -247,7 +247,9 @@ func (Cobbler) Reset() error { return newOrch().CobblerReset() }
 func (Generator) Start() error { return newOrch().GeneratorStart() }
 
 // Run executes N cycles of measure + stitch within the current generation.
-func (Generator) Run() error { return newOrch().GeneratorRun() }
+// Pass cycles > 0 to override the generation.cycles value in configuration.yaml for this run only.
+// Pass 0 to use the configured value (or run until all issues are closed if also 0).
+func (Generator) Run(cycles int) error { return newOrch().GeneratorRun(cycles) }
 
 // Resume recovers from an interrupted run and continues.
 func (Generator) Resume() error { return newOrch().GeneratorResume() }

--- a/orchestrator.go.tmpl
+++ b/orchestrator.go.tmpl
@@ -117,7 +117,10 @@ func (Cobbler) Reset() error { return newOrch().CobblerReset() }
 func (Generator) Start() error { return newOrch().GeneratorStart() }
 
 // Run executes N cycles of measure + stitch within the current generation.
-func (Generator) Run() error { return newOrch().GeneratorRun() }
+// Run executes N cycles of measure + stitch within the current generation.
+// Pass cycles > 0 to override the generation.cycles value in configuration.yaml for this run only.
+// Pass 0 to use the configured value (or run until all issues are closed if also 0).
+func (Generator) Run(cycles int) error { return newOrch().GeneratorRun(cycles) }
 
 // Resume recovers from an interrupted run and continues.
 func (Generator) Resume() error { return newOrch().GeneratorResume() }

--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -16,13 +16,17 @@ import (
 )
 
 // GeneratorRun executes N cycles of Measure + Stitch within the current generation.
-// Reads cycles and max-issues from Config.
-func (o *Orchestrator) GeneratorRun() error {
+// If cycles > 0 it overrides configuration.yaml's generation.cycles for this run only.
+// cycles == 0 means use the configured value (or unlimited if that is also 0).
+func (o *Orchestrator) GeneratorRun(cycles int) error {
 	currentBranch, err := gitCurrentBranch()
 	if err != nil {
 		return fmt.Errorf("getting current branch: %w", err)
 	}
 
+	if cycles > 0 {
+		o.cfg.Generation.Cycles = cycles
+	}
 	o.cfg.Generation.Branch = currentBranch
 	setGeneration(currentBranch)
 	defer clearGeneration()


### PR DESCRIPTION
## Summary

Adds a `cycles int` parameter to `mage generator:run`. Passing `cycles > 0` overrides `generation.cycles` from `configuration.yaml` for that run only; passing `0` uses the configured value (unchanged behaviour). Users can now run `mage generator:run 3` without editing the config file.

## Changes

- **#123** — `GeneratorRun(cycles int)` in `pkg/orchestrator/generator.go`: if `cycles > 0`, overrides `o.cfg.Generation.Cycles` before `RunCycles`
- `magefiles/magefile.go`: `Run(cycles int)` passes through to `GeneratorRun`
- `orchestrator.go.tmpl`: updated to match `magefile.go`

## Stats

  Lines of code (Go, production): 10043 (+4)
  Lines of code (Go, tests):      10354 (+0)
  Words (documentation):          18780 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] `mage test:unit` passes
- [ ] `mage generator:run 3` runs exactly 3 cycles
- [ ] `mage generator:run 0` behaves identically to old `mage generator:run`

Closes #121