### PR TITLE
GH-340: Upgrade to latest version of sdd-hello-world

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -221,14 +221,16 @@ func (o *Orchestrator) GeneratorStart() error {
 	if err := gitResetSoft(branchSHA, "."); err != nil {
 		return fmt.Errorf("squashing start commits: %w", err)
 	}
-	_ = gitStageAll(".") // best-effort; commit below will catch nothing-to-commit
+	_ = gitStageAll(".")
 	var msg string
 	if o.cfg.Generation.PreserveSources {
 		msg = fmt.Sprintf("Start generation: %s\n\nBase branch: %s. Sources preserved (preserve_sources=true).\nTagged previous state as %s.", genName, baseBranch, genName)
 	} else {
 		msg = fmt.Sprintf("Start generation: %s\n\nBase branch: %s. Delete Go files, reinitialize module.\nTagged previous state as %s.", genName, baseBranch, genName)
 	}
-	if err := gitCommit(msg, "."); err != nil {
+	// Use allow-empty because a specs-only repo may have no Go files
+	// to delete, leaving no changes to commit after source reset.
+	if err := gitCommitAllowEmpty(msg, "."); err != nil {
 		return fmt.Errorf("committing clean state: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Upgrade cobbler-scaffold to work with sdd-hello-world v1.20260301.3, which is a specs-only tag (no Go source, only documentation and specifications). This exposed four gaps in how the orchestrator handles repos without code.

## Changes

- Scaffold re-creates missing seed file templates when configuration.yaml exists but references absent files (specs-only repos)
- PrepareTestRepo clears stale generation.branch from downloaded module configuration so generator lifecycle tests pass
- GeneratorStart uses allow-empty commit during source reset squash for repos with no Go files to delete
- Build/Install/Clean E2E tests skip when the target repo has no main package source

## Stats

- go_loc_prod: 10,760 → 10,820 (+60)
- go_loc_test: 13,951 → 13,984 (+33)
- go_loc: 24,711 → 24,804 (+93)

## Test plan

- [x] `mage analyze` passes
- [x] Unit tests pass (`go test ./pkg/orchestrator/`)
- [x] Non-Claude use case tests pass (uc001-uc007)
- [x] Claude-dependent tests pass (uc002 RunOneCycle, uc003 Measure*, uc004 StitchRecordsInvocation)
- [x] Pre-existing flakiness in StitchExecutesTask (GitHub API eventual consistency) unrelated to this change

Closes #340