### PR TITLE
GH-321: Update PRDs: replace beads references with GitHub Issues

### DIFF
--- a/docs/specs/product-requirements/prd001-orchestrator-core.yaml
+++ b/docs/specs/product-requirements/prd001-orchestrator-core.yaml
@@ -28,7 +28,7 @@ requirements:
       - R1.5: ProjectConfig must include GoSourceDirs ([]string) listing directories with Go source
       - R1.6: ProjectConfig must include VersionFile (string) for the version.go path
       - R1.7: GenerationConfig must include Prefix (string, default "generation-") for generation branch names
-      - R1.8: CobblerConfig must include BeadsDir (string, default ".beads/") for the issue tracker directory
+      - R1.8: CobblerConfig must include IssuesRepo (string) for the GitHub repository (owner/repo) used as the issue tracker; auto-detected from module_path when empty
       - R1.9: CobblerConfig must include Dir (string, default ".cobbler/") for the scratch directory
       - R1.10: ProjectConfig must include MagefilesDir (string, default "magefiles") for the directory skipped during Go file deletion
       - R1.11: ClaudeConfig must include SecretsDir (string, default ".secrets") for token files
@@ -74,7 +74,7 @@ requirements:
       - R2.1: New(Config) must return an *Orchestrator with defaults applied to zero-value fields
       - R2.2: applyDefaults must set Project.BinaryDir to "bin" when empty
       - R2.3: applyDefaults must set Generation.Prefix to "generation-" when empty
-      - R2.4: applyDefaults must set Cobbler.BeadsDir to ".beads/" when empty
+      - R2.4: applyDefaults must leave Cobbler.IssuesRepo empty when not set; detectGitHubRepo derives it from module_path at runtime
       - R2.5: applyDefaults must set Cobbler.Dir to ".cobbler/" when empty
       - R2.6: applyDefaults must set Project.MagefilesDir to "magefiles" when empty
       - R2.7: applyDefaults must set Claude.SecretsDir to ".secrets" when empty
@@ -114,10 +114,10 @@ requirements:
   R5:
     title: Initialization and Reset
     items:
-      - R5.1: Init must initialize the beads issue tracker
-      - R5.2: FullReset must reset cobbler, generator, and beads in sequence
-      - R5.3: BeadsInit must create the beads database directory
-      - R5.4: BeadsReset must remove and reinitialize the beads database
+      - R5.1: Init is a no-op placeholder kept for mage target compatibility; issue tracking uses GitHub Issues
+      - R5.2: FullReset must reset cobbler and generator in sequence
+      - R5.3: Reserved (local issue database removed; issue tracking uses GitHub Issues)
+      - R5.4: Reserved (local issue database removed; issue tracking uses GitHub Issues)
 
   R6:
     title: Seed Files

--- a/docs/specs/product-requirements/prd002-generation-lifecycle.yaml
+++ b/docs/specs/product-requirements/prd002-generation-lifecycle.yaml
@@ -27,7 +27,7 @@ requirements:
       - R2.1: GeneratorStart must record the current branch as the base branch; any clean branch is a valid starting point
       - R2.2: GeneratorStart must tag the current base branch state as {generationName}-start
       - R2.3: GeneratorStart must create and switch to the generation branch
-      - R2.4: GeneratorStart must reset the beads database and reinitialize with the generation prefix
+      - R2.4: GeneratorStart must record the base branch and prepare the generation branch; issue tracking uses GitHub Issues and requires no local database reset
       - R2.5: GeneratorStart must delete all Go source files (except magefiles) and re-seed from templates
       - R2.6: GeneratorStart must reinitialize go.mod with a fresh module and local replace directive
       - R2.7: GeneratorStart must squash intermediate commits into a single clean commit

--- a/docs/specs/product-requirements/prd003-cobbler-workflows.yaml
+++ b/docs/specs/product-requirements/prd003-cobbler-workflows.yaml
@@ -13,7 +13,7 @@ goals:
   - G2: Define the stitch workflow that executes tasks in isolated worktrees
   - G3: Support configurable Claude invocation parameters
   - G4: Record invocation metrics for every Claude session
-  - G5: Handle task dependencies and lifecycle through beads integration
+  - G5: Handle task dependencies and lifecycle through GitHub Issues integration
 
 requirements:
   R1:
@@ -26,25 +26,25 @@ requirements:
   R2:
     title: Measure Workflow
     items:
-      - R2.1: Measure must verify beads is initialized before proceeding
+      - R2.1: Measure must verify the GitHub Issues repo is reachable before proceeding
       - R2.2: Measure must resolve and switch to the target branch
