### PR TITLE
GH-456: Clean Go binaries before staging in commitWorktreeChanges

### DIFF
--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -703,11 +703,49 @@ func mergeBranch(branchName, baseBranch, repoRoot string) error {
 	return nil
 }
 
+// cleanGoBinaries removes untracked executable files with no extension from
+// dir before staging. Go binaries produced by `go build ./cmd/<name>/` land
+// in the working directory as extensionless executables; this prevents them
+// from being committed to the generation branch (GH-456).
+// Errors are logged but never fatal — a missed binary is less harmful than
+// blocking the commit.
+func cleanGoBinaries(dir string) {
+	cmd := exec.Command(binGit, "ls-files", "--others", "--exclude-standard")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		logf("cleanGoBinaries: git ls-files: %v", err)
+		return
+	}
+
+	removed := 0
+	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if name == "" || filepath.Ext(name) != "" {
+			continue // skip empty lines and files with extensions
+		}
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+			continue // skip missing, directories, and non-executables
+		}
+		if err := os.Remove(path); err != nil {
+			logf("cleanGoBinaries: remove %s: %v", name, err)
+		} else {
+			logf("cleanGoBinaries: removed binary %s", name)
+			removed++
+		}
+	}
+	logf("cleanGoBinaries: removed %d binary file(s)", removed)
+}
+
 // commitWorktreeChanges stages and commits all changes Claude made in the
 // worktree. Claude does not run git commands; the orchestrator handles git
 // externally. Returns nil if there are no changes to commit.
 func commitWorktreeChanges(task stitchTask) error {
 	logf("commitWorktreeChanges: staging changes in %s", task.worktreeDir)
+
+	// Remove compiled Go binaries before staging so they are not committed.
+	cleanGoBinaries(task.worktreeDir)
 
 	addCmd := exec.Command(binGit, "add", "-A")
 	addCmd.Dir = task.worktreeDir

--- a/pkg/orchestrator/stitch_test.go
+++ b/pkg/orchestrator/stitch_test.go
@@ -314,6 +314,145 @@ func TestParseRequiredReading_ValidYAML(t *testing.T) {
 	}
 }
 
+// --- cleanGoBinaries ---
+
+func TestCleanGoBinaries_RemovesExecutableNoExtension(t *testing.T) {
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init", "-b", "main")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "initial")
+
+	// Create a fake Go binary (untracked, executable, no extension).
+	binaryPath := filepath.Join(dir, "myapp")
+	if err := os.WriteFile(binaryPath, []byte("ELF"), 0o755); err != nil {
+		t.Fatalf("creating fake binary: %v", err)
+	}
+	// Create a Go source file that should survive.
+	srcPath := filepath.Join(dir, "main.go")
+	if err := os.WriteFile(srcPath, []byte("package main\n"), 0o644); err != nil {
+		t.Fatalf("creating source file: %v", err)
+	}
+
+	cleanGoBinaries(dir)
+
+	if _, err := os.Stat(binaryPath); !os.IsNotExist(err) {
+		t.Errorf("fake binary still exists after cleanGoBinaries")
+	}
+	if _, err := os.Stat(srcPath); err != nil {
+		t.Errorf("source file was removed by cleanGoBinaries: %v", err)
+	}
+}
+
+func TestCleanGoBinaries_KeepsFilesWithExtensions(t *testing.T) {
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init", "-b", "main")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "initial")
+
+	// Files with extensions must never be removed.
+	files := []string{"app.go", "app.sh", "app.exe", "app.yaml"}
+	for _, name := range files {
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, []byte("data"), 0o755); err != nil {
+			t.Fatalf("creating %s: %v", name, err)
+		}
+	}
+
+	cleanGoBinaries(dir)
+
+	for _, name := range files {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("file %s was incorrectly removed by cleanGoBinaries", name)
+		}
+	}
+}
+
+func TestCleanGoBinaries_KeepsNonExecutableFiles(t *testing.T) {
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init", "-b", "main")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "initial")
+
+	// A non-executable file with no extension (e.g., a data file) must survive.
+	dataPath := filepath.Join(dir, "Makefile")
+	if err := os.WriteFile(dataPath, []byte("all:\n"), 0o644); err != nil {
+		t.Fatalf("creating Makefile: %v", err)
+	}
+
+	cleanGoBinaries(dir)
+
+	if _, err := os.Stat(dataPath); err != nil {
+		t.Errorf("non-executable file was removed by cleanGoBinaries: %v", err)
+	}
+}
+
+func TestCleanGoBinaries_BinaryNotCommittedAfterClean(t *testing.T) {
+	dir := t.TempDir()
+	run := func(args ...string) {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("setup %v: %v\n%s", args, err, out)
+		}
+	}
+	run("git", "init", "-b", "main")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test")
+	run("git", "config", "commit.gpgsign", "false")
+	run("git", "commit", "--allow-empty", "-m", "initial")
+
+	// Simulate Claude leaving a binary and a source file.
+	os.WriteFile(filepath.Join(dir, "wc"), []byte("ELF binary"), 0o755)
+	os.WriteFile(filepath.Join(dir, "wc.go"), []byte("package main\n"), 0o644)
+
+	task := stitchTask{id: "1", title: "wc impl", worktreeDir: dir}
+	if err := commitWorktreeChanges(task); err != nil {
+		t.Fatalf("commitWorktreeChanges() error = %v", err)
+	}
+
+	// Verify that the binary was not committed.
+	cmd := exec.Command("git", "show", "--name-only", "--format=", "HEAD")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git show: %v", err)
+	}
+	committed := string(out)
+	if strings.Contains(committed, "\nwc\n") || strings.HasPrefix(committed, "wc\n") {
+		t.Errorf("binary 'wc' was committed: %s", committed)
+	}
+	if !strings.Contains(committed, "wc.go") {
+		t.Errorf("expected wc.go to be committed, got: %s", committed)
+	}
+}
+
 // --- commitWorktreeChanges ---
 
 func TestCommitWorktreeChanges_NoChanges(t *testing.T) {


### PR DESCRIPTION
## Summary

`commitWorktreeChanges` used `git add -A` which staged any Go binaries left in the worktree by the stitch agent's build verification step. The new `cleanGoBinaries` function removes these before staging by finding untracked extensionless executable files via `git ls-files --others`, targeting Go binaries without requiring knowledge of their names in advance.

## Changes

- `pkg/orchestrator/stitch.go`: Add `cleanGoBinaries(dir)` called from `commitWorktreeChanges` before `git add -A`
- `pkg/orchestrator/stitch_test.go`: 4 new tests covering removal, preservation of source/non-exec/extensioned files, and end-to-end commit verification

## Stats

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Production LOC | 11068 | 11106 | +38 |
| Test LOC | 14441 | 14580 | +139 |

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] `TestCleanGoBinaries_BinaryNotCommittedAfterClean` demonstrates the fix end-to-end

Closes #456