### PR TITLE
GH-469: Add BuildAll, bin/ gitignore, and stitch build instruction

### DIFF
--- a/pkg/orchestrator/build.go
+++ b/pkg/orchestrator/build.go
@@ -32,6 +32,70 @@ func (o *Orchestrator) Build() error {
 	return nil
 }
 
+// BuildAll compiles all cmd/ sub-packages to BinaryDir when MainPackage is
+// empty. It discovers every cmd/*/main.go package and builds each to
+// bin/<name> using go build -o bin/<name> ./cmd/<name>/. If no cmd/
+// directory exists the target is skipped. prd003 B1.1.
+func (o *Orchestrator) BuildAll() error {
+	if o.cfg.Project.MainPackage != "" {
+		// Single-package project — delegate to Build.
+		return o.Build()
+	}
+
+	pkgs, err := discoverCmdPackages(".")
+	if err != nil {
+		return fmt.Errorf("discovering cmd packages: %w", err)
+	}
+	if len(pkgs) == 0 {
+		logf("build:all: no cmd/ packages found, skipping")
+		return nil
+	}
+
+	if err := os.MkdirAll(o.cfg.Project.BinaryDir, 0o755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	for _, pkg := range pkgs {
+		name := filepath.Base(pkg)
+		outPath := filepath.Join(o.cfg.Project.BinaryDir, name)
+		logf("build:all: go build -o %s %s", outPath, pkg)
+		cmd := exec.Command(binGo, "build", "-o", outPath, pkg)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("go build %s: %w", pkg, err)
+		}
+	}
+
+	logf("build:all: built %d package(s) to %s", len(pkgs), o.cfg.Project.BinaryDir)
+	return nil
+}
+
+// discoverCmdPackages returns the import paths of all packages under cmd/
+// that contain a main.go file, relative to root.
+func discoverCmdPackages(root string) ([]string, error) {
+	cmdDir := filepath.Join(root, "cmd")
+	entries, err := os.ReadDir(cmdDir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading cmd/: %w", err)
+	}
+
+	var pkgs []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		mainGo := filepath.Join(cmdDir, e.Name(), "main.go")
+		if _, err := os.Stat(mainGo); err == nil {
+			pkgs = append(pkgs, "./cmd/"+e.Name()+"/")
+		}
+	}
+	return pkgs, nil
+}
+
 // Lint runs golangci-lint on the project.
 func (o *Orchestrator) Lint() error {
 	logf("lint: running golangci-lint")

--- a/pkg/orchestrator/build_test.go
+++ b/pkg/orchestrator/build_test.go
@@ -6,6 +6,7 @@ package orchestrator
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -57,6 +58,87 @@ func TestInstall_SkipsWhenNoMainPackage(t *testing.T) {
 	}}
 	if err := o.Install(); err != nil {
 		t.Errorf("Install() with empty MainPackage should not error, got: %v", err)
+	}
+}
+
+// --- BuildAll ---
+
+func TestBuildAll_SkipsWhenNoCmdDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &Orchestrator{cfg: Config{
+		Project: ProjectConfig{BinaryDir: filepath.Join(dir, "bin")},
+	}}
+	if err := o.BuildAll(); err != nil {
+		t.Errorf("BuildAll() with no cmd/ should not error, got: %v", err)
+	}
+	// bin/ should not be created when there are no packages.
+	if _, err := os.Stat(filepath.Join(dir, "bin")); !os.IsNotExist(err) {
+		t.Error("BuildAll() should not create bin/ when no cmd/ packages exist")
+	}
+}
+
+func TestBuildAll_DelegatesToBuildWhenMainPackageSet(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{cfg: Config{
+		Project: ProjectConfig{
+			MainPackage: "nonexistent/pkg",
+			BinaryDir:   t.TempDir(),
+			BinaryName:  "mybin",
+		},
+	}}
+	// Should attempt Build() and fail because package doesn't exist.
+	// Key is it does NOT fall through to multi-cmd path.
+	err := o.BuildAll()
+	if err == nil {
+		t.Error("BuildAll() with nonexistent MainPackage should fail")
+	}
+	if !strings.Contains(err.Error(), "go build") {
+		t.Errorf("error = %q, want to contain 'go build'", err.Error())
+	}
+}
+
+func TestDiscoverCmdPackages_NoCmdDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	pkgs, err := discoverCmdPackages(dir)
+	if err != nil {
+		t.Fatalf("discoverCmdPackages error = %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Errorf("pkgs = %v, want empty", pkgs)
+	}
+}
+
+func TestDiscoverCmdPackages_FindsMainPackages(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create cmd/foo/main.go and cmd/bar/main.go; cmd/notmain/ has no main.go.
+	for _, path := range []string{
+		"cmd/foo/main.go",
+		"cmd/bar/main.go",
+	} {
+		full := filepath.Join(dir, path)
+		os.MkdirAll(filepath.Dir(full), 0o755)
+		os.WriteFile(full, []byte("package main\n"), 0o644)
+	}
+	os.MkdirAll(filepath.Join(dir, "cmd/notmain"), 0o755)
+
+	pkgs, err := discoverCmdPackages(dir)
+	if err != nil {
+		t.Fatalf("discoverCmdPackages error = %v", err)
+	}
+	if len(pkgs) != 2 {
+		t.Errorf("pkgs = %v, want 2 entries", pkgs)
+	}
+	for _, p := range pkgs {
+		if !strings.HasPrefix(p, "./cmd/") || !strings.HasSuffix(p, "/") {
+			t.Errorf("pkg %q should be of form ./cmd/<name>/", p)
+		}
 	}
 }
 

