### PR TITLE
GH-315: Fix version.go.tmpl seed — remove main(), constants-only

### DIFF
--- a/pkg/orchestrator/scaffold.go
+++ b/pkg/orchestrator/scaffold.go
@@ -391,16 +391,13 @@ func scaffoldSeedTemplate(targetDir, modulePath, mainPkg string) (destPath, tmpl
 	destPath = filepath.Join(relDir, "version.go")
 	tmplPath = filepath.Join(dirMagefiles, "version.go.tmpl")
 
-	tmplContent := `package main
+	tmplContent := `// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
 
-import "fmt"
+package main
 
 // Version is set during the generation process.
 const Version = "{{.Version}}"
-
-func main() {
-	fmt.Printf("%s version %s\n", "` + detectBinaryName(modulePath) + `", Version)
-}
 `
 	absPath := filepath.Join(targetDir, tmplPath)
 	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {

--- a/pkg/orchestrator/scaffold_test.go
+++ b/pkg/orchestrator/scaffold_test.go
@@ -338,8 +338,8 @@ func TestScaffoldSeedTemplate_CreatesFile(t *testing.T) {
 	if !strings.Contains(content, "{{.Version}}") {
 		t.Error("template missing Version placeholder")
 	}
-	if !strings.Contains(content, "repo") {
-		t.Error("template missing binary name derived from module")
+	if strings.Contains(content, "func main") {
+		t.Error("template must not contain func main() — version.go is constants-only")
 	}
 }
 


### PR DESCRIPTION
## Summary

`scaffoldSeedTemplate` generated a `version.go.tmpl` containing `package main`, `import \"fmt\"`, and `func main()`. When `generator:stop` re-seeded `version.go` from this template, it created an add/add conflict with the generation branch's `main.go`. This fix strips the template to a constants-only file.

## Changes

- `pkg/orchestrator/scaffold.go`: `tmplContent` is now copyright header + `package main` + `const Version = \"{{.Version}}\"`. Removed `import \"fmt\"` and `func main()`.
- `pkg/orchestrator/scaffold_test.go`: assert `func main` is absent from the generated template (replaces the now-removed binary-name assertion).

## Stats

- Lines of code (Go, production): 10756 (-7)
- Lines of code (Go, tests): 14018 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] `go test ./pkg/orchestrator/` passes
- [x] `TestScaffoldSeedTemplate_CreatesFile` verifies template has no `func main`

Closes #315