### PR TITLE
GH-247: Fix hardcoded branch name assumptions in generator.go

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -682,7 +682,7 @@ func (o *Orchestrator) hasOpenIssues() bool {
 		logf("hasOpenIssues: detectGitHubRepo: %v", err)
 		return false
 	}
-	branch, err := gitCurrentBranch()
+	branch, err := gitCurrentBranch(".")
 	if err != nil {
 		return false
 	}

--- a/pkg/orchestrator/compare.go
+++ b/pkg/orchestrator/compare.go
@@ -123,7 +123,7 @@ func (r *GitTagResolver) ensureBuild() error {
 
 func (r *GitTagResolver) cleanup() {
 	if r.wtDir != "" {
-		if err := gitWorktreeRemove(r.wtDir); err != nil {
+		if err := gitWorktreeRemove(r.wtDir, "."); err != nil {
 			logf("compare: warning: removing worktree %s: %v", r.wtDir, err)
 		}
 		r.wtDir = ""

--- a/pkg/orchestrator/docker.go
+++ b/pkg/orchestrator/docker.go
@@ -200,7 +200,7 @@ func imageBaseName(image string) string {
 
 // latestVersionTag returns the most recent v* git tag, or "" if none exist.
 func latestVersionTag() string {
-	tags := gitListTags("v*")
+	tags := gitListTags("v*", ".")
 	if len(tags) == 0 {
 		return ""
 	}

--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -19,7 +19,7 @@ import (
 // If cycles > 0 it overrides configuration.yaml's generation.cycles for this run only.
 // cycles == 0 means use the configured value (or unlimited if that is also 0).
 func (o *Orchestrator) GeneratorRun(cycles int) error {
-	currentBranch, err := gitCurrentBranch()
+	currentBranch, err := gitCurrentBranch(".")
 	if err != nil {
 		return fmt.Errorf("getting current branch: %w", err)
 	}
@@ -48,7 +48,7 @@ func (o *Orchestrator) GeneratorResume() error {
 	if !strings.HasPrefix(branch, o.cfg.Generation.Prefix) {
 		return fmt.Errorf("not a generation branch: %s\nSet generation.branch in configuration.yaml", branch)
 	}
-	if !gitBranchExists(branch) {
+	if !gitBranchExists(branch, ".") {
 		return fmt.Errorf("branch does not exist: %s", branch)
 	}
 
@@ -67,7 +67,7 @@ func (o *Orchestrator) GeneratorResume() error {
 	wtBase := worktreeBasePath()
 
 	logf("resume: pruning worktrees")
-	if err := gitWorktreePrune(); err != nil {
+	if err := gitWorktreePrune("."); err != nil {
 		logf("resume: warning: worktree prune: %v", err)
 	}
 
@@ -162,13 +162,13 @@ func (o *Orchestrator) RunCycles(label string) error {
 // branch, deletes Go files, reinitializes the Go module, and commits the clean
 // state. Any clean branch is a valid starting point (prd002 R2.1).
 func (o *Orchestrator) GeneratorStart() error {
-	baseBranch, err := gitCurrentBranch()
+	baseBranch, err := gitCurrentBranch(".")
 	if err != nil {
 		return fmt.Errorf("getting current branch: %w", err)
 	}
 
 	// Reject dirty worktrees — a generation must start from a clean state.
-	if gitHasChanges() {
+	if gitHasChanges(".") {
 		return fmt.Errorf("worktree has uncommitted changes on %s; commit or stash before starting a generation", baseBranch)
 	}
 
@@ -182,18 +182,18 @@ func (o *Orchestrator) GeneratorStart() error {
 
 	// Tag the current base branch state before the generation begins.
 	logf("generator:start: tagging current state as %s", startTag)
-	if err := gitTag(startTag); err != nil {
+	if err := gitTag(startTag, "."); err != nil {
 		return fmt.Errorf("tagging base branch: %w", err)
 	}
 
 	// Create and switch to generation branch.
 	logf("generator:start: creating branch")
-	if err := gitCheckoutNew(genName); err != nil {
+	if err := gitCheckoutNew(genName, "."); err != nil {
 		return fmt.Errorf("creating branch: %w", err)
 	}
 
 	// Record branch point so intermediate commits can be squashed.
-	branchSHA, err := gitRevParseHEAD()
+	branchSHA, err := gitRevParseHEAD(".")
 	if err != nil {
 		return fmt.Errorf("getting branch HEAD: %w", err)
 	}
@@ -218,17 +218,17 @@ func (o *Orchestrator) GeneratorStart() error {
 
 	// Squash intermediate commits into one clean commit.
 	logf("generator:start: squashing into single commit")
-	if err := gitResetSoft(branchSHA); err != nil {
+	if err := gitResetSoft(branchSHA, "."); err != nil {
 		return fmt.Errorf("squashing start commits: %w", err)
 	}
-	_ = gitStageAll() // best-effort; commit below will catch nothing-to-commit
+	_ = gitStageAll(".") // best-effort; commit below will catch nothing-to-commit
 	var msg string
 	if o.cfg.Generation.PreserveSources {
 		msg = fmt.Sprintf("Start generation: %s\n\nBase branch: %s. Sources preserved (preserve_sources=true).\nTagged previous state as %s.", genName, baseBranch, genName)
 	} else {
 		msg = fmt.Sprintf("Start generation: %s\n\nBase branch: %s. Delete Go files, reinitialize module.\nTagged previous state as %s.", genName, baseBranch, genName)
 	}
-	if err := gitCommit(msg); err != nil {
+	if err := gitCommit(msg, "."); err != nil {
 		return fmt.Errorf("committing clean state: %w", err)
 	}
 
@@ -270,11 +270,11 @@ func (o *Orchestrator) readBaseBranch() string {
 func (o *Orchestrator) GeneratorStop() error {
 	branch := o.cfg.Generation.Branch
 	if branch != "" {
-		if !gitBranchExists(branch) {
+		if !gitBranchExists(branch, ".") {
 			return fmt.Errorf("branch does not exist: %s", branch)
 		}
 	} else {
-		current, err := gitCurrentBranch()
+		current, err := gitCurrentBranch(".")
 		if err != nil {
 			return fmt.Errorf("getting current branch: %w", err)
 		}
@@ -310,13 +310,13 @@ func (o *Orchestrator) GeneratorStop() error {
 	baseBranch := o.readBaseBranch()
 
 	logf("generator:stop: tagging as %s", finishedTag)
-	if err := gitTag(finishedTag); err != nil {
+	if err := gitTag(finishedTag, "."); err != nil {
 		return fmt.Errorf("tagging generation: %w", err)
 	}
 
 	// Switch to the base branch.
 	logf("generator:stop: switching to %s", baseBranch)
-	if err := gitCheckout(baseBranch); err != nil {
+	if err := gitCheckout(baseBranch, "."); err != nil {
 		return fmt.Errorf("checking out %s: %w", baseBranch, err)
 	}
 
@@ -343,19 +343,19 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 		_ = o.resetGoSources(branch) // best-effort; merge will overwrite these files
 	}
 
-	_ = gitStageAll() // best-effort; commit below handles empty index
+	_ = gitStageAll(".") // best-effort; commit below handles empty index
 	var prepareMsg string
 	if o.cfg.Generation.PreserveSources {
 		prepareMsg = fmt.Sprintf("Prepare %s for generation merge (preserve_sources)\n\nSources preserved. Merging %s.", baseBranch, branch)
 	} else {
 		prepareMsg = fmt.Sprintf("Prepare %s for generation merge: delete Go code\n\nDocumentation preserved for merge. Code will be replaced by %s.", baseBranch, branch)
 	}
-	if err := gitCommitAllowEmpty(prepareMsg); err != nil {
+	if err := gitCommitAllowEmpty(prepareMsg, "."); err != nil {
 		return fmt.Errorf("committing prepare step: %w", err)
 	}
 
 	logf("generator:stop: merging into %s", baseBranch)
-	cmd := gitMergeCmd(branch)
+	cmd := gitMergeCmd(branch, ".")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -371,7 +371,7 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 
 	mergedTag := branch + "-merged"
 	logf("generator:stop: tagging %s as %s", baseBranch, mergedTag)
-	if err := gitTag(mergedTag); err != nil {
+	if err := gitTag(mergedTag, "."); err != nil {
 		return fmt.Errorf("tagging merge: %w", err)
 	}
 
@@ -382,7 +382,7 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 		reqTag := fmt.Sprintf("v1.%s.%d-requirements", date, revision)
 
 		logf("generator:stop: tagging code as %s", codeTag)
-		if err := gitTag(codeTag); err != nil {
+		if err := gitTag(codeTag, "."); err != nil {
 			logf("generator:stop: code tag warning: %v", err)
 		}
 
@@ -392,13 +392,13 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 			if err := writeVersionConst(o.cfg.Project.VersionFile, codeTag); err != nil {
 				logf("generator:stop: version file warning: %v", err)
 			} else {
-				_ = gitStageAll()                                        // best-effort; commit below handles empty index
-				_ = gitCommit(fmt.Sprintf("Set version to %s", codeTag)) // best-effort; version update is non-critical
+				_ = gitStageAll(".")                                        // best-effort; commit below handles empty index
+				_ = gitCommit(fmt.Sprintf("Set version to %s", codeTag), ".") // best-effort; version update is non-critical
 			}
 		}
 
 		logf("generator:stop: tagging requirements as %s (at %s)", reqTag, startTag)
-		if err := gitTagAt(reqTag, startTag); err != nil {
+		if err := gitTagAt(reqTag, startTag, "."); err != nil {
 			logf("generator:stop: requirements tag warning: %v", err)
 		}
 	}
@@ -417,12 +417,12 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 			logf("generator:stop: warning removing history dir: %v", err)
 		}
 	}
-	_ = gitStageAll()
+	_ = gitStageAll(".")
 	cleanupMsg := fmt.Sprintf("Reset %s to specs-only after v1 tag\n\nGenerated code preserved at version tags. Branch restored to documentation-only state.", baseBranch)
-	_ = gitCommit(cleanupMsg) // best-effort; may be empty if nothing changed
+	_ = gitCommit(cleanupMsg, ".") // best-effort; may be empty if nothing changed
 
 	logf("generator:stop: deleting branch")
-	_ = gitDeleteBranch(branch) // best-effort; branch may already be deleted
+	_ = gitDeleteBranch(branch, ".") // best-effort; branch may already be deleted
 	return nil
 }
 
@@ -431,7 +431,7 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 // earlier generations that would otherwise be lost during the reset+merge
 // cycle. See prd002-generation-lifecycle R5.8.
 func (o *Orchestrator) restoreFromStartTag(startTag string) error {
-	startFiles, err := gitLsTreeFiles(startTag)
+	startFiles, err := gitLsTreeFiles(startTag, ".")
 	if err != nil {
 		return fmt.Errorf("listing files at %s: %w", startTag, err)
 	}
@@ -451,7 +451,7 @@ func (o *Orchestrator) restoreFromStartTag(startTag string) error {
 			continue
 		}
 
-		content, err := gitShowFileContent(startTag, path)
+		content, err := gitShowFileContent(startTag, path, ".")
 		if err != nil {
 			logf("generator:stop: could not read %s from %s: %v", path, startTag, err)
 			continue
@@ -475,10 +475,10 @@ func (o *Orchestrator) restoreFromStartTag(startTag string) error {
 	}
 
 	logf("generator:stop: restored %d file(s) from earlier generations", len(restored))
-	_ = gitStageAll()
+	_ = gitStageAll(".")
 	msg := fmt.Sprintf("Restore %d file(s) from earlier generations\n\nFiles restored from %s:\n%s",
 		len(restored), startTag, strings.Join(restored, "\n"))
-	if err := gitCommit(msg); err != nil {
+	if err := gitCommit(msg, "."); err != nil {
 		return fmt.Errorf("committing restored files: %w", err)
 	}
 	return nil
@@ -486,7 +486,7 @@ func (o *Orchestrator) restoreFromStartTag(startTag string) error {
 
 // listGenerationBranches returns all generation-* branch names.
 func (o *Orchestrator) listGenerationBranches() []string {
-	return gitListBranches(o.cfg.Generation.Prefix + "*")
+	return gitListBranches(o.cfg.Generation.Prefix + "*", ".")
 }
 
 // tagSuffixes lists the lifecycle tag suffixes in order.
@@ -525,10 +525,10 @@ func (o *Orchestrator) generationRevision(branch string) int {
 	}
 
 	nameSet := make(map[string]bool)
-	for _, t := range gitListTags(o.cfg.Generation.Prefix + date + "-*") {
+	for _, t := range gitListTags(o.cfg.Generation.Prefix + date + "-*", ".") {
 		nameSet[generationName(t)] = true
 	}
-	for _, b := range gitListBranches(o.cfg.Generation.Prefix + date + "-*") {
+	for _, b := range gitListBranches(o.cfg.Generation.Prefix + date + "-*", ".") {
 		nameSet[b] = true
 	}
 
@@ -560,7 +560,7 @@ func generationName(tag string) string {
 // cleanupUnmergedTags renames tags for generations that were never
 // merged into a single -abandoned tag.
 func (o *Orchestrator) cleanupUnmergedTags() {
-	tags := gitListTags(o.cfg.Generation.Prefix + "*")
+	tags := gitListTags(o.cfg.Generation.Prefix + "*", ".")
 	if len(tags) == 0 {
 		return
 	}
@@ -583,11 +583,11 @@ func (o *Orchestrator) cleanupUnmergedTags() {
 			abTag := name + "-abandoned"
 			if t != abTag {
 				logf("generator:reset: marking abandoned: %s -> %s", t, abTag)
-				_ = gitRenameTag(t, abTag) // best-effort; tag may not exist
+				_ = gitRenameTag(t, abTag, ".") // best-effort; tag may not exist
 			}
 		} else {
 			logf("generator:reset: removing tag %s", t)
-			_ = gitDeleteTag(t) // best-effort cleanup
+			_ = gitDeleteTag(t, ".") // best-effort cleanup
 		}
 	}
 }
@@ -595,7 +595,7 @@ func (o *Orchestrator) cleanupUnmergedTags() {
 // resolveBranch determines which branch to work on.
 func (o *Orchestrator) resolveBranch(explicit string) (string, error) {
 	if explicit != "" {
-		if !gitBranchExists(explicit) {
+		if !gitBranchExists(explicit, ".") {
 			return "", fmt.Errorf("branch does not exist: %s", explicit)
 		}
 		return explicit, nil
@@ -604,7 +604,7 @@ func (o *Orchestrator) resolveBranch(explicit string) (string, error) {
 	branches := o.listGenerationBranches()
 	switch len(branches) {
 	case 0:
-		return gitCurrentBranch()
+		return gitCurrentBranch(".")
 	case 1:
 		return branches[0], nil
 	default:
@@ -618,7 +618,7 @@ func (o *Orchestrator) resolveBranch(explicit string) (string, error) {
 // commit first; if that fails and the tree is still dirty, it stashes
 // changes so the checkout can succeed.
 func saveAndSwitchBranch(target string) error {
-	current, err := gitCurrentBranch()
+	current, err := gitCurrentBranch(".")
 	if err != nil {
 		return err
 	}
@@ -626,28 +626,28 @@ func saveAndSwitchBranch(target string) error {
 		return nil
 	}
 
-	if err := gitStageAll(); err != nil {
+	if err := gitStageAll("."); err != nil {
 		return fmt.Errorf("staging changes: %w", err)
 	}
 
 	msg := fmt.Sprintf("WIP: save state before switching to %s", target)
-	if err := gitCommit(msg); err != nil {
+	if err := gitCommit(msg, "."); err != nil {
 		// Commit failed (e.g. nothing to commit). Unstage and fall
 		// back to stash if the tree is still dirty.
-		_ = gitUnstageAll() // best-effort; unstage before stash fallback
-		if gitHasChanges() {
+		_ = gitUnstageAll(".") // best-effort; unstage before stash fallback
+		if gitHasChanges(".") {
 			logf("saveAndSwitchBranch: commit failed, stashing dirty tree")
-			_ = gitStash(msg) // best-effort; switching branch is the priority
+			_ = gitStash(msg, ".") // best-effort; switching branch is the priority
 		}
 	}
 
 	logf("saveAndSwitchBranch: %s -> %s", current, target)
-	return gitCheckout(target)
+	return gitCheckout(target, ".")
 }
 
 // ensureOnBranch switches to the given branch if not already on it.
 func ensureOnBranch(branch string) error {
-	current, err := gitCurrentBranch()
+	current, err := gitCurrentBranch(".")
 	if err != nil {
 		return err
 	}
@@ -655,14 +655,14 @@ func ensureOnBranch(branch string) error {
 		return nil
 	}
 	logf("ensureOnBranch: switching from %s to %s", current, branch)
-	return gitCheckout(branch)
+	return gitCheckout(branch, ".")
 }
 
 // GeneratorList shows active branches and past generations.
 func (o *Orchestrator) GeneratorList() error {
 	branches := o.listGenerationBranches()
-	tags := gitListTags(o.cfg.Generation.Prefix + "*")
-	current, _ := gitCurrentBranch()
+	tags := gitListTags(o.cfg.Generation.Prefix + "*", ".")
+	current, _ := gitCurrentBranch(".")
 
 	nameSet := make(map[string]bool)
 	branchSet := make(map[string]bool)
@@ -732,11 +732,11 @@ func (o *Orchestrator) GeneratorSwitch() error {
 	if target != baseBranch && !strings.HasPrefix(target, o.cfg.Generation.Prefix) {
 		return fmt.Errorf("not a generation branch or %s: %s", baseBranch, target)
 	}
-	if !gitBranchExists(target) {
+	if !gitBranchExists(target, ".") {
 		return fmt.Errorf("branch does not exist: %s", target)
 	}
 
-	current, err := gitCurrentBranch()
+	current, err := gitCurrentBranch(".")
 	if err != nil {
 		return fmt.Errorf("getting current branch: %w", err)
 	}
@@ -786,7 +786,7 @@ func (o *Orchestrator) GeneratorReset() error {
 		}
 	}
 
-	if err := gitWorktreePrune(); err != nil {
+	if err := gitWorktreePrune("."); err != nil {
 		logf("generator:reset: warning: worktree prune: %v", err)
 	}
 
@@ -801,7 +801,7 @@ func (o *Orchestrator) GeneratorReset() error {
 		logf("generator:reset: removing %d generation branch(es)", len(genBranches))
 		for _, gb := range genBranches {
 			logf("generator:reset: deleting branch %s", gb)
-			_ = gitForceDeleteBranch(gb) // best-effort; branch may be already removed
+			_ = gitForceDeleteBranch(gb, ".") // best-effort; branch may be already removed
 		}
 	}
 
@@ -824,8 +824,8 @@ func (o *Orchestrator) GeneratorReset() error {
 	}
 
 	logf("generator:reset: committing clean state")
-	_ = gitStageAll()                                                  // best-effort; commit below handles empty index
-	_ = gitCommitAllowEmpty("Generator reset: return to clean state") // best-effort; reset is complete regardless
+	_ = gitStageAll(".")                                                  // best-effort; commit below handles empty index
+	_ = gitCommitAllowEmpty("Generator reset: return to clean state", ".") // best-effort; reset is complete regardless
 
 	logf("generator:reset: done, only %s branch remains", baseBranch)
 	return nil

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -512,7 +512,7 @@ func TestCleanupDirs_EmptyList(t *testing.T) {
 func TestEnsureOnBranch_AlreadyOnBranch(t *testing.T) {
 	initTestGitRepo(t)
 
-	current, err := gitCurrentBranch()
+	current, err := gitCurrentBranch("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -525,7 +525,7 @@ func TestEnsureOnBranch_AlreadyOnBranch(t *testing.T) {
 func TestEnsureOnBranch_SwitchesBranch(t *testing.T) {
 	initTestGitRepo(t)
 
-	if err := gitCreateBranch("test-branch"); err != nil {
+	if err := gitCreateBranch("test-branch", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -533,7 +533,7 @@ func TestEnsureOnBranch_SwitchesBranch(t *testing.T) {
 		t.Fatalf("ensureOnBranch(test-branch) error = %v", err)
 	}
 
-	current, err := gitCurrentBranch()
+	current, err := gitCurrentBranch("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -547,7 +547,7 @@ func TestEnsureOnBranch_SwitchesBranch(t *testing.T) {
 func TestSaveAndSwitchBranch_AlreadyOnTarget(t *testing.T) {
 	initTestGitRepo(t)
 
-	current, _ := gitCurrentBranch()
+	current, _ := gitCurrentBranch("")
 	if err := saveAndSwitchBranch(current); err != nil {
 		t.Errorf("saveAndSwitchBranch(current) error = %v", err)
 	}
@@ -556,7 +556,7 @@ func TestSaveAndSwitchBranch_AlreadyOnTarget(t *testing.T) {
 func TestSaveAndSwitchBranch_CleanSwitch(t *testing.T) {
 	initTestGitRepo(t)
 
-	if err := gitCreateBranch("target"); err != nil {
+	if err := gitCreateBranch("target", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -564,7 +564,7 @@ func TestSaveAndSwitchBranch_CleanSwitch(t *testing.T) {
 		t.Fatalf("saveAndSwitchBranch(target) error = %v", err)
 	}
 
-	current, err := gitCurrentBranch()
+	current, err := gitCurrentBranch("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -580,7 +580,7 @@ func TestSaveAndSwitchBranch_DirtyWorkingTree(t *testing.T) {
 	exec.Command("git", "add", "tracked.txt").Run()
 	exec.Command("git", "commit", "--no-verify", "-m", "add tracked file").Run()
 
-	if err := gitCreateBranch("other"); err != nil {
+	if err := gitCreateBranch("other", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -590,7 +590,7 @@ func TestSaveAndSwitchBranch_DirtyWorkingTree(t *testing.T) {
 		t.Fatalf("saveAndSwitchBranch with dirty tree error = %v", err)
 	}
 
-	current, err := gitCurrentBranch()
+	current, err := gitCurrentBranch("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -604,7 +604,7 @@ func TestSaveAndSwitchBranch_DirtyWorkingTree(t *testing.T) {
 func TestResolveBranch_ExplicitBranchExists(t *testing.T) {
 	initTestGitRepo(t)
 
-	if err := gitCreateBranch("explicit-branch"); err != nil {
+	if err := gitCreateBranch("explicit-branch", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -637,7 +637,7 @@ func TestResolveBranch_NoGenerationBranches(t *testing.T) {
 		t.Fatalf("resolveBranch() error = %v", err)
 	}
 
-	current, _ := gitCurrentBranch()
+	current, _ := gitCurrentBranch("")
 	if got != current {
 		t.Errorf("resolveBranch() = %q, want current branch %q", got, current)
 	}
@@ -646,7 +646,7 @@ func TestResolveBranch_NoGenerationBranches(t *testing.T) {
 func TestResolveBranch_SingleGenerationBranch(t *testing.T) {
 	initTestGitRepo(t)
 
-	if err := gitCreateBranch("generation-2026-02-28-12-00-00"); err != nil {
+	if err := gitCreateBranch("generation-2026-02-28-12-00-00", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -663,8 +663,8 @@ func TestResolveBranch_SingleGenerationBranch(t *testing.T) {
 func TestResolveBranch_MultipleGenerationBranches(t *testing.T) {
 	initTestGitRepo(t)
 
-	gitCreateBranch("generation-2026-02-28-12-00-00")
-	gitCreateBranch("generation-2026-02-28-13-00-00")
+	gitCreateBranch("generation-2026-02-28-12-00-00", "")
+	gitCreateBranch("generation-2026-02-28-13-00-00", "")
 
 	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
 	_, err := o.resolveBranch("")
@@ -691,9 +691,9 @@ func TestListGenerationBranches_NoBranches(t *testing.T) {
 func TestListGenerationBranches_WithBranches(t *testing.T) {
 	initTestGitRepo(t)
 
-	gitCreateBranch("generation-2026-02-28-12-00-00")
-	gitCreateBranch("generation-2026-02-28-13-00-00")
-	gitCreateBranch("other-branch")
+	gitCreateBranch("generation-2026-02-28-12-00-00", "")
+	gitCreateBranch("generation-2026-02-28-13-00-00", "")
+	gitCreateBranch("other-branch", "")
 
 	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
 	got := o.listGenerationBranches()
@@ -708,7 +708,7 @@ func TestGenerationRevision_SingleGeneration(t *testing.T) {
 	initTestGitRepo(t)
 
 	branch := "generation-2026-02-28-12-00-00"
-	if err := gitCreateBranch(branch); err != nil {
+	if err := gitCreateBranch(branch, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -722,9 +722,9 @@ func TestGenerationRevision_SingleGeneration(t *testing.T) {
 func TestGenerationRevision_MultipleGenerationsSameDay(t *testing.T) {
 	initTestGitRepo(t)
 
-	gitCreateBranch("generation-2026-02-28-10-00-00")
-	gitCreateBranch("generation-2026-02-28-12-00-00")
-	gitCreateBranch("generation-2026-02-28-14-00-00")
+	gitCreateBranch("generation-2026-02-28-10-00-00", "")
+	gitCreateBranch("generation-2026-02-28-12-00-00", "")
+	gitCreateBranch("generation-2026-02-28-14-00-00", "")
 
 	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
 
@@ -890,7 +890,7 @@ func TestGeneratorSwitch_AlreadyOnBranch(t *testing.T) {
 	initTestGitRepo(t)
 
 	branch := "generation-2026-02-28-12-00-00"
-	if err := gitCheckoutNew(branch); err != nil {
+	if err := gitCheckoutNew(branch, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -902,7 +902,7 @@ func TestGeneratorSwitch_AlreadyOnBranch(t *testing.T) {
 		t.Errorf("GeneratorSwitch() already on branch error = %v", err)
 	}
 
-	current, _ := gitCurrentBranch()
+	current, _ := gitCurrentBranch("")
 	if current != branch {
 		t.Errorf("current branch = %q, want %q", current, branch)
 	}
@@ -911,7 +911,7 @@ func TestGeneratorSwitch_AlreadyOnBranch(t *testing.T) {
 func TestGeneratorSwitch_SwitchToMain(t *testing.T) {
 	initTestGitRepo(t)
 
-	if err := gitCheckoutNew("generation-2026-02-28-12-00-00"); err != nil {
+	if err := gitCheckoutNew("generation-2026-02-28-12-00-00", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -924,7 +924,7 @@ func TestGeneratorSwitch_SwitchToMain(t *testing.T) {
 		t.Errorf("GeneratorSwitch() to main error = %v", err)
 	}
 
-	current, _ := gitCurrentBranch()
+	current, _ := gitCurrentBranch("")
 	if current != "main" {
 		t.Errorf("current branch = %q, want %q", current, "main")
 	}
@@ -958,14 +958,14 @@ func TestGeneratorReset_UsesConfiguredBaseBranch(t *testing.T) {
 func TestCleanupUnmergedTags_MergedNotTouched(t *testing.T) {
 	initTestGitRepo(t)
 
-	gitTag("generation-2026-02-28-12-00-00-start")
-	gitTag("generation-2026-02-28-12-00-00-finished")
-	gitTag("generation-2026-02-28-12-00-00-merged")
+	gitTag("generation-2026-02-28-12-00-00-start", "")
+	gitTag("generation-2026-02-28-12-00-00-finished", "")
+	gitTag("generation-2026-02-28-12-00-00-merged", "")
 
 	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
 	o.cleanupUnmergedTags()
 
-	tags := gitListTags("generation-2026-02-28-12-00-00-*")
+	tags := gitListTags("generation-2026-02-28-12-00-00-*", "")
 	if len(tags) != 3 {
 		t.Errorf("expected 3 tags after cleanup, got %d: %v", len(tags), tags)
 	}
@@ -974,13 +974,13 @@ func TestCleanupUnmergedTags_MergedNotTouched(t *testing.T) {
 func TestCleanupUnmergedTags_UnmergedAbandoned(t *testing.T) {
 	initTestGitRepo(t)
 
-	gitTag("generation-2026-02-28-12-00-00-start")
-	gitTag("generation-2026-02-28-12-00-00-finished")
+	gitTag("generation-2026-02-28-12-00-00-start", "")
+	gitTag("generation-2026-02-28-12-00-00-finished", "")
 
 	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
 	o.cleanupUnmergedTags()
 
-	tags := gitListTags("generation-2026-02-28-12-00-00-*")
+	tags := gitListTags("generation-2026-02-28-12-00-00-*", "")
 	found := false
 	for _, tag := range tags {
 		if tag == "generation-2026-02-28-12-00-00-abandoned" {
@@ -1050,6 +1050,45 @@ func TestCleanGoSources_RemovesGoFiles(t *testing.T) {
 	// Binary dir should be removed.
 	if _, err := os.Stat("bin"); !os.IsNotExist(err) {
 		t.Error("bin/ should be removed")
+	}
+}
+
+// initTestGitRepoInDir sets up a bare-minimum git repo in dir without calling
+// os.Chdir. Tests using this helper can safely call t.Parallel() because they
+// do not modify the process-wide working directory.
+func initTestGitRepoInDir(t *testing.T, dir string) {
+	t.Helper()
+	cmds := [][]string{
+		{"git", "init", "-b", "main"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test"},
+		{"git", "config", "commit.gpgsign", "false"},
+		{"git", "commit", "--allow-empty", "-m", "initial"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git setup %v failed: %v\n%s", args, err, out)
+		}
+	}
+}
+
+// --- gitCurrentBranch with explicit dir (git, parallel-safe) ---
+
+// TestGitCurrentBranch_ExplicitDir demonstrates that git helpers can run in
+// parallel when an explicit dir is passed instead of relying on os.Chdir.
+func TestGitCurrentBranch_ExplicitDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	initTestGitRepoInDir(t, dir)
+
+	branch, err := gitCurrentBranch(dir)
+	if err != nil {
+		t.Fatalf("gitCurrentBranch(%q) error = %v", dir, err)
+	}
+	if branch == "" {
+		t.Errorf("gitCurrentBranch(%q) returned empty branch", dir)
 	}
 }
 

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -123,7 +123,7 @@ func (o *Orchestrator) RunMeasure() error {
 
 	// Get initial state: open GitHub issues for this generation.
 	existingIssues, _ := listActiveIssuesContext(repo, generation)
-	commitSHA, _ := gitRevParseHEAD() // empty string on error is acceptable for logging
+	commitSHA, _ := gitRevParseHEAD(".") // empty string on error is acceptable for logging
 
 	logf("existing issues context len=%d, maxMeasureIssues=%d, commit=%s",
 		len(existingIssues), o.cfg.Cobbler.MaxMeasureIssues, commitSHA)

--- a/pkg/orchestrator/stitch_test.go
+++ b/pkg/orchestrator/stitch_test.go
@@ -394,8 +394,8 @@ func TestCreateWorktree_CreatesWorktreeAndBranch(t *testing.T) {
 		t.Fatalf("createWorktree() error = %v", err)
 	}
 	t.Cleanup(func() {
-		gitWorktreeRemove(task.worktreeDir)
-		gitDeleteBranch(task.branchName)
+		gitWorktreeRemove(task.worktreeDir, "")
+		gitDeleteBranch(task.branchName, "")
 	})
 
 	// Verify the worktree directory exists.
@@ -404,7 +404,7 @@ func TestCreateWorktree_CreatesWorktreeAndBranch(t *testing.T) {
 	}
 
 	// Verify the branch was created.
-	if !gitBranchExists(task.branchName) {
+	if !gitBranchExists(task.branchName, "") {
 		t.Errorf("branch %q should exist after createWorktree()", task.branchName)
 	}
 }
@@ -539,7 +539,7 @@ func TestRecoverStaleBranches_WithStaleBranch(t *testing.T) {
 	branchName := "task/main-99999"
 	gitRun(t, "branch", branchName)
 
-	if !gitBranchExists(branchName) {
+	if !gitBranchExists(branchName, "") {
 		t.Fatal("setup: branch should exist")
 	}
 
@@ -550,7 +550,7 @@ func TestRecoverStaleBranches_WithStaleBranch(t *testing.T) {
 	}
 
 	// The stale branch should have been force-deleted.
-	if gitBranchExists(branchName) {
+	if gitBranchExists(branchName, "") {
 		t.Error("stale branch should have been deleted after recovery")
 	}
 }
@@ -573,7 +573,7 @@ func TestRecoverStaleBranches_WithWorktree(t *testing.T) {
 	}
 
 	// Worktree and branch should be cleaned up.
-	if gitBranchExists(branchName) {
+	if gitBranchExists(branchName, "") {
 		t.Error("stale branch should have been deleted")
 	}
 	if _, err := os.Stat(worktreeDir); !os.IsNotExist(err) {
@@ -618,7 +618,7 @@ func TestRecoverStaleTasks_WithStaleBranch(t *testing.T) {
 	}
 
 	// Branch should have been cleaned up.
-	if gitBranchExists(branchName) {
+	if gitBranchExists(branchName, "") {
 		t.Error("stale branch should have been recovered")
 	}
 }
@@ -664,7 +664,7 @@ func TestResetTask_WithRealWorktree(t *testing.T) {
 	if _, err := os.Stat(worktreeDir); !os.IsNotExist(err) {
 		t.Error("worktree directory should have been removed")
 	}
-	if gitBranchExists(branchName) {
+	if gitBranchExists(branchName, "") {
 		t.Error("branch should have been force-deleted")
 	}
 }
@@ -706,8 +706,8 @@ func TestCreateWorktree_ExistingBranch(t *testing.T) {
 		t.Fatalf("createWorktree() with existing branch error = %v", err)
 	}
 	t.Cleanup(func() {
-		gitWorktreeRemove(task.worktreeDir)
-		gitDeleteBranch(task.branchName)
+		gitWorktreeRemove(task.worktreeDir, "")
+		gitDeleteBranch(task.branchName, "")
 	})
 
 	if _, err := os.Stat(task.worktreeDir); os.IsNotExist(err) {
@@ -740,7 +740,7 @@ func TestCleanupWorktree_RealWorktree(t *testing.T) {
 		t.Error("worktree directory should have been removed")
 	}
 	// Branch should be deleted.
-	if gitBranchExists(branchName) {
+	if gitBranchExists(branchName, "") {
 		t.Errorf("branch %q should have been deleted", branchName)
 	}
 }

--- a/pkg/orchestrator/tag.go
+++ b/pkg/orchestrator/tag.go
@@ -22,7 +22,7 @@ import (
 // Exposed as a mage target (e.g., mage tag).
 func (o *Orchestrator) Tag() error {
 	// Ensure we're on the configured base branch for doc tags.
-	current, err := gitCurrentBranch()
+	current, err := gitCurrentBranch(".")
 	if err != nil {
 		return fmt.Errorf("getting current branch: %w", err)
 	}
@@ -42,7 +42,7 @@ func (o *Orchestrator) Tag() error {
 	logf("tag: creating documentation release %s", tag)
 
 	// Create the git tag.
-	if err := gitTag(tag); err != nil {
+	if err := gitTag(tag, "."); err != nil {
 		return fmt.Errorf("creating tag %s: %w", tag, err)
 	}
 
@@ -52,8 +52,8 @@ func (o *Orchestrator) Tag() error {
 		if err := writeVersionConst(o.cfg.Project.VersionFile, tag); err != nil {
 			logf("tag: version file warning: %v", err)
 		} else {
-			_ = gitStageAll() // best-effort; commit below handles empty index
-			if err := gitCommit(fmt.Sprintf("Set version to %s", tag)); err != nil {
+			_ = gitStageAll(".") // best-effort; commit below handles empty index
+			if err := gitCommit(fmt.Sprintf("Set version to %s", tag), "."); err != nil {
 				logf("tag: version commit warning: %v", err)
 			}
 		}
@@ -74,7 +74,7 @@ func (o *Orchestrator) Tag() error {
 // highest existing revision + 1.
 func nextDocRevision(prefix, date string) int {
 	pattern := fmt.Sprintf("%s%s.*", prefix, date)
-	tags := gitListTags(pattern)
+	tags := gitListTags(pattern, ".")
 	if len(tags) == 0 {
 		return 0
 	}


### PR DESCRIPTION
## Summary

Resolves two related issues discovered in audit #6: hardcoded `\"main\"` branch name strings in generator.go, and git command wrappers in commands.go lacking an explicit `cmd.Dir` parameter.

## Changes

- **GH-279**: Replaced four hardcoded `\"main\"` literals in `GeneratorSwitch` and `GeneratorReset` with `o.cfg.Cobbler.BaseBranch`. Added `TestGeneratorReset_UsesConfiguredBaseBranch` verifying the configured base branch is used.
- **GH-280**: Added `dir string` parameter to all 28 git helper functions in `commands.go`. Introduced `cmdGit(dir, arg...)` centralising `cmd.Dir` logic. Production callers pass `\".\"` (explicit CWD); test callers pass `\"\"` (unchanged behaviour). Added `initTestGitRepoInDir` helper and `TestGitCurrentBranch_ExplicitDir` with `t.Parallel()`, demonstrating that git helpers with explicit dir are safe for concurrent execution.

## Stats

Lines of code (Go, production): 10671 (+18)
Lines of code (Go, tests): 12565 (+61)
Words (documentation): 18901 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] `go test ./pkg/orchestrator/ -count=1` passes (121 tests)
- [x] `TestGitCurrentBranch_ExplicitDir` uses `t.Parallel()` successfully
- [x] No hardcoded `\"main\"` in GeneratorSwitch/GeneratorReset
- [x] All git helpers route through `cmdGit`

Closes #247