--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -221,6 +221,12 @@ func (o *Orchestrator) GeneratorStart() error {
 		return fmt.Errorf("recording base branch: %w", err)
 	}
 
+	// Ensure bin/ is ignored on the generation branch so compiled binaries
+	// are never staged by git add -A (GH-469).
+	if err := appendToGitignore(".", o.cfg.Project.BinaryDir+"/"); err != nil {
+		logf("generator:start: warning: could not update .gitignore: %v", err)
+	}
+
 	// Reset Go sources and reinitialize module unless preserve_sources is set.
 	// Library repos (e.g. cobbler-scaffold itself) set preserve_sources: true so
 	// generator:start does not destroy the library code. See prd002 R10.1.
@@ -921,4 +927,36 @@ func (o *Orchestrator) FullReset() error {
 		return err
 	}
 	return o.GeneratorReset()
+}
+
+// appendToGitignore adds entry to the .gitignore file in dir if not already
+// present. Creates the file if it does not exist. Used by GeneratorStart to
+// ensure build artifacts (bin/) are not committed to the generation branch
+// regardless of where they are produced (GH-469).
+func appendToGitignore(dir, entry string) error {
+	path := filepath.Join(dir, ".gitignore")
+
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading .gitignore: %w", err)
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == entry {
+			return nil // already present
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening .gitignore: %w", err)
+	}
+	defer f.Close()
+
+	prefix := ""
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		prefix = "\n"
+	}
+	_, err = fmt.Fprintf(f, "%s%s\n", prefix, entry)
+	return err
 }

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -785,6 +785,94 @@ func TestGeneratorStart_EnvNameOverridesConfig(t *testing.T) {
 	}
 }
 
