### PR TITLE
GH-122: Fix subrequirement counting in measure validation

### DIFF
--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -111,6 +113,13 @@ func (o *Orchestrator) RunMeasure() error {
 
 	// Run pre-cycle analysis so the measure prompt sees current project state.
 	o.RunPreCycleAnalysis()
+
+	// Warn about PRD requirement groups whose sub-item count exceeds
+	// max_requirements_per_task. This is advisory — measure continues
+	// regardless so the operator can restructure PRDs later.
+	if o.cfg.Cobbler.MaxRequirementsPerTask > 0 {
+		warnOversizedGroups(o.cfg.Cobbler.MaxRequirementsPerTask)
+	}
 
 	// Route target-repo defects to the target repo (prd003 R11).
 	// Schema errors and constitution drift are bugs in the target project's
@@ -414,8 +423,10 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 		logf("importIssues: [%d] title=%q dep=%d", i, issue.Title, issue.Dependency)
 	}
 
-	// Validate proposed issues against P9/P7 rules.
-	vr := validateMeasureOutput(issues, o.cfg.Cobbler.MaxRequirementsPerTask)
+	// Validate proposed issues against P9/P7 rules. Load PRD sub-item
+	// counts so the validator can expand group references (GH-122).
+	subItemCounts := loadPRDSubItemCounts()
+	vr := validateMeasureOutput(issues, o.cfg.Cobbler.MaxRequirementsPerTask, subItemCounts)
 	if len(vr.Warnings) > 0 {
 		logf("importIssues: %d warning(s)", len(vr.Warnings))
 	}
