### PR TITLE
GH-117: Fix measure agent releases filter enforcement

### DIFF
--- a/pkg/orchestrator/measure_test.go
+++ b/pkg/orchestrator/measure_test.go
@@ -576,6 +576,47 @@ func TestParseCompletedWork_NilInput(t *testing.T) {
 	}
 }
 
+func TestMeasureReleasesConstraint_WithReleases(t *testing.T) {
+	t.Parallel()
+	got := measureReleasesConstraint([]string{"01.0", "02.0"}, "")
+	if !contains(got, "01.0, 02.0") {
+		t.Errorf("expected releases list in constraint, got %q", got)
+	}
+	if !contains(got, "MUST") {
+		t.Errorf("expected hard constraint keyword, got %q", got)
+	}
+}
+
+func TestMeasureReleasesConstraint_WithRelease(t *testing.T) {
+	t.Parallel()
+	got := measureReleasesConstraint(nil, "01.0")
+	if !contains(got, "01.0") {
+		t.Errorf("expected release in constraint, got %q", got)
+	}
+	if !contains(got, "MUST") {
+		t.Errorf("expected hard constraint keyword, got %q", got)
+	}
+}
+
+func TestMeasureReleasesConstraint_None(t *testing.T) {
+	t.Parallel()
+	got := measureReleasesConstraint(nil, "")
+	if got != "" {
+		t.Errorf("expected empty constraint, got %q", got)
+	}
+}
+
+func TestMeasureReleasesConstraint_ReleasesTakePrecedence(t *testing.T) {
+	t.Parallel()
+	got := measureReleasesConstraint([]string{"01.0"}, "00.5")
+	if !contains(got, "01.0") {
+		t.Errorf("expected releases list in constraint, got %q", got)
+	}
+	if contains(got, "00.5") {
+		t.Errorf("expected legacy release to be ignored when releases is set, got %q", got)
+	}
+}
+
 // contains checks if substr is in s. Avoids importing strings in test.
 func contains(s, substr string) bool {
 	for i := 0; i+len(substr) <= len(s); i++ {


### PR DESCRIPTION
## Summary

Adds an explicit hard constraint to the measure prompt when `project.releases` or `project.release` is configured. The roadmap (`road-map.yaml`) is included in the prompt unfiltered, so without this constraint the agent could propose tasks from adjacent releases after exhausting the configured ones.

## Changes

- **#129**: Added `measureReleasesConstraint()` helper in `measure.go` that builds a "You MUST only propose tasks for releases [X]" constraint; called in `buildMeasurePrompt()` to append to `doc.Constraints`; 4 unit tests added

## Stats

  Lines of code (Go, production): 10067 (+24)
  Lines of code (Go, tests):      10395 (+41)
  Words (documentation):          18780 (+0)

## Test plan

- [x] `mage test:unit` passes
- [x] `mage analyze` passes
- [x] Constraint appears in prompt when releases configured; absent when unconfigured

Closes #117