### PR TITLE
GH-428: Allow custom generation branch names

### DIFF
--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -21,8 +21,9 @@ overview:
     finished (tagged, ready to merge) -> merged (on main, branch deleted). An alternative
     terminal state is abandoned (generation was never merged).
 
-    The generation branch name follows the pattern {GenPrefix}{timestamp}, where the timestamp
-    is formatted as 2006-01-02-15-04-05. Tags mark lifecycle events: {branch}-start,
+    The generation branch name follows the pattern {GenPrefix}{suffix}. When generation.name
+    is set, the suffix is the configured name (e.g., "gh-42"); otherwise, it is a timestamp
+    formatted as 2006-01-02-15-04-05. Tags mark lifecycle events: {branch}-start,
     {branch}-finished, {branch}-merged, {branch}-abandoned.
 
   coordination_pattern: |

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -94,6 +94,11 @@ type GenerationConfig struct {
 	// Prefix is the prefix for generation branch names (default "generation-").
 	Prefix string `yaml:"prefix"`
 
+	// Name sets a custom generation branch name suffix. When non-empty,
+	// GeneratorStart uses Prefix + Name instead of Prefix + timestamp.
+	// Example: Name "gh-42" with default prefix produces "generation-gh-42".
+	Name string `yaml:"name"`
+
 	// Cycles is the maximum number of measure+stitch cycles per run
 	// (default 0, meaning run until all issues are closed).
 	Cycles int `yaml:"cycles"`

--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -182,7 +182,11 @@ func (o *Orchestrator) GeneratorStart() error {
 		gcStaleGenerationIssues(ghRepo, o.cfg.Generation.Prefix)
 	}
 
-	genName := o.cfg.Generation.Prefix + time.Now().Format("2006-01-02-15-04-05")
+	suffix := o.cfg.Generation.Name
+	if suffix == "" {
+		suffix = time.Now().Format("2006-01-02-15-04-05")
+	}
+	genName := o.cfg.Generation.Prefix + suffix
 	startTag := genName + "-start"
 
 	setGeneration(genName)
@@ -395,35 +399,8 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 		return fmt.Errorf("tagging merge: %w", err)
 	}
 