@@ -484,8 +495,11 @@ func (v validationResult) HasErrors() bool {
 // validateMeasureOutput checks proposed issues against P9 granularity ranges
 // and P7 file naming conventions. Returns structured warnings and errors.
 // All issues are logged regardless of enforcing mode. maxReqs is the
-// operator-configured requirement cap (0 = unlimited).
-func validateMeasureOutput(issues []proposedIssue, maxReqs int) validationResult {
+// operator-configured requirement cap (0 = unlimited). subItemCounts maps
+// PRD stems to group IDs to sub-item counts; when a task requirement
+// references a PRD group, the expanded sub-item count is used instead of 1.
+// Expanded-count violations are logged as warnings (best-effort), not errors.
+func validateMeasureOutput(issues []proposedIssue, maxReqs int, subItemCounts map[string]map[string]int) validationResult {
 	var result validationResult
 	for _, issue := range issues {
 		var desc issueDescription
@@ -500,10 +514,23 @@ func validateMeasureOutput(issues []proposedIssue, maxReqs int) validationResult
 		acCount := len(desc.AcceptanceCriteria)
 		dCount := len(desc.DesignDecisions)
 
+		// Compute expanded requirement count by resolving PRD group
+		// references to their sub-item counts (GH-122).
+		expandedCount := expandedRequirementCount(desc.Requirements, subItemCounts)
+
 		if maxReqs > 0 && rCount > maxReqs {
 			msg := fmt.Sprintf("[%d] %q: has %d requirements, max is %d", issue.Index, issue.Title, rCount, maxReqs)
 			logf("validateMeasureOutput: %s", msg)
 			result.Errors = append(result.Errors, msg)
+		}
+
+		// Log expanded count as warning when it exceeds the limit.
+		// This is best-effort — we never block on expanded counts.
+		if maxReqs > 0 && expandedCount > maxReqs && expandedCount != rCount {
+			msg := fmt.Sprintf("[%d] %q: expanded sub-item count is %d (max %d); consider restructuring PRD requirement groups",
+				issue.Index, issue.Title, expandedCount, maxReqs)
+			logf("validateMeasureOutput: %s", msg)
+			result.Warnings = append(result.Warnings, msg)
 		}
 
 		if desc.DeliverableType == "code" {
@@ -550,6 +577,114 @@ func validateMeasureOutput(issues []proposedIssue, maxReqs int) validationResult
 		}
 	}
 	return result
+}
+
+// prdRefPattern matches PRD requirement references in task requirement text.
+// Examples: "prd003 R2", "prd004-ts R1.3", "prd001-orchestrator-core R5".
+// Group 1 = PRD stem (e.g., "prd003" or "prd004-ts").
+// Group 2 = requirement group number (e.g., "2" from "R2").
+// Group 3 = optional sub-item number (e.g., "3" from "R1.3"); empty for groups.
+var prdRefPattern = regexp.MustCompile(`(prd\d+[-\w]*)\s+R(\d+)(?:\.(\d+))?`)
+
+// loadPRDSubItemCounts loads all PRDs from the standard path and returns a
+// map of PRD stem -> group key -> sub-item count. A group with no sub-items
+// maps to 1. The stem is the filename without path and extension (e.g.,
+// "prd003-cobbler-workflows"); an additional entry keyed by the short prefix
+// (e.g., "prd003") is added for fuzzy matching.
+func loadPRDSubItemCounts() map[string]map[string]int {
+	paths, _ := filepath.Glob("docs/specs/product-requirements/prd*.yaml")
+	counts := make(map[string]map[string]int, len(paths)*2)
+	for _, path := range paths {
+		prd := loadYAML[PRDDoc](path)
+		if prd == nil {
+			continue
+		}
+		stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		groupCounts := make(map[string]int, len(prd.Requirements))
+		for key, group := range prd.Requirements {
+			if len(group.Items) > 0 {
+				groupCounts[key] = len(group.Items)
+			} else {
+				groupCounts[key] = 1
+			}
+		}
+		counts[stem] = groupCounts
+		// Add short prefix entry (e.g., "prd003") for fuzzy matching.
+		if idx := strings.IndexByte(stem, '-'); idx > 0 {
+			short := stem[:idx]
+			if _, exists := counts[short]; !exists {
+				counts[short] = groupCounts
+			}
+		}
+	}
+	return counts
+}
+
+// expandedRequirementCount computes the effective requirement count by
+// parsing PRD group references from each requirement's text and expanding
+// groups to their sub-item counts. A requirement referencing "prd003 R2"
+// where R2 has 4 sub-items counts as 4, not 1. Requirements without a
+// recognized PRD reference or referencing a specific sub-item (R1.3)
+// count as 1.
+func expandedRequirementCount(reqs []issueDescItem, subItemCounts map[string]map[string]int) int {
+	if len(subItemCounts) == 0 {
+		return len(reqs)
+	}
+	total := 0
+	for _, req := range reqs {
+		matches := prdRefPattern.FindStringSubmatch(req.Text)
+		if matches == nil {
+			total++
+			continue
+		}
+		prdStem := matches[1]
+		groupNum := matches[2]
+		subItem := matches[3]
+
+		// Specific sub-item reference (e.g., R1.3) counts as 1.
+		if subItem != "" {
+			total++
+			continue
+		}
+
+		// Group reference (e.g., R2). Look up sub-item count.
+		groupKey := "R" + groupNum
+		if groups, ok := subItemCounts[prdStem]; ok {
+			if count, found := groups[groupKey]; found {
+				total += count
+				continue
+			}
+		}
+		// PRD or group not found — count as 1.
+		total++
+	}
+	return total
+}
+
+// warnOversizedGroups loads PRDs and logs a warning for each requirement
+// group whose sub-item count exceeds maxReqs. This is advisory and runs
+// before the measure prompt is built so operators can restructure PRDs.
+func warnOversizedGroups(maxReqs int) {
+	paths, _ := filepath.Glob("docs/specs/product-requirements/prd*.yaml")
+	for _, path := range paths {
+		prd := loadYAML[PRDDoc](path)
+		if prd == nil {
+			continue
+		}
+		stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		keys := make([]string, 0, len(prd.Requirements))
+		for k := range prd.Requirements {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			group := prd.Requirements[key]
+			if len(group.Items) > maxReqs {
+				logf("warning: %s %s has %d sub-items (max_requirements_per_task=%d); consider splitting this requirement group",
+					stem, key, len(group.Items), maxReqs)
+			}
+		}
+	}
 }
 
 // saveHistory persists measure artifacts (log, issues YAML) to the configured

--- a/pkg/orchestrator/measure_test.go
+++ b/pkg/orchestrator/measure_test.go
@@ -51,7 +51,7 @@ design_decisions:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0)
+	vr := validateMeasureOutput(issues, 0, nil)
 	if vr.HasErrors() {
 		t.Errorf("expected no errors for valid code task, got: %v", vr.Errors)
 	}
@@ -89,7 +89,7 @@ design_decisions:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0)
+	vr := validateMeasureOutput(issues, 0, nil)
 	if !vr.HasErrors() {
 		t.Error("expected errors for code task with 2 requirements (P9 range 5-8)")
 	}
