### PR TITLE
GH-470: Remove all beads references from code and docs

### DIFF
--- a/.claude/README.md
+++ b/.claude/README.md
@@ -10,9 +10,9 @@ This directory contains custom instructions and rules for the Claude Code agent.
 .claude/
 ├── instructions.md           # Main agent instructions (always applied)
 ├── rules/                    # Rule files for specific contexts
-│   ├── beads-workflow.md
 │   ├── code-prd-architecture-linking.md
 │   ├── documentation-standards.md
+│   ├── git-workflow.md
 │   ├── prd-format.md
 │   ├── use-case-format.md
 │   ├── crumb-format.md
@@ -31,15 +31,14 @@ This directory contains custom instructions and rules for the Claude Code agent.
 
 ### instructions.md
 Main configuration file that Claude Code loads automatically. Contains:
-- Beads (bd) issue tracking workflow
+- GitHub Issues tracking workflow
 - Token tracking requirements
 - Session completion checklist
-- Offline working mode instructions
 
 ### rules/
 Context-specific rules that govern how the agent works:
 
-- **beads-workflow.md**: Issue tracking, token logging, session completion workflow
+- **git-workflow.md**: Issue tracking, worktree discipline, PR workflow
 - **code-prd-architecture-linking.md**: Requirements for linking code to PRDs and architecture docs
 - **documentation-standards.md**: Writing style, formatting, figures, and content quality rules
 - **prd-format.md**: Product Requirements Document structure and guidelines

--- a/.claude/commands/do-work.md
+++ b/.claude/commands/do-work.md
@@ -206,7 +206,7 @@ If it reaches 0, perform a **thorough code inspection**:
 
 ## Important Notes
 
-- No beads commands — all tracking is via `gh issue` and `gh api`
+- No bd/beads commands — all tracking is via `gh issue` and `gh api`
 - Token usage goes in a GitHub comment: `gh issue comment <number> --body "tokens: <count>"`
 - Follow-up work goes in new GitHub issues: `gh issue create --repo <owner>/<repo>`
 - Always run `mage stats` and include the full Stats block in commit messages

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
 
-# Use bd merge for beads JSONL files
-.beads/issues.jsonl merge=beads

