### PR TITLE
GH-465: Fix UC005_ResumeResetsOrphanedIssues eventual-consistency flakiness

### DIFF
--- a/tests/rel01.0/uc005/resume_test.go
+++ b/tests/rel01.0/uc005/resume_test.go
@@ -203,9 +203,11 @@ func TestRel01_UC005_ResumeResetsOrphanedIssues(t *testing.T) {
 	issueNumber := testutil.CreateIssue(t, dir, "orphaned task for resume test")
 	testutil.SetIssueInProgress(t, dir, issueNumber)
 
-	// Verify it is in_progress before resume.
-	if n := testutil.CountIssuesByStatus(t, dir, "in_progress"); n == 0 {
-		t.Fatal("expected at least 1 in_progress issue before resume")
+	// Verify it is in_progress before resume. Use IssueHasLabel (direct fetch
+	// by number) rather than CountIssuesByStatus (label-filter list) to avoid
+	// eventual-consistency lag on the label index.
+	if !testutil.IssueHasLabel(t, dir, issueNumber, "cobbler-in-progress") {
+		t.Fatal("expected issue to have cobbler-in-progress label before resume")
 	}
 
 	// Switch back to main so resume switches to the generation branch.


### PR DESCRIPTION
## Summary

`TestRel01_UC005_ResumeResetsOrphanedIssues` failed intermittently because the pre-condition check used `CountIssuesByStatus` (label-filter list endpoint), which has eventual-consistency lag after a label is applied. Replaced with `IssueHasLabel` using the exact issue number, consistent with the post-condition check at line 231 that already used this approach.

## Changes

- `tests/rel01.0/uc005/resume_test.go`: Replace `CountIssuesByStatus(t, dir, "in_progress")` with `IssueHasLabel(t, dir, issueNumber, "cobbler-in-progress")` for the pre-resume assertion

## Stats

go_loc_prod: 11283 (+0)
go_loc_test: 14897 (+2)

## Test plan

- [x] `TestRel01_UC005_ResumeResetsOrphanedIssues` passes
- [x] All uc005 tests pass (17s)
- [x] `mage analyze` clean

Closes #465