### PR TITLE
GH-367: Fix promoteReadyIssues label index lag

### DIFF
--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"time"
 )
 
 // cobblerIssue holds the parsed representation of a GitHub issue created by
@@ -270,6 +271,25 @@ func listOpenCobblerIssues(repo, generation string) ([]cobblerIssue, error) {
 		})
 	}
 	return issues, nil
+}
+
+// waitForIssuesVisible polls listOpenCobblerIssues until at least
+// expected issues appear or the timeout expires. The REST API label
+// index may lag briefly after issue creation, so this function
+// ensures all issues are visible before promotion or DAG resolution.
+func waitForIssuesVisible(repo, generation string, expected int) {
+	const maxWait = 15 * time.Second
+	const interval = time.Second
+	deadline := time.Now().Add(maxWait)
+	for time.Now().Before(deadline) {
+		issues, err := listOpenCobblerIssues(repo, generation)
+		if err == nil && len(issues) >= expected {
+			return
+		}
+		logf("waitForIssuesVisible: %d/%d visible, retrying...", len(issues), expected)
+		time.Sleep(interval)
+	}
+	logf("waitForIssuesVisible: timed out waiting for %d issues (generation=%s)", expected, generation)
 }
 
 // hasLabel returns true if the issue has the given label.

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -438,6 +438,7 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 	}
 
 	if len(ids) > 0 {
+		waitForIssuesVisible(repo, generation, len(ids))
 		if err := promoteReadyIssues(repo, generation); err != nil {
 			logf("importIssues: promoteReadyIssues warning: %v", err)
 		}

--- a/tests/rel01.0/internal/testutil/testutil.go
+++ b/tests/rel01.0/internal/testutil/testutil.go
@@ -19,6 +19,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator"
 	"gopkg.in/yaml.v3"
@@ -277,6 +278,26 @@ func CountReadyIssues(t testing.TB, dir string) int {
 		}
 	}
 	return count
+}
+
+// WaitForReadyIssues polls CountReadyIssues until at least min issues are
+// ready or timeout elapses. Returns the final count. This absorbs the
+// eventual-consistency lag in GitHub's label-filtered issue listing that
+// can cause promoteReadyIssues to miss newly created issues.
+func WaitForReadyIssues(t testing.TB, dir string, min int, timeout time.Duration) int {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for {
+		n := CountReadyIssues(t, dir)
+		if n >= min {
+			return n
+		}
+		if time.Now().After(deadline) {
+			t.Logf("WaitForReadyIssues: timed out after %v with %d/%d ready", timeout, n, min)
+			return n
+		}
+		time.Sleep(2 * time.Second)
+	}
 }
 
 // ensureGitHubLabel creates label on repo if it does not already exist.

--- a/tests/rel01.0/uc003/measure_claude_test.go
+++ b/tests/rel01.0/uc003/measure_claude_test.go
@@ -11,6 +11,7 @@ package uc003_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator"
 	"github.com/mesh-intelligence/cobbler-scaffold/tests/rel01.0/internal/testutil"
@@ -38,7 +39,7 @@ func TestRel01_UC003_MeasureCreatesIssues(t *testing.T) {
 		t.Fatalf("cobbler:measure: %v", err)
 	}
 
-	n := testutil.CountReadyIssues(t, dir)
+	n := testutil.WaitForReadyIssues(t, dir, 1, 30*time.Second)
 	if n == 0 {
 		t.Error("expected at least 1 ready issue after cobbler:measure, got 0")
 	}

--- a/tests/rel01.0/uc004/stitch_claude_test.go
+++ b/tests/rel01.0/uc004/stitch_claude_test.go
@@ -11,6 +11,7 @@ package uc004_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator"
 	"github.com/mesh-intelligence/cobbler-scaffold/tests/rel01.0/internal/testutil"
@@ -41,7 +42,7 @@ func TestRel01_UC004_StitchExecutesTask(t *testing.T) {
 	if err := testutil.RunMage(t, dir, "cobbler:measure"); err != nil {
 		t.Fatalf("cobbler:measure: %v", err)
 	}
-	if n := testutil.CountReadyIssues(t, dir); n == 0 {
+	if n := testutil.WaitForReadyIssues(t, dir, 1, 30*time.Second); n == 0 {
 		t.Fatal("expected at least 1 ready issue after measure, got 0")
 	}
 


### PR DESCRIPTION
## Summary

Fixes the flaky `StitchExecutesTask` and `MeasureCreatesIssues` test failures caused by GitHub's REST API label-filtered issue listing lagging behind individual issue creation. The `promoteReadyIssues` function would see an empty list immediately after creating issues, leaving `cobbler-ready` never applied.

## Changes

- Added `waitForIssuesVisible` polling function in `issues_gh.go` that waits up to 15s for all newly created issues to appear in label-filtered listings
- Called `waitForIssuesVisible` in `importIssuesImpl` (measure.go) before `promoteReadyIssues`
- Added `WaitForReadyIssues` polling helper in testutil.go for test-side resilience
- Updated uc003 and uc004 tests to use `WaitForReadyIssues` instead of direct `CountReadyIssues`

## Stats

- go_loc_prod: 10862
- go_loc_test: 13986
- 5 files changed, 46 insertions, 2 deletions

## Test plan

- [x] `mage analyze` passes
- [x] `go test ./pkg/orchestrator/ -count=1` passes
- [x] `go vet` passes for all modified packages
- [ ] E2E uc003/uc004 tests pass (require Claude credentials)

Closes #367