### PR TITLE
GH-113: Fix scaffold:pop to remove .cobbler/ directory

### DIFF
--- a/pkg/orchestrator/scaffold.go
+++ b/pkg/orchestrator/scaffold.go
@@ -193,9 +193,10 @@ func (o *Orchestrator) Scaffold(targetDir, orchestratorRoot string) error {
 }
 
 // Uninstall removes the files added by Scaffold from targetDir:
-// magefiles/orchestrator.go, docs/constitutions/, docs/prompts/, and
-// configuration.yaml. It also removes the orchestrator replace directive
-// from magefiles/go.mod and runs go mod tidy to clean up unused dependencies.
+// magefiles/orchestrator.go, docs/constitutions/, docs/prompts/,
+// configuration.yaml, and .cobbler/. It also removes the orchestrator replace
+// directive from magefiles/go.mod and runs go mod tidy to clean up unused
+// dependencies.
 func (o *Orchestrator) Uninstall(targetDir string) error {
 	logf("uninstall: removing orchestrator files from %s", targetDir)
 
@@ -217,6 +218,13 @@ func (o *Orchestrator) Uninstall(targetDir string) error {
 		return fmt.Errorf("removing docs/prompts: %w", err)
 	}
 	logf("uninstall: removed %s", promptsDir)
+
+	// Remove .cobbler/ directory written by Scaffold.
+	cobblerDir := filepath.Join(targetDir, dirCobbler)
+	if err := os.RemoveAll(cobblerDir); err != nil {
+		return fmt.Errorf("removing .cobbler: %w", err)
+	}
+	logf("uninstall: removed %s", cobblerDir)
 
 	// Remove configuration.yaml.
 	cfgPath := filepath.Join(targetDir, DefaultConfigFile)

--- a/pkg/orchestrator/scaffold_test.go
+++ b/pkg/orchestrator/scaffold_test.go
@@ -196,6 +196,34 @@ func TestRemoveIfExists_MissingFile_IsNoOp(t *testing.T) {
 	}
 }
 
+// --- Uninstall .cobbler/ cleanup ---
+
+func TestUninstall_RemovesCobblerDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Simulate what Scaffold writes: create .cobbler/ with context files.
+	cobblerDir := filepath.Join(dir, dirCobbler)
+	if err := os.MkdirAll(cobblerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"measure_context.yaml", "stitch_context.yaml"} {
+		if err := os.WriteFile(filepath.Join(cobblerDir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	o := &Orchestrator{}
+	// Uninstall should not fail even when other scaffolded files are absent.
+	if err := o.Uninstall(dir); err != nil {
+		t.Fatalf("Uninstall: %v", err)
+	}
+
+	if _, err := os.Stat(cobblerDir); !os.IsNotExist(err) {
+		t.Errorf(".cobbler/ should have been removed, got stat err: %v", err)
+	}
+}
+
 // --- writeScaffoldConfig ---
 
 func TestWriteScaffoldConfig_WritesValidYAML(t *testing.T) {


### PR DESCRIPTION
## Summary

`Uninstall()` now removes `.cobbler/` along with the other files it already cleaned up. A push/pop round-trip on a target repository no longer leaves `.cobbler/measure_context.yaml` and `.cobbler/stitch_context.yaml` behind.

## Changes

- **#131**: Added `os.RemoveAll(filepath.Join(targetDir, dirCobbler))` in `Uninstall()` after removing `docs/prompts/`; updated doc comment; added `TestUninstall_RemovesCobblerDir` unit test

## Stats

  Lines of code (Go, production): 10075 (+8)
  Lines of code (Go, tests):      10423 (+28)
  Words (documentation):          18780 (+0)

## Test plan

- [x] `mage test:unit` passes
- [x] `TestUninstall_RemovesCobblerDir` verifies .cobbler/ is removed

Closes #113