### PR TITLE
GH-430: Add provided_by field to ArchComponent schema

### DIFF
--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -107,7 +107,7 @@ document_types:
       - title
       - overview (summary, lifecycle, coordination_pattern)
       - interfaces (data_structures, operations, announcements)
-      - components (name, responsibility, capabilities, references)
+      - components (name, provided_by, responsibility, capabilities, references)
       - design_decisions (id, title, decision, benefits, alternatives_rejected)
       - technology_choices
       - project_structure

--- a/pkg/orchestrator/constitutions/design.yaml
+++ b/pkg/orchestrator/constitutions/design.yaml
@@ -107,7 +107,7 @@ document_types:
       - title
       - overview (summary, lifecycle, coordination_pattern)
       - interfaces (data_structures, operations, announcements)
-      - components (name, responsibility, capabilities, references)
+      - components (name, provided_by, responsibility, capabilities, references)
       - design_decisions (id, title, decision, benefits, alternatives_rejected)
       - technology_choices
       - project_structure

--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -176,6 +176,7 @@ type ArchInterface struct {
 
 type ArchComponent struct {
 	Name           string   `yaml:"name"`
+	ProvidedBy     string   `yaml:"provided_by,omitempty"`
 	Responsibility string   `yaml:"responsibility"`
 	Capabilities   []string `yaml:"capabilities"`
 	References     []string `yaml:"references,omitempty"`

--- a/pkg/orchestrator/prompts/measure.yaml
+++ b/pkg/orchestrator/prompts/measure.yaml
@@ -28,6 +28,7 @@ constraints: |
   - Do NOT duplicate existing issues. Review the issues in the project_context above before proposing.
   - Issues with status "closed" represent COMPLETED work. Do not re-propose work that a closed issue already covers, even under a different title or framing. The completed_work field in project_context lists all finished tasks — treat every entry as work that must not be repeated.
   - When source_code contains .go files for a package, that package already exists. Do not propose creating or reimplementing it. Trust the source code over prose descriptions in documentation (e.g., implementation_status sections in ARCHITECTURE.yaml may be stale).
+  - Components with a provided_by field in ARCHITECTURE.yaml are external infrastructure. Do NOT propose tasks that create or modify files in those components.
   - Do NOT exceed {limit} tasks. If more work is needed, create additional tasks in a future session.
   - Do NOT create tasks larger than {lines_max} lines of production code. Target {lines_min}-{lines_max} lines per task, touching 5-7 files. Split aggressively: a task that creates a struct and implements its methods is two tasks.
   - Each task must contain at most {max_requirements} requirements. Split any task that would exceed this limit.


### PR DESCRIPTION
## Summary

Add optional `provided_by` field to `ArchComponent` so consuming projects can mark scaffolded infrastructure as external. The measure prompt now instructs the agent to skip these components, preventing wasted cycles on files that conflict with cobbler-scaffold.

## Changes

- Add `ProvidedBy string` to `ArchComponent` struct in context.go
- Add measure prompt constraint to skip `provided_by` components
- Update design constitution schema to include `provided_by` in component fields
- Sync scaffolded constitution with embedded version

## Test plan

- [x] `mage analyze` passes (no constitution drift)
- [x] All unit tests pass
- [x] Existing projects without `provided_by` are unaffected (field is `omitempty`)

Closes #430