@@ -144,7 +144,7 @@ design_decisions:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0)
+	vr := validateMeasureOutput(issues, 0, nil)
 	if !vr.HasErrors() {
 		t.Error("expected errors for code task with 9 requirements (P9 range 5-8)")
 	}
@@ -173,7 +173,7 @@ acceptance_criteria:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0)
+	vr := validateMeasureOutput(issues, 0, nil)
 	if vr.HasErrors() {
 		t.Errorf("expected no errors for valid doc task, got: %v", vr.Errors)
 	}
@@ -206,7 +206,7 @@ acceptance_criteria:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0)
+	vr := validateMeasureOutput(issues, 0, nil)
 	if !vr.HasErrors() {
 		t.Error("expected errors for doc task with 5 requirements (P9 range 2-4)")
 	}
@@ -252,7 +252,7 @@ design_decisions:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0)
+	vr := validateMeasureOutput(issues, 0, nil)
 	if !vr.HasErrors() {
 		t.Error("expected errors for file named after package (P7 violation)")
 	}
@@ -310,7 +310,7 @@ design_decisions:
 
 	// runner.go in pkg/difftest/ is NOT a P7 violation because
 	// the file name does not match the parent directory name.
-	vr := validateMeasureOutput(issues, 0)
+	vr := validateMeasureOutput(issues, 0, nil)
 	p7Errors := 0
 	for _, e := range vr.Errors {
 		if contains(e, "P7 violation") {
@@ -330,7 +330,7 @@ func TestValidateMeasureOutput_UnparseableDescription(t *testing.T) {
 		Description: `{{{not valid yaml`,
 	}}
 
-	vr := validateMeasureOutput(issues, 0)
+	vr := validateMeasureOutput(issues, 0, nil)
 	if len(vr.Warnings) == 0 {
 		t.Error("expected warning for unparseable description")
 	}
@@ -388,7 +388,7 @@ acceptance_criteria:
 		},
 	}
 
-	vr := validateMeasureOutput(issues, 0)
+	vr := validateMeasureOutput(issues, 0, nil)
 	if !vr.HasErrors() {
 		t.Error("expected errors from invalid second issue")
 	}
@@ -428,7 +428,7 @@ func TestValidateMeasureOutput_MaxReqs_ZeroIsUnlimited(t *testing.T) {
 		Title:       "Huge task",
 		Description: "deliverable_type: code\nrequirements:\n" + reqs,
 	}}
-	vr := validateMeasureOutput(issues, 0)
+	vr := validateMeasureOutput(issues, 0, nil)
 	for _, e := range vr.Errors {
 		if contains(e, "max is") {
 			t.Errorf("maxReqs=0 should not produce max-requirements error, got: %s", e)
@@ -456,7 +456,7 @@ requirements:
     text: req
 `,
 	}}
-	vr := validateMeasureOutput(issues, 5)
+	vr := validateMeasureOutput(issues, 5, nil)
 	for _, e := range vr.Errors {
 		if contains(e, "max is") {
 			t.Errorf("5 requirements at maxReqs=5 should not error, got: %s", e)
@@ -486,7 +486,7 @@ requirements:
     text: req
 `,
 	}}
