### PR TITLE
GH-311: Embed and scaffold testing.yaml constitution

### DIFF
--- a/pkg/orchestrator/scaffold.go
+++ b/pkg/orchestrator/scaffold.go
@@ -22,6 +22,9 @@ import (
 //go:embed constitutions/design.yaml
 var designConstitution string
 
+//go:embed constitutions/testing.yaml
+var testingConstitution string
+
 // orchestratorModule is the Go module path for this orchestrator library.
 const orchestratorModule = "github.com/mesh-intelligence/cobbler-scaffold"
 
@@ -58,6 +61,7 @@ func (o *Orchestrator) Scaffold(targetDir, orchestratorRoot string) error {
 		"planning.yaml":  planningConstitution,
 		"execution.yaml": executionConstitution,
 		"go-style.yaml":  goStyleConstitution,
+		"testing.yaml":   testingConstitution,
 	}
 	for _, name := range slices.Sorted(maps.Keys(constitutionFiles)) {
 		p := filepath.Join(constitutionsDir, name)


### PR DESCRIPTION
## Summary

`docs/constitutions/testing.yaml` was present in cobbler-scaffold but never embedded or written to target repos during scaffold. Two lines fix it: an embed directive and an entry in `constitutionFiles`.

## Changes

- `pkg/orchestrator/scaffold.go`: add `//go:embed constitutions/testing.yaml` and `"testing.yaml": testingConstitution` to `constitutionFiles`

## Stats

    Lines of code (Go, production): 10675 (+4)
    Lines of code (Go, tests):      13898 (+0)
    Words (documentation):          18901 (+0)

## Test plan

- [x] `go build ./pkg/orchestrator/` passes
- [x] `go test ./pkg/orchestrator/ -run TestScaffold` passes
- [x] `mage analyze` passes

Closes #311