### PR TITLE
GH-276: Unit tests for filesystem functions at 0% coverage

### DIFF
--- a/pkg/orchestrator/cobbler_test.go
+++ b/pkg/orchestrator/cobbler_test.go
@@ -1151,3 +1151,28 @@ func TestLogConfig_NoUserPrompt(t *testing.T) {
 	// When UserPrompt is empty, the second logf call is skipped.
 	o.logConfig("stitch")
 }
+
+// --- CobblerReset ---
+
+func TestCobblerReset_RemovesDir(t *testing.T) {
+	t.Parallel()
+	dir := filepath.Join(t.TempDir(), ".cobbler")
+	os.MkdirAll(filepath.Join(dir, "sub"), 0o755)
+	os.WriteFile(filepath.Join(dir, "sub", "file.txt"), []byte("data"), 0o644)
+
+	o := &Orchestrator{cfg: Config{Cobbler: CobblerConfig{Dir: dir}}}
+	if err := o.CobblerReset(); err != nil {
+		t.Fatalf("CobblerReset: %v", err)
+	}
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Error("expected cobbler dir to be removed")
+	}
+}
+
+func TestCobblerReset_NonExistentDir(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{cfg: Config{Cobbler: CobblerConfig{Dir: filepath.Join(t.TempDir(), "nope")}}}
+	if err := o.CobblerReset(); err != nil {
+		t.Fatalf("CobblerReset on nonexistent dir: %v", err)
+	}
+}

--- a/pkg/orchestrator/issues_gh_test.go
+++ b/pkg/orchestrator/issues_gh_test.go
@@ -5,6 +5,7 @@ package orchestrator
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -224,4 +225,34 @@ func TestDAGPromotionDepClosed(t *testing.T) {
 // writeFileForTest is a test helper that writes content to path.
 func writeFileForTest(path, content string) error {
 	return os.WriteFile(path, []byte(content), 0o644)
+}
+
+// --- goModModulePath ---
+
+func TestGoModModulePath_ValidGoMod(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module github.com/org/repo\n\ngo 1.23\n"), 0o644)
+	got := goModModulePath(dir)
+	if got != "github.com/org/repo" {
+		t.Errorf("goModModulePath = %q, want github.com/org/repo", got)
+	}
+}
+
+func TestGoModModulePath_MissingFile(t *testing.T) {
+	t.Parallel()
+	got := goModModulePath(t.TempDir())
+	if got != "" {
+		t.Errorf("goModModulePath = %q, want empty for missing go.mod", got)
+	}
+}
+
+func TestGoModModulePath_NoModuleLine(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "go.mod"), []byte("go 1.23\n"), 0o644)
+	got := goModModulePath(dir)
+	if got != "" {
+		t.Errorf("goModModulePath = %q, want empty for go.mod without module line", got)
+	}
 }


### PR DESCRIPTION
## Summary

Added 20 unit tests covering 9 filesystem-only functions that previously had 0% unit test coverage (2 of original 11 were already tested). Package coverage improved from 53.7% to 55.7%.

## Changes

- `analyze_test.go`: Tests for `Analyze` (2 tests)
- `cobbler_test.go`: Tests for `CobblerReset` (2 tests)
- `generator_test.go`: Tests for `cleanGoSources` (1 test)
- `issues_gh_test.go`: Tests for `goModModulePath` (3 tests)
- `precycle_test.go`: Tests for `RunPreCycleAnalysis` (2 tests)
- `scaffold_test.go`: Tests for `copyFile` (2), `scaffoldSeedTemplate` (2), `copyDir` (3)
- `stats_test.go`: Tests for `Stats` (1), `CollectStats` (2 new)

## Stats

```
go_loc_prod: 10651 (+0)
go_loc_test: 13467 (+429)
spec_words:  18901 (+0)
```

## Test plan

- [x] All 20 new tests pass
- [x] All existing tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] 7 of 9 functions at >80% coverage; remaining 3 are thin wrappers with uncoverable error paths
- [x] Package coverage: 53.7% → 55.7%

Closes #276