### PR TITLE
GH-107: Fix generator:run no-arg invocation regression

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -246,10 +246,13 @@ func (Cobbler) Reset() error { return newOrch().CobblerReset() }
 // Start begins a new generation trail.
 func (Generator) Start() error { return newOrch().GeneratorStart() }
 
-// Run executes N cycles of measure + stitch within the current generation.
-// Pass cycles > 0 to override the generation.cycles value in configuration.yaml for this run only.
-// Pass 0 to use the configured value (or run until all issues are closed if also 0).
-func (Generator) Run(cycles int) error { return newOrch().GeneratorRun(cycles) }
+// Run executes measure + stitch cycles using the generation.cycles value in configuration.yaml.
+// Use RunN to override the cycle count for a single invocation.
+func (Generator) Run() error { return newOrch().GeneratorRun(0) }
+
+// RunN executes exactly n cycles of measure + stitch within the current generation.
+// Pass n > 0 to override generation.cycles in configuration.yaml for this run only.
+func (Generator) RunN(n int) error { return newOrch().GeneratorRun(n) }
 
 // Resume recovers from an interrupted run and continues.
 func (Generator) Resume() error { return newOrch().GeneratorResume() }

--- a/orchestrator.go.tmpl
+++ b/orchestrator.go.tmpl
@@ -116,11 +116,13 @@ func (Cobbler) Reset() error { return newOrch().CobblerReset() }
 // Start begins a new generation trail.
 func (Generator) Start() error { return newOrch().GeneratorStart() }
 
-// Run executes N cycles of measure + stitch within the current generation.
-// Run executes N cycles of measure + stitch within the current generation.
-// Pass cycles > 0 to override the generation.cycles value in configuration.yaml for this run only.
-// Pass 0 to use the configured value (or run until all issues are closed if also 0).
-func (Generator) Run(cycles int) error { return newOrch().GeneratorRun(cycles) }
+// Run executes measure + stitch cycles using the generation.cycles value in configuration.yaml.
+// Use RunN to override the cycle count for a single invocation.
+func (Generator) Run() error { return newOrch().GeneratorRun(0) }
+
+// RunN executes exactly n cycles of measure + stitch within the current generation.
+// Pass n > 0 to override generation.cycles in configuration.yaml for this run only.
+func (Generator) RunN(n int) error { return newOrch().GeneratorRun(n) }
 
 // Resume recovers from an interrupted run and continues.
 func (Generator) Resume() error { return newOrch().GeneratorResume() }


### PR DESCRIPTION
## Summary

Fixes a regression where `mage generator:run` failed with "not enough arguments for target Generator:Run, expected 1, got 0". The `Run(cycles int)` Mage target was changed to require an explicit cycle count, breaking the common no-arg invocation. Split into `Run()` (uses configured cycles) and `RunN(n int)` (overrides), matching the same pattern used for vscode:push/pop.

## Changes

- #137: Split `Generator.Run(cycles int)` into `Run()` and `RunN(n int)` in `magefiles/magefile.go` and `orchestrator.go.tmpl`. `Run()` calls `GeneratorRun(0)` (uses `generation.cycles` from configuration.yaml); `RunN(n)` calls `GeneratorRun(n)`. Full `mage test:usecase` run confirms all tests pass.

## Test run results

- 2026-02-28: 64/64 pass, 1 intentional skip (`TestSelectiveContext_FullPipeline` requires `COBBLER_E2E_CLAUDE=1`)
- `TestRel01_UC002_RunOneCycle` now passes (was failing with "not enough arguments")
- `TestRel01_UC004_StitchExecutesTask` transient failure on first run, passed on re-run (resource pressure)

## Stats

Lines of code (Go, production): 10087 (+0)
Lines of code (Go, tests):      10492 (+0)
Words (documentation):          18780 (+0)

## Test plan

- [x] `mage test:unit` passes
- [x] `mage test:usecase` passes (all 64 tests, 1 intentional skip)
- [x] `mage analyze` passes

Closes #107