--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ vscode-extension/*.vsix
 
 # Auto-generated config when mage runs from magefiles/
 magefiles/configuration.yaml
+
+# Beads daemon runtime artifacts
+.beads/

--- a/docs/ARCHITECTURE-diagrams.md
+++ b/docs/ARCHITECTURE-diagrams.md
@@ -15,15 +15,15 @@ graph TD
         Orchestrator["Orchestrator\n<i>main struct</i>"]
         Generator["Generator\n<i>lifecycle</i>"]
         Cobbler["Cobbler\n<i>measure + stitch</i>"]
-        Commands["Commands\n<i>git, beads, go wrappers</i>"]
+        Commands["Commands\n<i>git, go wrappers</i>"]
         Stats["Stats\n<i>metrics</i>"]
     end
 
     subgraph EXT["External Tools"]
         Git
         ClaudeCode["Claude Code"]
-        Beads["Beads (bd)"]
         GoToolchain["Go Toolchain"]
+        GitHub["GitHub Issues API"]
     end
 
     Magefile --> Orchestrator
@@ -34,8 +34,8 @@ graph TD
     Cobbler --> Commands
     Cobbler --> ClaudeCode
     Commands --> Git
-    Commands --> Beads
     Commands --> GoToolchain
+    Commands --> GitHub
 ```
 
 |Figure 1 System context showing orchestrator components and external tools |

--- a/docs/VISION.yaml
+++ b/docs/VISION.yaml
@@ -60,8 +60,6 @@ why_we_build_this: |
 related_projects:
   - project: Crumbs
     role: Consuming project; provides the Cupboard CLI and storage library
-  - project: Beads
-    role: Issue tracker used by the orchestrator to track tasks
   - project: Mage
     role: Build system; orchestrator methods are exposed as Mage targets
 

--- a/docs/constitutions/execution.yaml
+++ b/docs/constitutions/execution.yaml
@@ -163,7 +163,7 @@ technology:
   cli_framework: cobra
   build_system: mage
   yaml_library: gopkg.in/yaml.v3
-  issue_tracker: cupboard (migrating from beads)
+  issue_tracker: cupboard
 
 git_conventions:
   note: Git is managed externally. Do NOT run any git commands.
@@ -198,8 +198,7 @@ sections:
     title: Technology Stack
     content: |
       The project uses Go with mage for build automation, cobra for CLI, viper
-      for configuration, yaml.v3 for YAML parsing, and cupboard (migrating from
-      beads) for issue tracking.
+      for configuration, yaml.v3 for YAML parsing, and cupboard for issue tracking.
   - tag: git_conventions
     title: Git Conventions
     content: |

--- a/docs/engineering/eng02-prompt-templates.yaml
+++ b/docs/engineering/eng02-prompt-templates.yaml
@@ -57,10 +57,10 @@ sections:
 
       | Field | Type | Source |
       |-------|------|--------|
-      | Title | string | Task title from beads |
-      | ID | string | Task ID from beads |
-      | IssueType | string | Task type from beads (default "task") |
-      | Description | string | Task description from beads |
+      | Title | string | Task title from GitHub issue |
+      | ID | string | Task ID from GitHub issue |
+      | IssueType | string | Task type from GitHub issue (default "task") |
+      | Description | string | Task description from GitHub issue |
       | ExecutionConstitution | string | Embedded execution.yaml constitution |
       | ProjectContext | string (YAML) | buildProjectContext — docs + source from worktree |
 
@@ -140,7 +140,7 @@ sections:
 
       | Category | Example | Why |
       |----------|---------|-----|
-      | Tool restrictions | Do NOT use bd commands | Agent should write JSON, not interact with issue tracker |
+      | Tool restrictions | Do NOT use gh commands to create issues | Agent should write JSON output, not interact with issue tracker |
       | Scope boundaries | Do NOT modify files outside the list | Prevents uncontrolled changes |
       | Context isolation | Do NOT assume the stitch agent has access to your analysis | Measure must write self-contained descriptions |
       | Quality gates | Do NOT leave uncommitted changes | Ensures clean state after stitch |

--- a/docs/engineering/eng03-project-initialization.yaml
+++ b/docs/engineering/eng03-project-initialization.yaml
@@ -26,7 +26,7 @@ sections:
       |------|---------|
       | Go 1.25+ | Build and run |
       | Mage (magefile/mage) | Build system; orchestrator methods are Mage targets |
-      | Beads (bd) | Git-backed issue tracking |
+      | GitHub Issues | Issue tracking via GitHub API |
       | Podman | Container runtime for Claude execution |
 
   - title: Scaffold Procedure
@@ -136,7 +136,6 @@ sections:
 
       cobbler:
         dir                        default: .cobbler/ — scratch directory
-        beads_dir                  default: .beads/   — issue tracker directory
         max_stitch_issues          default: 0 (unlimited) — total stitch cap for a run
         max_stitch_issues_per_cycle default: 10 — tasks per cycle before re-measuring
         max_measure_issues         default: 1  — new issues per measure pass
@@ -166,8 +165,8 @@ sections:
     content: |
       | Target | Description |
       |--------|-------------|
-      | init | Initialize the project (beads issue tracker) |
-      | reset | Full reset: cobbler, generator, beads |
+      | init | Initialize the project |
+      | reset | Full reset: cobbler, generator |
       | stats | Print Go LOC and documentation word counts as JSON |
       | build | Compile the project binary |
       | lint | Run golangci-lint |
@@ -185,8 +184,6 @@ sections:
       | generator:list | Show active branches and past generations |
       | generator:switch | Commit work and check out another generation branch |
       | generator:reset | Destroy generation branches and return to clean main |
-      | beads:init | Initialize beads issue tracker |
-      | beads:reset | Clear beads issue history |
 
 references:
   - docs/ARCHITECTURE.yaml

--- a/docs/engineering/eng04-measure-scaling.yaml
+++ b/docs/engineering/eng04-measure-scaling.yaml
@@ -36,7 +36,7 @@ sections:
     content: |
       Test: `TestMeasure_TimingByLimit` against go-unix-utils (v0.20260220.2).
       Single Claude call requesting N issues simultaneously. Each run starts
-      from a clean beads state with zero existing issues.
+      from a clean state with zero existing issues.
       Default `ClaudeMaxTimeSec=300` (5 minutes).
 
       | Limit | Result | Wall Time | Claude Time | Turns | Output Tokens | Issues |
@@ -78,7 +78,7 @@ sections:
 
       1. Build prompt with all existing issues and limit=1
       2. Call Claude to propose exactly one new issue
-      3. Import the issue into beads
+      3. Create the issue in GitHub Issues
       4. Repeat from step 1 until the desired number of issues is reached
 
       ### Advantages
@@ -91,7 +91,7 @@ sections:
         issues, so Claude naturally avoids duplicates and can reason about
         dependencies relative to what already exists
       - **Incremental progress**: If a call fails, previously created issues
-        are preserved in beads
+        are preserved in GitHub Issues
       - **Linear scaling**: Total time scales linearly with issue count
         (N * ~2 min) rather than super-linearly
 
@@ -100,14 +100,14 @@ sections:
       - Input tokens are sent N times (once per call). With prompt caching,
         the cache read ratio is ~58%, so the marginal input cost of repeated
         calls is lower than the raw token count suggests.
-      - Each call requires beads import and prompt rebuild overhead (~2-5s),
+      - Each call requires issue creation and prompt rebuild overhead (~2-5s),
         which is negligible compared to the Claude invocation time.
 
   - title: Iterative Benchmark Results
     content: |
       Test: `TestMeasure_TimingByLimit` against go-unix-utils (v0.20260220.2).
       Iterative strategy: N sequential Claude calls, each requesting 1 issue.
-      Each run starts from a clean beads state. Model: claude-opus-4-6.
+      Each run starts from a clean state. Model: claude-opus-4-6.
       Default `ClaudeMaxTimeSec=300` (5 minutes). Date: 2026-02-21.
 
       ### Summary

--- a/docs/specs/product-requirements/prd005-metrics-collection.yaml
+++ b/docs/specs/product-requirements/prd005-metrics-collection.yaml
@@ -9,7 +9,7 @@ problem: |
   that records per-invocation data and provides aggregate project statistics.
 
 goals:
-  - G1: Collect per-invocation metrics (tokens, LOC, diff stats) and store them on beads issues
+  - G1: Collect per-invocation metrics (tokens, LOC, diff stats) and store them in history
   - G2: Provide aggregate project statistics (Go LOC, documentation word counts)
   - G3: Support LOC snapshots before and after each Claude invocation
   - G4: Enumerate context files by category and estimate prompt token cost
@@ -25,7 +25,7 @@ requirements:
       - R1.5: InvocationRecord must include LOCBefore with Production and Test counts
       - R1.6: InvocationRecord must include LOCAfter with Production and Test counts
       - R1.7: InvocationRecord must include Diff with Files, Insertions, and Deletions counts
-      - R1.8: recordInvocation must serialize InvocationRecord to JSON and add it as a beads comment
+      - R1.8: recordInvocation must serialize InvocationRecord to JSON and write it to the history directory
 
   R2:
     title: LOC Snapshots
@@ -74,7 +74,7 @@ non_goals:
   - This PRD does not define cost estimation from token counts
 
 acceptance_criteria:
-  - Every Claude invocation produces an InvocationRecord stored on the beads issue
+  - Every Claude invocation produces an InvocationRecord written to the history directory
   - LOC snapshots capture production and test counts before and after each invocation
   - Stats prints Go LOC and documentation word counts as YAML
   - Token parsing extracts input and output counts from Claude output

--- a/docs/specs/product-requirements/prd006-vscode-extension.yaml
+++ b/docs/specs/product-requirements/prd006-vscode-extension.yaml
@@ -3,16 +3,16 @@ title: VS Code Extension for Generation Tracking and Lifecycle Management
 
 problem: |
   The orchestrator runs generation cycles from the terminal via mage
-  targets. Developers must switch between terminal, git log, and beads
-  CLI to understand what state a generation is in, what issues exist,
+  targets. Developers must switch between terminal, git log, and the GitHub
+  issues page to understand what state a generation is in, what issues exist,
   how branches compare, and what metrics each invocation produced.
   Without an integrated view inside the editor, situational awareness
-  requires constant context-switching and manual git/beads queries.
+  requires constant context-switching and manual git/GitHub queries.
 
 goals:
   - G1: Provide real-time visibility into generation lifecycle state from within VS Code
   - G2: Enable comparison between version tags and between generation branches
-  - G3: Surface beads issue status, dependencies, and invocation metrics inside the editor
+  - G3: Surface GitHub issue status, dependencies, and invocation metrics inside the editor
   - G4: Allow lifecycle management (start, run, resume, stop, reset, switch) without leaving VS Code
   - G5: Navigate specification artifacts (use cases, PRDs, test suites) and their relationships from a tree view
   - G6: Trace from source code annotations back to the specification YAML they reference
@@ -56,19 +56,19 @@ requirements:
     title: Issue Tracker Tree View
     items:
       - R4.1: The extension must provide a TreeDataProvider for the mageOrchestrator.issues view
-      - R4.2: The tree must parse .beads/issues.jsonl to list all issues
+      - R4.2: The tree must fetch issues from the GitHub Issues API to list all issues
       - R4.3: Issues must be grouped by status (open, in_progress, closed) with each group as a collapsible parent node
       - R4.4: Each issue node must display the issue title, type (task/epic), and ID
       - R4.5: Clicking an issue node must reveal child nodes showing description, dependencies, and comments
       - R4.6: The tree must display InvocationRecord data from issue comments as formatted child nodes (tokens, LOC delta, duration, diff stats)
-      - R4.7: The tree must refresh automatically when .beads/issues.jsonl changes (via FileSystemWatcher)
+      - R4.7: The tree must refresh automatically on a configurable polling interval via the GitHub Issues API
       - R4.8: The tree must include a context menu action to open the issue in a read-only editor panel with full details
 
   R5:
     title: Metrics Dashboard
     items:
       - R5.1: The extension must register a command to show a metrics dashboard as a VS Code webview panel
-      - R5.2: The dashboard must aggregate InvocationRecord data from all issue comments in .beads/issues.jsonl
+      - R5.2: The dashboard must aggregate InvocationRecord data from all GitHub issue comments
       - R5.3: The dashboard must display total and per-invocation token usage (input and output tokens)
       - R5.4: The dashboard must display LOC progression (production and test lines before and after each invocation)
       - R5.5: The dashboard must display diff statistics (files changed, insertions, deletions) per invocation
@@ -87,9 +87,9 @@ requirements:
     title: Extension Infrastructure
     items:
       - R7.1: The extension must activate when the workspace contains a configuration.yaml file (workspaceContains activation event)
-      - R7.2: The extension must use FileSystemWatcher instances to monitor .beads/, .git/refs/, and configuration.yaml for changes
-      - R7.3: The extension must dispose all watchers and terminals on deactivation
-      - R7.4: The extension must handle missing files gracefully (no configuration.yaml, no .beads/ directory, no git tags)
+      - R7.2: The extension must use FileSystemWatcher instances to monitor .git/refs/ and configuration.yaml for changes; GitHub issue data is refreshed via polling
+      - R7.3: The extension must dispose all watchers, polling timers, and terminals on deactivation
+      - R7.4: The extension must handle missing data gracefully (no configuration.yaml, no GitHub issues, no git tags)
       - R7.5: The extension must log errors to a dedicated VS Code output channel named Mage Orchestrator
       - R7.6: The extension must register all commands, tree data providers, and webview panels in the activate function
       - R7.7: The extension must declare all new commands and views in package.json contributes
@@ -138,7 +138,7 @@ acceptance_criteria:
   - Generation browser lists all generations with correct lifecycle state derived from git tags
   - Tag-to-tag comparison opens a file summary with clickable entries that launch VS Code diff editors
   - Generation-to-generation comparison resolves branches and shows the same file summary
-  - Issue tracker parses .beads/issues.jsonl and displays issues grouped by status
+  - Issue tracker fetches GitHub issues and displays them grouped by status
   - InvocationRecord metrics appear as formatted child nodes under each issue
   - Metrics dashboard aggregates and displays token usage, LOC progression, and diff stats
   - All views refresh automatically when underlying data changes

--- a/docs/specs/test-suites/test-rel01.0.yaml
+++ b/docs/specs/test-suites/test-rel01.0.yaml
@@ -22,7 +22,7 @@ tags:
   - smoke
 
 preconditions:
-  - Clean git repository on main branch with no beads directory
+  - Clean git repository on main branch
   - Go module initialized
   - configuration.yaml present
 
@@ -39,7 +39,7 @@ test_cases:
       state:
         project.binary_dir: "bin"
         generation.prefix: "generation-"
-        cobbler.beads_dir: ".beads/"
+        cobbler.dir: ".cobbler/"
         cobbler.dir: ".cobbler/"
         project.magefiles_dir: "magefiles"
         claude.secrets_dir: ".secrets"
@@ -53,14 +53,14 @@ test_cases:
         cfg := orchestrator.Config{
           Project:    orchestrator.ProjectConfig{ModulePath: "example.com/test", BinaryName: "mybin", BinaryDir: "out"},
           Generation: orchestrator.GenerationConfig{Prefix: "gen-"},
-          Cobbler:    orchestrator.CobblerConfig{BeadsDir: ".issues/"},
+          Cobbler:    orchestrator.CobblerConfig{Dir: ".cobbler/"},
         }
         o := orchestrator.New(cfg)
     expected:
       state:
         project.binary_dir: "out"
         generation.prefix: "gen-"
-        cobbler.beads_dir: ".issues/"
+        cobbler.dir: ".cobbler/"
 
   - use_case: rel01.0-uc001-orchestrator-initialization
     name: New returns non-nil Orchestrator
@@ -75,14 +75,14 @@ test_cases:
         orchestrator_not_nil: true
 
   - use_case: rel01.0-uc001-orchestrator-initialization
-    name: Init creates beads directory
-    go_test: TestRel01_UC001_InitCreatesBD
+    name: Init creates cobbler directory
+    go_test: TestRel01_UC001_InitCreatesCobbler
     inputs:
       command: mage init
     expected:
       exit_code: 0
       state:
-        beads_dir_exists: true
+        cobbler.dir_exists: true
 
   - use_case: rel01.0-uc001-orchestrator-initialization
     name: Init is idempotent
@@ -103,29 +103,6 @@ test_cases:
       exit_code: 0
       state:
         cobbler.dir_exists: false
-        beads_dir_exists: true
-
-  - use_case: rel01.0-uc001-orchestrator-initialization
-    name: BeadsReset preserves beads directory
-    go_test: TestRel01_UC001_BeadsResetKeepsDir
-    inputs:
-      command: mage beads:reset
-    expected:
-      exit_code: 0
-      state:
-        beads_dir_exists: true
-
-  - use_case: rel01.0-uc001-orchestrator-initialization
-    name: BeadsReset clears issues
-    go_test: TestRel01_UC001_BeadsResetClearsIssues
-    inputs:
-      command: |
-        bd create --type task --title "test"
-        mage beads:reset
-    expected:
-      exit_code: 0
-      state:
-        ready_issues: 0
 
   - use_case: rel01.0-uc001-orchestrator-initialization
     name: FullReset clears all orchestrator state
@@ -143,14 +120,6 @@ test_cases:
     go_test: TestRel01_UC001_CobblerResetWhenMissing
     inputs:
       command: mage cobbler:reset
-    expected:
-      exit_code: 0
-
-  - use_case: rel01.0-uc001-orchestrator-initialization
-    name: BeadsReset succeeds when directory missing
-    go_test: TestRel01_UC001_BeadsResetWhenMissing
-    inputs:
-      command: mage beads:reset
     expected:
       exit_code: 0
 
@@ -187,7 +156,7 @@ test_cases:
     expected:
       exit_code: 0
       state:
-        beads_dir_exists: true
+        cobbler.dir_exists: true
 
 # ---- uc002: Generation lifecycle from start to stop ----
 
@@ -390,24 +359,12 @@ test_cases:
       exit_code: 0
 
   - use_case: rel01.0-uc003-measure-workflow
-    name: Measure fails when beads not initialized
-    go_test: TestRel01_UC003_MeasureFailsWithoutBeads
-    inputs:
-      command: |
-        rm -rf .beads
-        mage cobbler:measure
-    expected:
-      exit_code: 1
-      stderr_contains: "beads not initialized"
-
-  - use_case: rel01.0-uc003-measure-workflow
-    name: Measure imports proposed issues into beads
+    name: Measure imports proposed issues into GitHub
     go_test: TestRel01_UC003_MeasureCreatesIssues
     covered_by: TestRel01_UC003_MeasureCreatesIssues
     inputs:
       command: |
         mage cobbler:measure
-        bd list --json
       config_overrides:
         cobbler.max_measure_issues: 3
     expected:
@@ -429,32 +386,16 @@ test_cases:
         issues_count_lte: 2
 
   - use_case: rel01.0-uc003-measure-workflow
-    name: Measure records InvocationRecord on created issues
+    name: Measure records InvocationRecord in history
     go_test: TestRel01_UC003_MeasureRecordsInvocation
     inputs:
-      command: |
-        mage cobbler:measure
-        bd list --json
+      command: mage cobbler:measure
       config_overrides:
         cobbler.max_measure_issues: 1
     expected:
       exit_code: 0
       state:
         invocation_record_present: true
-
-  - use_case: rel01.0-uc003-measure-workflow
-    name: BeadsReset clears issues after measure
-    go_test: TestRel01_UC003_BeadsResetClearsAfterMeasure
-    inputs:
-      command: |
-        mage cobbler:measure
-        mage beads:reset
-      config_overrides:
-        cobbler.max_measure_issues: 1
-    expected:
-      exit_code: 0
-      state:
-        ready_issues: 0
 
   - use_case: rel01.0-uc003-measure-workflow
     name: Measure fails without Claude credentials on main
@@ -481,17 +422,6 @@ test_cases:
         task_closed: true
         task_branch_deleted: true
         worktree_cleaned: true
-
-  - use_case: rel01.0-uc004-stitch-workflow
-    name: Stitch fails when beads not initialized
-    go_test: TestRel01_UC004_StitchFailsWithoutBeads
-    inputs:
-      command: |
-        rm -rf .beads
-        mage cobbler:stitch
-    expected:
-      exit_code: 1
-      stderr_contains: "beads not initialized"
 
   - use_case: rel01.0-uc004-stitch-workflow
     name: Stitch stops when no ready tasks
@@ -560,7 +490,7 @@ test_cases:
     go_test: TestRel01_UC004_StitchWithManualIssue
     inputs:
       command: |
-        bd create --type task --title "e2e stitch test task"
+        gh issue create --repo "$ISSUES_REPO" --title "e2e stitch test task" --label cobbler:ready
         mage cobbler:stitch
       config_overrides:
         claude.secrets_dir: "/dev/null/impossible"
@@ -985,4 +915,4 @@ cleanup:
   - Delete all generation and task branches
   - Remove worktrees
   - Remove cobbler scratch directory
-  - Reset beads
+  - Close any open GitHub test issues

--- a/docs/specs/test-suites/test-rel02.0.yaml
+++ b/docs/specs/test-suites/test-rel02.0.yaml
@@ -21,7 +21,7 @@ preconditions:
   - VS Code with orchestrator extension installed
   - Workspace contains configuration.yaml
   - Git repository initialized with main branch
-  - Beads initialized
+  - GitHub repository configured in configuration.yaml
 
 # ---- uc001: VS Code lifecycle command execution ----
 
@@ -285,9 +285,9 @@ test_cases:
         - "Diff: 3F +120 -20"
 
   - use_case: rel02.0-uc004-issue-tracker-view
-    name: Tree handles missing beads directory
+    name: Tree handles GitHub API unavailability
     inputs:
-      beads_dir_exists: false
+      github_api_available: false
     expected:
       tree_empty: true
       no_error: true

--- a/docs/specs/use-cases/rel01.0-uc001-orchestrator-initialization.yaml
+++ b/docs/specs/use-cases/rel01.0-uc001-orchestrator-initialization.yaml
@@ -4,7 +4,7 @@ title: Orchestrator Initialization and Configuration
 summary: |
   A consuming project creates a Config struct with project-specific
   settings, passes it to New() to get an Orchestrator, and calls Init()
-  to initialize the beads issue tracker. The orchestrator applies defaults
+  to initialize the orchestrator. The orchestrator applies defaults
   to zero-value fields and is ready to receive generation commands.
 
 actor: Developer integrating the orchestrator into a consuming project
@@ -14,18 +14,18 @@ trigger: First-time setup of the orchestrator in a magefile
 flow:
   - F1: "Create Config: construct a Config struct with ModulePath, BinaryName, GoSourceDirs, and other project-specific fields"
   - F2: "Construct Orchestrator: call New(config) to get an *Orchestrator with defaults applied"
-  - F3: "Initialize: call orchestrator.Init() to set up the beads issue tracker"
-  - F4: "Verify: confirm beads directory exists and git status shows tracked files"
+  - F3: "Initialize: call orchestrator.Init() to set up the cobbler scratch directory"
+  - F4: "Verify: confirm cobbler directory exists and git status shows tracked files"
 
 touchpoints:
   - T1: "Config struct: all fields defined in prd001-orchestrator-core R1"
   - T2: "New constructor: applies defaults per prd001-orchestrator-core R2"
-  - T3: "Init method: initializes beads per prd001-orchestrator-core R5"
+  - T3: "Init method: initializes cobbler scratch directory per prd001-orchestrator-core R5"
 
 success_criteria:
   - S1: New(config) returns a non-nil *Orchestrator
   - S2: Zero-value Config fields receive their documented defaults
-  - S3: Init() creates the beads database directory without error
+  - S3: Init() creates the cobbler scratch directory without error
   - S4: The orchestrator is ready to accept generation commands
 
 out_of_scope:

--- a/docs/specs/use-cases/rel01.0-uc003-measure-workflow.yaml
+++ b/docs/specs/use-cases/rel01.0-uc003-measure-workflow.yaml
@@ -2,9 +2,9 @@ id: rel01.0-uc003-measure-workflow
 title: Measure Workflow Task Proposal
 
 summary: |
-  The measure phase analyzes the project state, queries existing issues,
+  The measure phase analyzes the project state, queries existing GitHub issues,
   invokes Claude with a prompt template, and imports the proposed tasks
-  into beads with dependency wiring. A developer triggers this through
+  into GitHub Issues with dependency wiring. A developer triggers this through
   mage cobbler:measure or as part of a generation run.
 
 actor: Orchestrator (automated, triggered by developer via Mage)
@@ -12,16 +12,15 @@ actor: Orchestrator (automated, triggered by developer via Mage)
 trigger: Running mage cobbler:measure or as part of GeneratorRun
 
 flow:
-  - F1: "Verify preconditions: confirm beads is initialized and resolve the target branch"
-  - F2: "Query state: call bd list to get existing issues as JSON"
+  - F1: "Verify preconditions: confirm cobbler scratch directory exists and resolve the target branch"
+  - F2: "Query state: list existing GitHub issues as JSON context"
   - F3: "Clean scratch: remove old proposed-issues files from the cobbler directory"
   - F4: "Build prompt: render the measure template with existing issues, task limit, output path, and user input"
   - F5: "Invoke Claude: run Claude with the prompt, capturing token usage"
   - F6: "Parse output: read the JSON file written by Claude"
-  - F7: "Import issues: create tasks in beads for each proposed issue"
-  - F8: "Wire dependencies: link dependent issues using bd dep add"
-  - F9: "Record metrics: store InvocationRecord on each created issue"
-  - F10: "Commit: commit beads changes"
+  - F7: "Import issues: create GitHub issues for each proposed task"
+  - F8: "Wire dependencies: link dependent issues on GitHub"
+  - F9: "Record metrics: store token usage in history"
 
 touchpoints:
   - T1: "Config (workflow fields): prd001-orchestrator-core R1, prd003-cobbler-workflows R1, R2"
@@ -31,13 +30,12 @@ touchpoints:
   - T5: "InvocationRecord: prd005-metrics-collection R1"
 
 success_criteria:
-  - S1: Measure queries existing issues and includes them in the prompt
+  - S1: Measure queries existing GitHub issues and includes them in the prompt
   - S2: Claude receives a well-formed prompt with project context
-  - S3: Proposed issues are imported into beads with correct titles and descriptions
+  - S3: Proposed issues are created on GitHub with correct titles and descriptions
   - S4: Dependencies between issues are wired correctly
-  - S5: InvocationRecords are stored on each created issue
+  - S5: Token usage is recorded in the history directory
 
 out_of_scope:
   - Claude behavior and prompt quality (we test the workflow, not Claude output)
   - Stitch execution of proposed tasks (see rel01.0-uc004)
-

--- a/docs/specs/use-cases/rel01.0-uc004-stitch-workflow.yaml
+++ b/docs/specs/use-cases/rel01.0-uc004-stitch-workflow.yaml
@@ -2,7 +2,7 @@ id: rel01.0-uc004-stitch-workflow
 title: Stitch Workflow Task Execution
 
 summary: |
-  The stitch phase picks ready tasks from beads, creates isolated git
+  The stitch phase picks ready tasks from GitHub Issues, creates isolated git
   worktrees, invokes Claude to implement each task, merges the results
   back, records metrics, and closes the tasks. A developer triggers
   this through mage cobbler:stitch or as part of a generation run.
@@ -12,10 +12,10 @@ actor: Orchestrator (automated, triggered by developer via Mage)
 trigger: Running mage cobbler:stitch or as part of GeneratorRun
 
 flow:
-  - F1: "Verify preconditions: confirm beads is initialized and resolve the target branch"
+  - F1: "Verify preconditions: confirm cobbler scratch directory exists and resolve the target branch"
   - F2: "Recover stale tasks: clean up any orphaned worktrees or in_progress issues from interrupted runs"
-  - F3: "Pick task: call bd ready -n 1 --type task to get the next ready task"
-  - F4: "Claim task: set the task status to in_progress"
+  - F3: "Pick task: query GitHub Issues for the next ready task"
+  - F4: "Claim task: set the task label to in_progress on GitHub"
   - F5: "Create worktree: create a git worktree on branch task/{baseBranch}-{issueID}"
   - F6: "Capture LOC before: snapshot production and test line counts"
   - F7: "Build prompt: render the stitch template with task title, ID, type, and description"
@@ -23,7 +23,7 @@ flow:
   - F9: "Merge branch: merge the task branch back to the base branch"
   - F10: "Capture metrics: LOC after, git diff stats, token usage"
   - F11: "Clean up: remove the worktree and delete the task branch"
-  - F12: "Close task: record InvocationRecord and close the issue in beads"
+  - F12: "Close task: record token usage in history and close the GitHub issue"
   - F13: "Repeat: go to F3 until no ready tasks remain or MaxIssues is reached"
 
 touchpoints:
@@ -38,11 +38,10 @@ success_criteria:
   - S2: Each task runs in its own isolated worktree
   - S3: Task branches are merged back to the base branch after completion
   - S4: Worktrees and task branches are cleaned up after merge
-  - S5: InvocationRecords with LOC and diff data are stored on each task
-  - S6: Tasks are closed in beads after successful execution
+  - S5: Token usage and diff stats are recorded in history
+  - S6: GitHub issues are closed after successful execution
   - S7: Stitch stops when no ready tasks remain or MaxIssues is reached
 
 out_of_scope:
   - Claude behavior and code quality (we test the workflow, not Claude output)
   - Task proposal (see rel01.0-uc003)
-

--- a/docs/specs/use-cases/rel02.0-uc004-issue-tracker-view.yaml
+++ b/docs/specs/use-cases/rel02.0-uc004-issue-tracker-view.yaml
@@ -5,12 +5,12 @@ id: rel02.0-uc004-issue-tracker-view
 title: Issue Tracker View
 
 summary: |
-  A developer opens the Issue Tracker panel in VS Code and sees all beads
+  A developer opens the Issue Tracker panel in VS Code and sees all GitHub
   issues grouped by status (open, in_progress, closed). Expanding an issue
   reveals its description, dependencies, and comments. InvocationRecord
   metrics (tokens, LOC delta, duration, diff stats) from issue comments
-  appear as formatted child nodes. The view auto-refreshes when
-  .beads/issues.jsonl changes on disk.
+  appear as formatted child nodes. The view auto-refreshes on a polling
+  interval.
 
 actor: Developer using VS Code with the orchestrator extension installed
 
@@ -18,22 +18,22 @@ trigger: Developer opens the Issue Tracker panel in the VS Code sidebar
 
 flow:
   - F1: "Open Issue Tracker: developer clicks the mageOrchestrator.issues view in the VS Code sidebar"
-  - F2: "Parse issues: extension reads .beads/issues.jsonl and builds a tree of all issues"
+  - F2: "Fetch issues: extension calls the GitHub Issues API and builds a tree of all issues"
   - F3: "Group by status: tree displays three collapsible parent nodes (Open, In Progress, Closed) with issues sorted under the matching group"
   - F4: "Browse issue list: each issue node displays its title, type (task or epic), and ID"
   - F5: "Expand issue: developer expands an issue node to see child nodes for description, dependencies, and comments"
   - F6: "View InvocationRecord metrics: comments containing InvocationRecord JSON render as formatted child nodes showing tokens (input and output), LOC delta (production and test before/after), duration, and diff stats (files changed, insertions, deletions)"
   - F7: "Open issue detail: developer right-clicks an issue and selects the context menu action to open a read-only editor panel with the full issue content"
-  - F8: "Auto-refresh: a FileSystemWatcher on .beads/issues.jsonl triggers a tree rebuild when the file changes"
+  - F8: "Auto-refresh: extension polls the GitHub Issues API on a configurable interval and rebuilds the tree when issues change"
 
 touchpoints:
   - T1: "Issue tree view provider: prd006-vscode-extension R4.1"
-  - T2: "JSONL parsing: prd006-vscode-extension R4.2"
+  - T2: "GitHub Issues API fetch: prd006-vscode-extension R4.2"
   - T3: "Status grouping: prd006-vscode-extension R4.3"
   - T4: "Issue node display (title, type, ID): prd006-vscode-extension R4.4"
   - T5: "Expandable details (description, dependencies, comments): prd006-vscode-extension R4.5"
   - T6: "InvocationRecord formatting: prd006-vscode-extension R4.6"
-  - T7: "FileSystemWatcher auto-refresh: prd006-vscode-extension R4.7"
+  - T7: "Polling auto-refresh: prd006-vscode-extension R4.7"
   - T8: "Context menu open in editor: prd006-vscode-extension R4.8"
   - T9: "InvocationRecord data shape: fields input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost, loc_before, loc_after, duration_sec, git_diff_stat parsed from issue comments"
 
@@ -42,9 +42,9 @@ success_criteria:
   - S2: Each issue node shows its title, type, and ID
   - S3: Expanding an issue reveals description, dependencies, and comments as child nodes
   - S4: InvocationRecord comments display tokens, LOC delta, duration, and diff stats as formatted child nodes
-  - S5: Tree refreshes automatically when .beads/issues.jsonl is modified on disk
+  - S5: Tree refreshes automatically on the configured polling interval
   - S6: Context menu action opens a read-only editor panel with the full issue details
-  - S7: Tree handles an empty or missing .beads/issues.jsonl without errors
+  - S7: Tree handles an empty issue list or API error without crashing
 
 out_of_scope:
   - Creating, editing, or closing issues from the tree view (read-only display)
@@ -56,9 +56,9 @@ dependencies:
   - D1: prd006-vscode-extension R4 (Issue Tracker Tree View requirements)
   - D2: prd005-metrics-collection R1 (InvocationRecord format for parsing comments)
   - D3: Extension infrastructure (prd006 R7) must be in place for tree views and watchers to register
-  - D4: Beads CLI must maintain .beads/issues.jsonl in the expected JSONL format
+  - D4: GitHub repository must be configured in configuration.yaml (issues_repo field)
 
 risks:
-  - K1: "Large issue files may slow tree rendering | Parse incrementally and cache the tree model between refreshes"
+  - K1: "Large issue counts may slow tree rendering | Paginate GitHub API calls and cache the tree model between refreshes"
   - K2: "InvocationRecord JSON in comments may vary across versions | Parse known fields only and ignore unrecognized fields"
-  - K3: "Concurrent writes to issues.jsonl during generation runs | Use debounced FileSystemWatcher to avoid partial reads"
+  - K3: "GitHub API rate limiting during generation runs | Use conditional GET with ETag caching to minimize API calls"

--- a/docs/specs/use-cases/rel02.0-uc005-metrics-dashboard.yaml
+++ b/docs/specs/use-cases/rel02.0-uc005-metrics-dashboard.yaml
@@ -8,7 +8,7 @@ summary: |
   A developer opens a metrics dashboard inside VS Code to review aggregated
   token usage, LOC progression, diff statistics, and per-invocation details
   across all generation tasks. The dashboard parses InvocationRecord data from
-  .beads/issues.jsonl and renders an HTML summary in a webview panel that
+  GitHub issue comments and renders an HTML summary in a webview panel that
   refreshes when the underlying data changes.
 
 actor: Developer using VS Code with the orchestrator extension installed
@@ -18,13 +18,13 @@ trigger: Developer invokes the Cobbler Measure or Cobbler Stitch command, or ope
 flow:
   - F1: "Open Command Palette: developer presses Cmd+Shift+P and selects 'Mage Orchestrator: Cobbler Measure' or accesses the dashboard directly"
   - F2: "Show dashboard: extension creates a webview panel titled 'Metrics Dashboard' in the active editor column"
-  - F3: "Parse invocation records: BeadsStore reads .beads/issues.jsonl and extracts InvocationRecord data from issue comments"
+  - F3: "Fetch invocation records: GitHubStore fetches GitHub issues and extracts InvocationRecord data from issue comments"
   - F4: "Aggregate metrics: aggregateMetrics computes totals for tokens (input, output, cache creation, cache read), cost, duration, and diff stats across all records"
   - F5: "Render HTML: renderDashboardHtml produces an HTML document with a summary table and a per-invocation details table styled with VS Code theme variables"
   - F6: "Display summary: the summary section shows invocation count, token breakdown, estimated cost, total duration, and diff statistics (files changed, insertions, deletions)"
   - F7: "Display per-invocation details: a table lists each invocation with caller, date, duration, input/output/total tokens, LOC progression (production and test), diff stats, and issue ID"
   - F8: "Handle empty state: when no invocation records exist, the dashboard shows an informational message instead of empty tables"
-  - F9: "Refresh on data change: when .beads/issues.jsonl changes, the dashboard re-reads the store and re-renders the HTML content"
+  - F9: "Refresh on poll: the dashboard re-fetches GitHub issues on the configured polling interval and re-renders the HTML content"
   - F10: "Singleton panel: if the dashboard is already visible, subsequent show() calls reveal the existing panel and refresh its content rather than creating a new one"
 
 touchpoints:
@@ -36,17 +36,17 @@ touchpoints:
   - T6: "Duration display: prd006-vscode-extension R5.6"
   - T7: "HTML table rendering: prd006-vscode-extension R5.7"
   - T8: "Data refresh: prd006-vscode-extension R5.8"
-  - T9: "InvocationRecord data model: token counts (input, output, cache creation, cache read), cost, LOC before/after, duration, diff stats read from .beads/issues.jsonl comments"
+  - T9: "InvocationRecord data model: token counts (input, output, cache creation, cache read), cost, LOC before/after, duration, diff stats read from GitHub issue comments"
 
 success_criteria:
-  - S1: Dashboard command opens a webview panel with aggregated metrics from .beads/issues.jsonl
+  - S1: Dashboard command opens a webview panel with aggregated metrics from GitHub issue comments
   - S2: Summary section shows total invocation count, token breakdown (input, output, cache creation, cache read), estimated cost, and total duration
   - S3: Summary section shows diff statistics (files changed, insertions, deletions) when records contain diff data
   - S4: Per-invocation table shows caller, date, duration, input/output/total tokens, LOC progression, diff stats, and issue ID for each record
   - S5: Dashboard renders with VS Code theme colors (foreground, background, borders)
   - S6: When no invocation records exist, an informational empty-state message appears
   - S7: Re-invoking the dashboard command when the panel is visible refreshes content rather than creating a new panel
-  - S8: Dashboard refreshes automatically when .beads/issues.jsonl changes
+  - S8: Dashboard refreshes automatically on the configured polling interval
 
 out_of_scope:
   - Real-time streaming of Claude output during invocations
@@ -57,9 +57,10 @@ out_of_scope:
 dependencies:
   - D1: prd006-vscode-extension R5 (metrics dashboard requirements)
   - D2: prd005-metrics-collection R1 (InvocationRecord data model)
-  - D3: Extension infrastructure (prd006 R7) for webview panel management and FileSystemWatcher
-  - D4: BeadsStore (beadsModel.ts) for parsing .beads/issues.jsonl and extracting invocation records
+  - D3: Extension infrastructure (prd006 R7) for webview panel management
+  - D4: GitHubStore for fetching GitHub issues and extracting invocation records from comments
 
 risks:
-  - K1: "Large .beads/issues.jsonl files slow dashboard rendering | Aggregate lazily and cache results until invalidated"
+  - K1: "Large issue counts slow dashboard rendering | Aggregate lazily and cache results until next poll"
   - K2: "InvocationRecord format varies between simple and rich records | aggregateMetrics handles both formats with optional field guards"
+  - K3: "GitHub API rate limiting | Use conditional GET with ETag caching; surface rate-limit errors in the empty-state message"

--- a/pkg/orchestrator/constitutions/execution.yaml
+++ b/pkg/orchestrator/constitutions/execution.yaml
@@ -163,7 +163,7 @@ technology:
   cli_framework: cobra
   build_system: mage
   yaml_library: gopkg.in/yaml.v3
-  issue_tracker: cupboard (migrating from beads)
+  issue_tracker: cupboard
 
 git_conventions:
   note: Git is managed externally. Do NOT run any git commands.
@@ -198,8 +198,7 @@ sections:
     title: Technology Stack
     content: |
       The project uses Go with mage for build automation, cobra for CLI, viper
-      for configuration, yaml.v3 for YAML parsing, and cupboard (migrating from
-      beads) for issue tracking.
+      for configuration, yaml.v3 for YAML parsing, and cupboard for issue tracking.
   - tag: git_conventions
     title: Git Conventions
     content: |

--- a/pkg/orchestrator/constitutions/issue-format.yaml
+++ b/pkg/orchestrator/constitutions/issue-format.yaml
@@ -202,7 +202,7 @@ sections:
   - tag: schema
     title: Issue Schema
     content: |
-      Each beads issue description is a YAML document with five required fields:
+      Each issue description is a YAML document with five required fields:
       deliverable_type, required_reading, files, requirements, and
       acceptance_criteria. Optional fields include design_decisions and
       format_rule.

--- a/tests/rel01.0/uc008/measure_benchmark_test.go
+++ b/tests/rel01.0/uc008/measure_benchmark_test.go
@@ -81,7 +81,7 @@ type measureBenchmarkSummary struct {
 
 // TestRel01_UC008_MeasureTiming runs the iterative single-turn measure at
 // limits 1 through 5 and records wall-clock time, issue count, and per-iteration
-// token breakdown. Each limit gets a fresh repo and beads state.
+// token breakdown. Each limit gets a fresh repo and GitHub Issues state.
 func TestRel01_UC008_MeasureTiming(t *testing.T) {
 	summary := measureBenchmarkSummary{
 		TestName:  "TestRel01_UC008_MeasureTiming",

--- a/vscode-extension/src/__fixtures__/docs/specs/use-cases/uc001-basic.yaml
+++ b/vscode-extension/src/__fixtures__/docs/specs/use-cases/uc001-basic.yaml
@@ -6,7 +6,7 @@ summary: |
 
 touchpoints:
   - T1: "Config struct: all fields defined in prd001-orchestrator-core R1"
-  - T2: "Init method: initializes beads per prd001-orchestrator-core R5"
+  - T2: "Init method: initializes cobbler workspace per prd001-orchestrator-core R5"
 
 success_criteria:
   - S1: Parser returns a valid UseCase object


### PR DESCRIPTION
## Summary

Removes all references to beads (bd CLI) from the codebase. Beads was the previous local-file-based issue tracker (`.beads/issues.jsonl`); the project now uses GitHub Issues exclusively via the GitHub API.

## Changes

- `.gitignore`: add `.beads/` to prevent runtime artifacts
- `.gitattributes`: remove beads JSONL merge driver
- `docs/VISION.yaml`: remove Beads from related_projects
- `docs/ARCHITECTURE-diagrams.md`: remove Beads node, add GitHub Issues API
- Constitutions (`docs/` and `pkg/orchestrator/`): remove beads references from technology stack
- `docs/engineering/eng02`, `eng03`, `eng04`: replace beads/bd with GitHub Issues
- `.claude/README.md`: replace beads-workflow.md with git-workflow.md
- Use cases `rel01.0-uc001`, `uc003`, `uc004` and `rel02.0-uc004`, `uc005`: rewritten to use GitHub Issues API
- PRDs `prd005`, `prd006`: remove `.beads/` path references throughout
- Test suites `test-rel01.0`, `test-rel02.0`: remove beads-specific test cases, update language
- Benchmark test comment and vscode extension fixture updated

## Stats

```
go_loc_prod: 11109
go_loc_test: 14607
spec_words: prd=8204 test_suite=3676 use_case=7157
```

23 files changed, 104 insertions, 183 deletions

## Test plan

- [x] `mage analyze` passes
- [x] All unit tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] No remaining beads references in active code/docs (audit files preserved as historical records)

Closes #470