+// TestGeneratorStart_AddsBinToGitignore verifies that GeneratorStart appends
+// bin/ to .gitignore on the generation branch (GH-469).
+// MUST NOT call t.Parallel() — uses initTestGitRepo / os.Chdir.
+func TestGeneratorStart_AddsBinToGitignore(t *testing.T) {
+	initTestGitRepo(t)
+
+	o := &Orchestrator{cfg: Config{
+		Generation: GenerationConfig{
+			Prefix:          "generation-",
+			PreserveSources: true,
+		},
+		Project: ProjectConfig{MagefilesDir: "magefiles", BinaryDir: "bin"},
+		Cobbler: CobblerConfig{Dir: ".cobbler/"},
+	}}
+
+	if err := o.GeneratorStart(); err != nil {
+		t.Fatalf("GeneratorStart() error = %v", err)
+	}
+
+	data, err := os.ReadFile(".gitignore")
+	if err != nil {
+		t.Fatalf("reading .gitignore: %v", err)
+	}
+	if !strings.Contains(string(data), "bin/") {
+		t.Errorf(".gitignore = %q, want to contain 'bin/'", string(data))
+	}
+}
+
+// --- appendToGitignore (parallel-safe, no git) ---
+
+func TestAppendToGitignore_CreatesFileWhenMissing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := appendToGitignore(dir, "bin/"); err != nil {
+		t.Fatalf("appendToGitignore error = %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, ".gitignore"))
+	if err != nil {
+		t.Fatalf("reading .gitignore: %v", err)
+	}
+	if !strings.Contains(string(data), "bin/") {
+		t.Errorf(".gitignore = %q, want 'bin/'", string(data))
+	}
+}
+
+func TestAppendToGitignore_SkipsWhenAlreadyPresent(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	os.WriteFile(path, []byte("bin/\n"), 0o644)
+
+	if err := appendToGitignore(dir, "bin/"); err != nil {
+		t.Fatalf("appendToGitignore error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading .gitignore: %v", err)
+	}
+	// Should have exactly one occurrence.
+	count := strings.Count(string(data), "bin/")
+	if count != 1 {
+		t.Errorf(".gitignore has %d occurrences of 'bin/', want 1:\n%s", count, data)
+	}
+}
+
+func TestAppendToGitignore_AppendsToExistingFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".gitignore")
+	os.WriteFile(path, []byte("*.log\n"), 0o644)
+
+	if err := appendToGitignore(dir, "bin/"); err != nil {
+		t.Fatalf("appendToGitignore error = %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading .gitignore: %v", err)
+	}
+	if !strings.Contains(string(data), "*.log") {
+		t.Error("appendToGitignore removed existing content")
+	}
+	if !strings.Contains(string(data), "bin/") {
+		t.Errorf(".gitignore = %q, want to contain 'bin/'", string(data))
+	}
+}
+
 // --- GeneratorSwitch validation (git, NOT parallel) ---
 
 func TestGeneratorSwitch_NoBranchConfigured(t *testing.T) {

--- a/pkg/orchestrator/prompts/stitch.yaml
+++ b/pkg/orchestrator/prompts/stitch.yaml
@@ -23,3 +23,4 @@ constraints: |
   - Do NOT invent interfaces, types, or patterns not described in the source code, Required Reading, or PRDs.
   - Do NOT add features, refactoring, or improvements beyond what the requirements specify.
   - Do NOT run any git commands. No git add, git commit, git init, git status, rm .git, or any other git operation. Git is managed externally by the orchestrator. Just write code and verify it compiles and passes tests.
+  - When building cmd/ binaries to verify compilation, use `go build -o bin/<name> ./cmd/<name>/` so outputs land in bin/ (which is git-ignored) rather than in the working directory.


### PR DESCRIPTION
## Summary

Fixes the root cause of compiled binaries being committed to generation branches. The stitch agent was using bare `go build ./cmd/<name>/` which places binaries in the worktree root; `cleanGoBinaries` failed to catch them (reported \"removed 0 binary file(s)\"). This PR addresses all three required fixes from the issue.

## Changes

- **`build.go`**: `BuildAll()` discovers all `cmd/*/main.go` packages and builds each to `bin/<name>` using `go build -o bin/<name> ./cmd/<name>/`; `discoverCmdPackages()` helper scans `cmd/` for subdirectories containing `main.go`
- **`generator.go`**: `GeneratorStart` appends `bin/` to `.gitignore` on the generation branch so compiled artifacts are never staged by `git add -A`, regardless of build tool used; `appendToGitignore()` helper creates or appends without duplicating entries
- **`prompts/stitch.yaml`**: added constraint instructing Claude to use `go build -o bin/<name> ./cmd/<name>/` so verification builds output to `bin/` (git-ignored) rather than the working directory
- **`build_test.go`**: `TestBuildAll_SkipsWhenNoCmdDir`, `TestBuildAll_DelegatesToBuildWhenMainPackageSet`, `TestDiscoverCmdPackages_NoCmdDir`, `TestDiscoverCmdPackages_FindsMainPackages`
- **`generator_test.go`**: `TestGeneratorStart_AddsBinToGitignore`, `TestAppendToGitignore_CreatesFileWhenMissing`, `TestAppendToGitignore_SkipsWhenAlreadyPresent`, `TestAppendToGitignore_AppendsToExistingFile`

## Stats

```
go_loc_prod: 11211 (+102)
go_loc_test: 14777 (+170)
```

## Test plan

- [x] `mage analyze` passes
- [x] All unit tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] 8 new tests covering BuildAll, discoverCmdPackages, appendToGitignore, and GeneratorStart gitignore behavior

Closes #469