-	// Create versioned tags using v[REL].[DATE].[REVISION] convention.
-	if date := o.generationDateCompact(branch); date != "" {
-		revision := o.generationRevision(branch)
-		codeTag := fmt.Sprintf("v1.%s.%d", date, revision)
-		reqTag := fmt.Sprintf("v1.%s.%d-requirements", date, revision)
-
-		logf("generator:stop: tagging code as %s", codeTag)
-		if err := gitTag(codeTag, "."); err != nil {
-			logf("generator:stop: code tag warning: %v", err)
-		}
-
-		// Update the version constant in the consuming project's version file.
-		if o.cfg.Project.VersionFile != "" {
-			logf("generator:stop: writing version %s to %s", codeTag, o.cfg.Project.VersionFile)
-			if err := writeVersionConst(o.cfg.Project.VersionFile, codeTag); err != nil {
-				logf("generator:stop: version file warning: %v", err)
-			} else {
-				_ = gitStageAll(".")                                        // best-effort; commit below handles empty index
-				_ = gitCommit(fmt.Sprintf("Set version to %s", codeTag), ".") // best-effort; version update is non-critical
-			}
-		}
-
-		logf("generator:stop: tagging requirements as %s (at %s)", reqTag, startTag)
-		if err := gitTagAt(reqTag, startTag, "."); err != nil {
-			logf("generator:stop: requirements tag warning: %v", err)
-		}
-	}
-
-	// Reset base branch to specs-only after v1 tag preserves the code (prd002 R5.10, R5.11).
+	// Reset base branch to specs-only (prd002 R5.10, R5.11).
+	// Version tagging is handled separately by mage tag (Tag() in tag.go).
 	// Use cleanGoSources (not resetGoSources) to avoid re-seeding files like version.go.
 	// Skip when preserve_sources is true — library repos keep their Go source (prd002 R10.2).
 	if o.cfg.Generation.PreserveSources {
@@ -511,60 +488,6 @@ func (o *Orchestrator) listGenerationBranches() []string {
 
 // tagSuffixes lists the lifecycle tag suffixes in order.
 var tagSuffixes = []string{"-start", "-finished", "-merged", "-abandoned"}
-
-// generationDate extracts the date portion (YYYY-MM-DD) from a
-// generation branch name like "generation-2026-02-12-07-13-55".
-func (o *Orchestrator) generationDate(branch string) string {
-	rest := strings.TrimPrefix(branch, o.cfg.Generation.Prefix)
-	if rest == branch {
-		return ""
-	}
-	if len(rest) < 10 {
-		return ""
-	}
-	return rest[:10]
-}
-
-// generationDateCompact extracts the date in YYYYMMDD format from a
-// generation branch name like "generation-2026-02-12-07-13-55".
-func (o *Orchestrator) generationDateCompact(branch string) string {
-	date := o.generationDate(branch)
-	if date == "" {
-		return ""
-	}
-	return strings.ReplaceAll(date, "-", "")
-}
-
-// generationRevision returns the 0-indexed position of a generation
-// among all generations started on the same date. Counts unique
-// generation names from tags and branches matching the date.
-func (o *Orchestrator) generationRevision(branch string) int {
-	date := o.generationDate(branch) // "2026-02-12"
-	if date == "" {
-		return 0
-	}
-
-	nameSet := make(map[string]bool)
-	for _, t := range gitListTags(o.cfg.Generation.Prefix + date + "-*", ".") {
-		nameSet[generationName(t)] = true
-	}
-	for _, b := range gitListBranches(o.cfg.Generation.Prefix + date + "-*", ".") {
-		nameSet[b] = true
-	}
-
-	var names []string
-	for n := range nameSet {
-		names = append(names, n)
-	}
-	slices.Sort(names)
-
-	for i, n := range names {
-		if n == branch {
-			return i
-		}
-	}
-	return 0
-}
 
 // generationName strips the lifecycle suffix from a tag to recover
 // the generation name.

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -60,67 +60,6 @@ func chdirTemp(t *testing.T) string {
 	return dir
 }
 
-// --- generationDate (pure, parallelizable) ---
-
-func TestGenerationDate_ValidBranch(t *testing.T) {
-	t.Parallel()
-	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
-	got := o.generationDate("generation-2026-02-12-07-13-55")
-	want := "2026-02-12"
-	if got != want {
-		t.Errorf("generationDate() = %q, want %q", got, want)
-	}
-}
-
-func TestGenerationDate_NoPrefix(t *testing.T) {
-	t.Parallel()
-	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
-	got := o.generationDate("main")
-	if got != "" {
-		t.Errorf("generationDate(main) = %q, want empty", got)
-	}
-}
-
-func TestGenerationDate_ShortRest(t *testing.T) {
-	t.Parallel()
-	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
-	got := o.generationDate("generation-20")
-	if got != "" {
-		t.Errorf("generationDate(short) = %q, want empty", got)
-	}
-}
-
-func TestGenerationDate_CustomPrefix(t *testing.T) {
-	t.Parallel()
-	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "gen-"}}}
-	got := o.generationDate("gen-2026-03-01-12-00-00")
-	want := "2026-03-01"
-	if got != want {
-		t.Errorf("generationDate() = %q, want %q", got, want)
-	}
-}
-
-// --- generationDateCompact (pure, parallelizable) ---
-
-func TestGenerationDateCompact_Valid(t *testing.T) {
-	t.Parallel()
-	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
-	got := o.generationDateCompact("generation-2026-02-12-07-13-55")
-	want := "20260212"
-	if got != want {
-		t.Errorf("generationDateCompact() = %q, want %q", got, want)
-	}
-}
-
-func TestGenerationDateCompact_Invalid(t *testing.T) {
-	t.Parallel()
-	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
-	got := o.generationDateCompact("main")
-	if got != "" {
-		t.Errorf("generationDateCompact(main) = %q, want empty", got)
-	}
-}
-
 // --- generationName (pure, parallelizable) ---
 
 func TestGenerationName_StripsSuffixes(t *testing.T) {
@@ -702,57 +641,6 @@ func TestListGenerationBranches_WithBranches(t *testing.T) {
 	}
 }
 
