### PR TITLE
GH-114: Fix vscode:push and vscode:pop no-arg invocation

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -313,15 +313,19 @@ func (Compare) Run(argA, argB string) error {
 
 // --- Vscode targets ---
 
-// Push compiles the extension and installs it into VS Code.
-// Pass a profile name to target a specific VS Code profile (e.g., mage vscode:push GO).
-// Pass an empty string to install to the default profile.
-func (Vscode) Push(profile string) error { return newOrch().VscodePush(profile) }
+// Push compiles the extension and installs it into the default VS Code profile.
+func (Vscode) Push() error { return newOrch().VscodePush("") }
 
-// Pop uninstalls the extension from VS Code.
-// Pass a profile name to target a specific VS Code profile (e.g., mage vscode:pop GO).
-// Pass an empty string to uninstall from the default profile.
-func (Vscode) Pop(profile string) error { return newOrch().VscodePop(profile) }
+// PushProfile compiles the extension and installs it into a named VS Code profile
+// (e.g., mage vscode:pushProfile GO).
+func (Vscode) PushProfile(profile string) error { return newOrch().VscodePush(profile) }
+
+// Pop uninstalls the extension from the default VS Code profile.
+func (Vscode) Pop() error { return newOrch().VscodePop("") }
+
+// PopProfile uninstalls the extension from a named VS Code profile
+// (e.g., mage vscode:popProfile GO).
+func (Vscode) PopProfile(profile string) error { return newOrch().VscodePop(profile) }
 
 // --- Constitution targets ---
 


### PR DESCRIPTION
## Summary

Splits `Vscode.Push(profile)` and `Vscode.Pop(profile)` into no-arg default variants (`Push`, `Pop`) and named-profile variants (`PushProfile`, `PopProfile`). Users can now run `mage vscode:pop` and `mage vscode:push` without arguments for the common case.

## Changes

- **#133**: Replaced `Vscode.Push(profile string)` with `Push()` + `PushProfile(profile string)`; replaced `Vscode.Pop(profile string)` with `Pop()` + `PopProfile(profile string)` in `magefiles/magefile.go`

## Stats

  Lines of code (Go, production): 10075 (+0)
  Lines of code (Go, tests):      10423 (+0)
  Words (documentation):          18780 (+0)

## Test plan

- [x] `mage -l` shows `vscode:pop`, `vscode:popProfile`, `vscode:push`, `vscode:pushProfile`
- [x] `mage test:unit` passes

Closes #114