-	vr := validateMeasureOutput(issues, 5)
+	vr := validateMeasureOutput(issues, 5, nil)
 	found := false
 	for _, e := range vr.Errors {
 		if contains(e, "max is") {
@@ -525,7 +525,7 @@ requirements:
     text: req
 `,
 	}}
-	vr := validateMeasureOutput(issues, 5)
+	vr := validateMeasureOutput(issues, 5, nil)
 	found := false
 	for _, e := range vr.Errors {
 		if contains(e, "8") && contains(e, "5") && contains(e, "Task Title") {
@@ -538,6 +538,192 @@ requirements:
 	}
 }
 
+
+// --- expandedRequirementCount ---
+
+func TestExpandedRequirementCount_NilSubItemCounts(t *testing.T) {
+	t.Parallel()
+	reqs := []issueDescItem{
+		{ID: "R1", Text: "Implement prd003 R2"},
+		{ID: "R2", Text: "Something else"},
+	}
+	got := expandedRequirementCount(reqs, nil)
+	if got != 2 {
+		t.Errorf("expandedRequirementCount with nil map = %d, want 2", got)
+	}
+}
+
+func TestExpandedRequirementCount_GroupExpansion(t *testing.T) {
+	t.Parallel()
+	subItems := map[string]map[string]int{
+		"prd003": {"R2": 4, "R5": 2},
+	}
+	reqs := []issueDescItem{
+		{ID: "R1", Text: "Implement prd003 R2"},       // expands to 4
+		{ID: "R2", Text: "Handle prd003 R5"},           // expands to 2
+		{ID: "R3", Text: "Something with no PRD ref"},  // counts as 1
+	}
+	got := expandedRequirementCount(reqs, subItems)
+	if got != 7 {
+		t.Errorf("expandedRequirementCount = %d, want 7 (4+2+1)", got)
+	}
+}
+
+func TestExpandedRequirementCount_SubItemRefCountsAsOne(t *testing.T) {
+	t.Parallel()
+	subItems := map[string]map[string]int{
+		"prd003": {"R2": 4},
+	}
+	reqs := []issueDescItem{
+		{ID: "R1", Text: "Implement prd003 R2.3"}, // specific sub-item = 1
+	}
+	got := expandedRequirementCount(reqs, subItems)
+	if got != 1 {
+		t.Errorf("expandedRequirementCount for sub-item ref = %d, want 1", got)
+	}
+}
+
+func TestExpandedRequirementCount_UnknownPRDCountsAsOne(t *testing.T) {
+	t.Parallel()
+	subItems := map[string]map[string]int{
+		"prd003": {"R2": 4},
+	}
+	reqs := []issueDescItem{
+		{ID: "R1", Text: "Implement prd999 R1"}, // unknown PRD
+	}
+	got := expandedRequirementCount(reqs, subItems)
+	if got != 1 {
+		t.Errorf("expandedRequirementCount for unknown PRD = %d, want 1", got)
+	}
+}
+
+func TestExpandedRequirementCount_FuzzyPRDStemMatch(t *testing.T) {
+	t.Parallel()
+	// "prd003-cobbler-workflows" mapped under both full stem and "prd003".
+	subItems := map[string]map[string]int{
+		"prd003-cobbler-workflows": {"R2": 4},
+		"prd003":                   {"R2": 4},
+	}
+	reqs := []issueDescItem{
+		{ID: "R1", Text: "Implement prd003 R2"}, // matches short prefix
+	}
+	got := expandedRequirementCount(reqs, subItems)
+	if got != 4 {
+		t.Errorf("expandedRequirementCount with fuzzy match = %d, want 4", got)
+	}
+}
+
+// --- validateMeasureOutput expanded count warning ---
+
+func TestValidateMeasureOutput_ExpandedCountWarning(t *testing.T) {
+	t.Parallel()
+	subItems := map[string]map[string]int{
+		"prd003": {"R2": 10},
+	}
+	issues := []proposedIssue{{
+		Index: 0,
+		Title: "Expanded task",
+		Description: `deliverable_type: code
+requirements:
+  - id: R1
+    text: Implement prd003 R2
+  - id: R2
+    text: plain req
+  - id: R3
+    text: another req
+  - id: R4
+    text: yet another
+  - id: R5
+    text: last one
+acceptance_criteria:
+  - id: AC1
+    text: ac1
+  - id: AC2
+    text: ac2
+  - id: AC3
+    text: ac3
+  - id: AC4
+    text: ac4
+  - id: AC5
+    text: ac5
+design_decisions:
+  - id: D1
+    text: d1
+  - id: D2
+    text: d2
+  - id: D3
+    text: d3
+`,
+	}}
+	// 5 listed requirements, but expanded count = 10+4 = 14. maxReqs = 8.
+	// Should produce a warning (not an error) about expanded count.
+	vr := validateMeasureOutput(issues, 8, subItems)
+	foundWarning := false
+	for _, w := range vr.Warnings {
+		if contains(w, "expanded sub-item count") {
+			foundWarning = true
+			break
+		}
+	}
+	if !foundWarning {
+		t.Errorf("expected expanded count warning, got warnings: %v, errors: %v", vr.Warnings, vr.Errors)
+	}
+	// The expanded count violation must NOT appear in errors.
+	for _, e := range vr.Errors {
+		if contains(e, "expanded") {
+			t.Errorf("expanded count violation should be warning, not error: %s", e)
+		}
+	}
+}
+
+func TestValidateMeasureOutput_NoExpandedWarningWhenUnderLimit(t *testing.T) {
+	t.Parallel()
+	subItems := map[string]map[string]int{
+		"prd003": {"R2": 2},
+	}
+	issues := []proposedIssue{{
+		Index: 0,
+		Title: "Small task",
+		Description: `deliverable_type: code
+requirements:
+  - id: R1
+    text: Implement prd003 R2
+  - id: R2
+    text: plain req
+  - id: R3
+    text: another req
+  - id: R4
+    text: yet another
+  - id: R5
+    text: last one
+acceptance_criteria:
+  - id: AC1
+    text: ac1
+  - id: AC2
+    text: ac2
+  - id: AC3
+    text: ac3
+  - id: AC4
+    text: ac4
+  - id: AC5
+    text: ac5
+design_decisions:
+  - id: D1
+    text: d1
+  - id: D2
+    text: d2
+  - id: D3
+    text: d3
+`,
+	}}
+	// 5 listed, expanded = 2+4 = 6. maxReqs = 8. Under limit.
+	vr := validateMeasureOutput(issues, 8, subItems)
+	for _, w := range vr.Warnings {
+		if contains(w, "expanded") {
+			t.Errorf("should not warn when expanded count under limit, got: %s", w)
+		}
+	}
+}
 
 func TestMeasureReleasesConstraint_WithReleases(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Summary

`validateMeasureOutput` now expands PRD group references to sub-item counts when checking `max_requirements_per_task`. A task referencing "prd003 R2" where R2 has 4 sub-items counts as 4, not 1. Expanded-count violations are logged as warnings (best-effort), never as blocking errors.

## Changes

- Added `loadPRDSubItemCounts()` to load PRD sub-item structure from YAML specs
- Added `expandedRequirementCount()` to resolve group references to actual sub-item counts
- Added `warnOversizedGroups()` pre-prompt advisory for groups exceeding the configured limit
- Updated `validateMeasureOutput` to accept sub-item counts and log expanded violations as warnings
- Added 7 new tests covering group expansion, sub-item refs, fuzzy matching, and warning behavior
- Updated 13 existing test calls for the new function signature

## Test plan

- [x] `go vet ./pkg/orchestrator/` passes
- [x] All tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] Expanded count tests verify warnings not errors

Closes #122