-      - R2.3: Measure must query existing issues from beads via bd list
+      - R2.3: Measure must query existing GitHub Issues from the configured issues repo via gh issue list
       - R2.4: Measure must clean up old proposed-issues files from the cobbler directory
       - R2.5: Measure must build the prompt from the template with existing issues, limit, output path, and user input
       - R2.6: Measure must invoke Claude with the built prompt
       - R2.7: Measure must parse the YAML output file written by Claude
-      - R2.8: Measure must import proposed issues into beads with title and description
+      - R2.8: Measure must create proposed issues as GitHub Issues with title, description, and generation label via gh issue create
       - R2.9: Measure must wire dependencies between imported issues based on the dependency index
       - R2.10: Measure must record an InvocationRecord on each created issue
-      - R2.11: Measure must commit beads changes after import
+      - R2.11: Reserved (GitHub Issues are created remotely; no local commit required)
 
   R3:
     title: Stitch Workflow
     items:
-      - R3.1: Stitch must verify beads is initialized before proceeding
+      - R3.1: Stitch must verify the GitHub Issues repo is reachable before proceeding
       - R3.2: Stitch must resolve and switch to the target branch
       - R3.3: Stitch must recover stale tasks from interrupted runs before processing
-      - R3.4: Stitch must pick ready tasks one at a time from beads (bd ready -n 1 --type task)
+      - R3.4: Stitch must pick ready tasks one at a time from GitHub Issues (open issues with the generation label and without the cobbler-in-progress label)
       - R3.5: Stitch must stop when no ready tasks remain or MaxIssues is reached
       - R3.6: For each task, stitch must claim the task by setting status to in_progress
       - R3.7: For each task, stitch must create a git worktree on a task branch
@@ -67,7 +67,7 @@ requirements:
       - R4.3: recoverStaleTasks must reset affected issues to ready status
       - R4.4: resetOrphanedIssues must find in_progress issues without corresponding task branches
       - R4.5: resetOrphanedIssues must reset orphaned issues to ready status
-      - R4.6: Recovery must commit beads changes if any state was recovered
+      - R4.6: Recovery must remove the cobbler-in-progress label from affected GitHub Issues if any state was recovered
       - R4.7: recoverStaleTasks and GeneratorResume must find stale task worktrees regardless of whether they are invoked from the main repo root or from a git worktree of the same repository
 
   R5:
@@ -103,9 +103,9 @@ requirements:
     title: Issue Import and Validation
     items:
       - R7.1: proposedIssue must include index (int), title (string), description (string), and dependency (int)
-      - R7.2: importIssues must create tasks in beads for each proposed issue
-      - R7.3: importIssues must wire dependencies using bd dep add for issues with dependency >= 0
-      - R7.4: importIssues must commit beads changes after successful import
+      - R7.2: importIssues must create a GitHub Issue for each proposed issue via gh issue create with the generation label
+      - R7.3: importIssues must order issues by dependency index so dependent issues are created after their prerequisites
+      - R7.4: Reserved (GitHub Issues are created remotely; no local commit required)
       - R7.5: When Config.Cobbler.MaxRequirementsPerTask is greater than zero, measure must count the number of requirement items in each proposed issue's description and reject issues that exceed the limit; rejected issues must trigger a re-prompt (up to Config.Cobbler.MaxMeasureRetries attempts) instructing Claude to split them into smaller tasks
 
   R8:
@@ -160,7 +160,7 @@ non_goals:
   - This PRD does not define concurrent task execution (tasks run sequentially)
 
 acceptance_criteria:
-  - Measure proposes tasks from project state and imports them into beads
+  - Measure proposes tasks from project state and creates them as GitHub Issues
   - Stitch executes ready tasks in isolated worktrees and merges results
   - Recovery resets stale tasks and orphaned issues to ready
   - Invocation records are stored on every task with token and LOC data


### PR DESCRIPTION
## Summary

Removes all beads/bd CLI references from prd001, prd002, and prd003. Requirements describing beads task creation, dependency wiring, and commit operations are rewritten to reference GitHub Issues and the gh CLI.

## Changes

- `prd003`: R3.4 (pick from GitHub Issues), R4.6 (remove cobbler-in-progress label), R7.2 (gh issue create), R7.3 (order by dependency), R7.4 (reserved — no local commit), acceptance criteria updated
- `prd001`, `prd002`: already updated in prior session (R5.1/5.3/5.4, R2.4)

## Stats

- Lines of code (Go, production): 10760 (+0)
- Lines of code (Go, tests): 13951 (+0)
- Words (documentation): 19108 (+0)

## Test plan

- [x] `mage analyze` passes with 0 errors
- [x] No references to `beads` or `bd` in any PRD

Closes #321