### PR TITLE
GH-169: Remove residual beads references

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -33,7 +33,6 @@ generation:
     cleanup_dirs: []
 cobbler:
     dir: .cobbler/
-    beads_dir: .beads/
     issues_repo: petar-djukic/cobbler-scaffold
     max_stitch_issues: 0
     max_stitch_issues_per_cycle: 10

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -79,10 +79,10 @@ func logf(format string, args ...any) {
 
 // --- Top-level targets ---
 
-// Init initializes the project (beads).
+// Init initializes the project.
 func Init() error { return newOrch().Init() }
 
-// Reset performs a full reset: cobbler, generator, beads.
+// Reset performs a full reset: cobbler and generator.
 func Reset() error { return newOrch().FullReset() }
 
 // Build compiles the project binary.

--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -48,7 +48,7 @@ func (o *Orchestrator) captureLOC() LocSnapshot {
 	return LocSnapshot{Production: rec.GoProdLOC, Test: rec.GoTestLOC}
 }
 
-// InvocationRecord is the JSON blob recorded as a beads comment after
+// InvocationRecord is the JSON blob recorded as a GitHub issue comment after
 // every Claude invocation.
 type InvocationRecord struct {
 	Caller    string       `json:"caller"`

--- a/pkg/orchestrator/commands.go
+++ b/pkg/orchestrator/commands.go
@@ -26,7 +26,6 @@ const (
 // Directory and file path constants.
 const (
 	dirMagefiles = "magefiles"
-	dirBeads     = ".beads"
 	dirCobbler   = ".cobbler"
 )
 

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -105,9 +105,6 @@ type CobblerConfig struct {
 	// Dir is the cobbler scratch directory (default ".cobbler/").
 	Dir string `yaml:"dir"`
 
-	// BeadsDir is the beads database directory (default ".beads/").
-	BeadsDir string `yaml:"beads_dir"`
-
 	// IssuesRepo is the GitHub repository (owner/repo) where orchestrator
 	// issues are created. If empty, detectGitHubRepo derives it from the
 	// target project's git remote or go.mod module path. Set this in
@@ -354,9 +351,6 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Generation.Prefix == "" {
 		c.Generation.Prefix = "generation-"
-	}
-	if c.Cobbler.BeadsDir == "" {
-		c.Cobbler.BeadsDir = dirBeads + "/"
 	}
 	if c.Cobbler.Dir == "" {
 		c.Cobbler.Dir = dirCobbler + "/"

--- a/pkg/orchestrator/config_test.go
+++ b/pkg/orchestrator/config_test.go
@@ -97,9 +97,6 @@ func TestLoadConfig_AppliesDefaults(t *testing.T) {
 	if cfg.Cobbler.Dir != ".cobbler/" {
 		t.Errorf("Cobbler.Dir default: got %q, want \".cobbler/\"", cfg.Cobbler.Dir)
 	}
-	if cfg.Cobbler.BeadsDir != ".beads/" {
-		t.Errorf("Cobbler.BeadsDir default: got %q, want \".beads/\"", cfg.Cobbler.BeadsDir)
-	}
 	if cfg.Cobbler.MaxStitchIssuesPerCycle != 10 {
 		t.Errorf("MaxStitchIssuesPerCycle default: got %d, want 10", cfg.Cobbler.MaxStitchIssuesPerCycle)
 	}

--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -207,7 +207,7 @@ func (o *Orchestrator) GeneratorStart() error {
 		return fmt.Errorf("resetting Go sources: %w", err)
 	}
 
-	// Squash intermediate commits (beads reset/init) into one clean commit.
+	// Squash intermediate commits into one clean commit.
 	logf("generator:start: squashing into single commit")
 	if err := gitResetSoft(branchSHA); err != nil {
 		return fmt.Errorf("squashing start commits: %w", err)

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -133,7 +133,7 @@ func (o *Orchestrator) RunMeasure() error {
 	logf("locBefore prod=%d test=%d", locBefore.Production, locBefore.Test)
 
 	// Iterative measure: call Claude once per issue with limit=1.
-	// Between calls, import the result into beads and refresh the issue list
+	// Between calls, import the result into GitHub Issues and refresh the issue list
 	// so subsequent calls see existing issues and avoid duplicates.
 	totalIssues := o.cfg.Cobbler.MaxMeasureIssues
 	var allCreatedIDs []string

--- a/pkg/orchestrator/scaffold.go
+++ b/pkg/orchestrator/scaffold.go
@@ -640,9 +640,9 @@ func (o *Orchestrator) PrepareTestRepo(module, version, orchestratorRoot string)
 	}
 
 	// Remove development artifacts from the copied source. Module
-	// sources may include .beads/, .cobbler/, or other local state
+	// sources may include .cobbler/ or other local state
 	// directories that interfere with a clean test environment.
-	for _, artifact := range []string{dirBeads, dirCobbler} {
+	for _, artifact := range []string{dirCobbler} {
 		p := filepath.Join(repoDir, artifact)
 		if _, err := os.Stat(p); err == nil {
 			logf("prepareTestRepo: removing artifact %s", artifact)

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -30,7 +30,7 @@ var executionConstitution string
 //go:embed constitutions/go-style.yaml
 var goStyleConstitution string
 
-// Stitch picks ready tasks from beads and invokes Claude to execute them.
+// Stitch picks ready tasks from GitHub Issues and invokes Claude to execute them.
 // Reads all options from Config.
 func (o *Orchestrator) Stitch() error {
 	_, err := o.RunStitch()


### PR DESCRIPTION
## Summary

Removes all remaining references to the beads (`bd`) CLI from production code, configuration, and tests. The orchestrator migrated to GitHub Issues in GH-112; this cleans up the leftover field, constant, and comments that were never removed.

## Changes

- #170: Removed `BeadsDir` field from `CobblerConfig`, `dirBeads` constant from `commands.go`, `dirBeads` from scaffold artifact cleanup loop; updated stale comments in `stitch.go`, `measure.go`, `cobbler.go`, `generator.go`; removed `BeadsDir` assertion from `config_test.go`; updated `magefile.go` doc comments; removed `beads_dir` from `configuration.yaml`

## Stats

Lines of code (Go, production): 10463 (-12)
Lines of code (Go, tests):      10549 (-3)
Words (documentation):          18780 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] `mage test:unit` passes
- [x] No remaining `dirBeads`, `BeadsDir`, or `beads_dir` references in production code

Closes #169