### PR TITLE
GH-319: Fix agent instructions: remove bd/beads references

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -2,16 +2,7 @@
 
 # Agent Instructions
 
-This project uses **bd** (beads) for issue tracking. Run `bd onboard` to get started.
-
-## Core Workflow
-
-See [rules/beads-workflow.md](rules/beads-workflow.md) for the complete workflow including:
-
-- Issue tracking with bd CLI
-- Token usage tracking
-- Session completion checklist
-- Git commit requirements
+Issue tracking uses GitHub Issues via the `gh` CLI. The `/do-work` and `/git-issue-pop` commands handle the full workflow: fetching issues, assigning tasks, tracking sub-issues, and opening pull requests.
 
 ## Pre-Commit Quality Gate
 


### PR DESCRIPTION
## Summary

Removes stale bd/beads content from `.claude/instructions.md`. The beads workflow section (10 lines including a broken link to the deleted `rules/beads-workflow.md`) is replaced with a single sentence pointing to GitHub Issues and the `/do-work` + `/git-issue-pop` commands.

## Changes

- `.claude/instructions.md`: removed "bd (beads)" sentence, removed broken beads-workflow.md link and its section body, replaced with one-line GitHub Issues statement

## Stats

- Lines of code (Go, production): 10760 (+0)
- Lines of code (Go, tests): 13951 (+0)
- Words (documentation): 19108 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] No references to `bd`, `beads`, or `beads-workflow.md` remain

Closes #319