-// --- generationRevision (git, NOT parallel) ---
-
-func TestGenerationRevision_SingleGeneration(t *testing.T) {
-	initTestGitRepo(t)
-
-	branch := "generation-2026-02-28-12-00-00"
-	if err := gitCreateBranch(branch, ""); err != nil {
-		t.Fatal(err)
-	}
-
-	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
-	got := o.generationRevision(branch)
-	if got != 0 {
-		t.Errorf("generationRevision() = %d, want 0", got)
-	}
-}
-
-func TestGenerationRevision_MultipleGenerationsSameDay(t *testing.T) {
-	initTestGitRepo(t)
-
-	gitCreateBranch("generation-2026-02-28-10-00-00", "")
-	gitCreateBranch("generation-2026-02-28-12-00-00", "")
-	gitCreateBranch("generation-2026-02-28-14-00-00", "")
-
-	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
-
-	got := o.generationRevision("generation-2026-02-28-10-00-00")
-	if got != 0 {
-		t.Errorf("generationRevision(10-00-00) = %d, want 0", got)
-	}
-
-	got = o.generationRevision("generation-2026-02-28-12-00-00")
-	if got != 1 {
-		t.Errorf("generationRevision(12-00-00) = %d, want 1", got)
-	}
-
-	got = o.generationRevision("generation-2026-02-28-14-00-00")
-	if got != 2 {
-		t.Errorf("generationRevision(14-00-00) = %d, want 2", got)
-	}
-}
-
-func TestGenerationRevision_InvalidBranch(t *testing.T) {
-	t.Parallel()
-	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
-	got := o.generationRevision("main")
-	if got != 0 {
-		t.Errorf("generationRevision(main) = %d, want 0", got)
-	}
-}
-
 // --- GeneratorResume validation (pure validation, parallelizable) ---
 
 func TestGeneratorResume_NotGenerationBranch(t *testing.T) {
@@ -833,6 +721,40 @@ func TestGeneratorStart_PreserveSources(t *testing.T) {
 
 	if _, err := os.Stat(goFile); os.IsNotExist(err) {
 		t.Error("GeneratorStart() deleted Go source file; want file preserved when PreserveSources=true")
+	}
+}
+
+// --- GeneratorStart custom name (git, NOT parallel) ---
+
+func TestGeneratorStart_CustomName(t *testing.T) {
+	initTestGitRepo(t)
+
+	o := &Orchestrator{cfg: Config{
+		Generation: GenerationConfig{
+			Prefix:          "generation-",
+			Name:            "gh-42",
+			PreserveSources: true,
+		},
+		Project: ProjectConfig{MagefilesDir: "magefiles"},
+		Cobbler: CobblerConfig{Dir: ".cobbler/"},
+	}}
+
+	if err := o.GeneratorStart(); err != nil {
+		t.Fatalf("GeneratorStart() error = %v", err)
+	}
+
+	branch, err := gitCurrentBranch("")
+	if err != nil {
+		t.Fatalf("gitCurrentBranch: %v", err)
+	}
+	if branch != "generation-gh-42" {
+		t.Errorf("branch = %q, want %q", branch, "generation-gh-42")
+	}
+
+	// Verify lifecycle tag was created.
+	tags := gitListTags("generation-gh-42-start", "")
+	if len(tags) != 1 {
+		t.Errorf("expected start tag, got %v", tags)
 	}
 }
 


### PR DESCRIPTION
## Summary

Add `generation.name` config field so generation branches can use a custom name (e.g., `generation-gh-42`) instead of a timestamp. Remove duplicate version-tagging from `GeneratorStop` — `mage tag` is the single versioning path.

## Changes

- Add `Name` field to `GenerationConfig` in config.go
- Use `Prefix + Name` in `GeneratorStart` when `Name` is non-empty, fall back to timestamp
- Remove duplicate version-tagging block from `GeneratorStop` (lines 398-424)
- Remove dead helpers: `generationDate`, `generationDateCompact`, `generationRevision`
- Remove 10 tests for deleted helpers, add 1 test for custom name
- Update ARCHITECTURE.yaml lifecycle description

## Stats

- Production: 11,113 → 11,041 (-72)
- Test: 14,420 → 14,342 (-78)
- Total: 4 files changed, 49 insertions, 198 deletions

## Test plan

- [x] `mage analyze` passes
- [x] All unit tests pass
- [x] `TestGeneratorStart_CustomName` validates custom branch naming

Closes #428