### PR TITLE
GH-369: Fix stale cobbler-gen issue accumulation

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -172,6 +172,12 @@ func (o *Orchestrator) GeneratorStart() error {
 		return fmt.Errorf("worktree has uncommitted changes on %s; commit or stash before starting a generation", baseBranch)
 	}
 
+	// Garbage-collect issues from generations whose branch no longer exists.
+	// This catches leaks from crashed tests or prior runs without cleanup.
+	if ghRepo, err := detectGitHubRepo(".", o.cfg); err == nil && ghRepo != "" {
+		gcStaleGenerationIssues(ghRepo, o.cfg.Generation.Prefix)
+	}
+
 	genName := o.cfg.Generation.Prefix + time.Now().Format("2006-01-02-15-04-05")
 	startTag := genName + "-start"
 
@@ -324,6 +330,14 @@ func (o *Orchestrator) GeneratorStop() error {
 
 	if err := o.mergeGeneration(branch, baseBranch); err != nil {
 		return err
+	}
+
+	// Close any open cobbler-gen issues for this generation so they do not
+	// accumulate as orphans after the branch is deleted.
+	if ghRepo, err := detectGitHubRepo(".", o.cfg); err == nil && ghRepo != "" {
+		if err := closeGenerationIssues(ghRepo, branch); err != nil {
+			logf("generator:stop: close issues warning: %v", err)
+		}
 	}
 
 	o.cleanupDirs()

--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -418,6 +418,49 @@ func closeGenerationIssues(repo, generation string) error {
 	return nil
 }
 
+// gcStaleGenerationIssues closes open issues whose generation branch no
+// longer exists locally. This catches leaked issues from crashed tests,
+// killed processes, or GeneratorStop runs that predated the cleanup fix.
+// It lists all GitHub labels matching cobbler-gen-*, extracts the generation
+// name, checks for a local branch, and closes issues for missing branches.
+func gcStaleGenerationIssues(repo, generationPrefix string) {
+	// List all labels in the repo that match the cobbler-gen- prefix.
+	out, err := exec.Command(binGh, "api",
+		fmt.Sprintf("repos/%s/labels", repo),
+		"--method", "GET",
+		"-f", "per_page=100",
+		"--jq", `[.[].name | select(startswith("`+cobblerGenLabelPrefix+`"))]`,
+	).Output()
+	if err != nil {
+		logf("gcStaleGenerationIssues: list labels: %v", err)
+		return
+	}
+	var labels []string
+	if err := json.Unmarshal(out, &labels); err != nil {
+		logf("gcStaleGenerationIssues: parse labels: %v", err)
+		return
+	}
+
+	for _, label := range labels {
+		generation := strings.TrimPrefix(label, cobblerGenLabelPrefix)
+		if generation == "" {
+			continue
+		}
+		// Only GC generations that match the configured prefix (e.g. "generation-").
+		// This avoids closing issues for non-generation branches like "main".
+		if !strings.HasPrefix(generation, generationPrefix) {
+			continue
+		}
+		if gitBranchExists(generation, ".") {
+			continue
+		}
+		logf("gcStaleGenerationIssues: branch %s gone, closing its issues", generation)
+		if err := closeGenerationIssues(repo, generation); err != nil {
+			logf("gcStaleGenerationIssues: %v", err)
+		}
+	}
+}
+
 // listActiveIssuesContext returns a human-readable summary of all open
 // issues for the generation, suitable for injection into the measure prompt.
 func listActiveIssuesContext(repo, generation string) (string, error) {


### PR DESCRIPTION
## Summary

Prevents orphaned `cobbler-gen-*` GitHub issues from accumulating by adding cleanup in `GeneratorStop` and a garbage-collection sweep in `GeneratorStart`.

## Changes

- `GeneratorStop()` now calls `closeGenerationIssues()` for the generation being stopped, closing issues before the branch is deleted
- `GeneratorStart()` runs `gcStaleGenerationIssues()` on startup, scanning for `cobbler-gen-*` labels whose generation branch no longer exists and closing their issues
- `gcStaleGenerationIssues()` helper in `issues_gh.go` lists all repo labels matching `cobbler-gen-*`, filters to the configured generation prefix, checks local branch existence, and closes issues for missing branches

## Stats

- go_loc_prod: 10919 (+57 from 10862)
- go_loc_test: 13986 (unchanged)
- 2 files changed, 57 insertions

## Test plan

- [x] `mage analyze` passes
- [x] `go test ./pkg/orchestrator/ -count=1` passes
- [x] `go vet` passes
- [ ] E2E tests pass (require Claude credentials)

Closes #369