### PR TITLE
GH-391: Audit #7 — Install error path, rename misleading test

### DIFF
--- a/pkg/orchestrator/build_test.go
+++ b/pkg/orchestrator/build_test.go
@@ -61,6 +61,18 @@ func TestInstall_SkipsWhenNoMainPackage(t *testing.T) {
 	}
 }
 
+func TestInstall_ErrorsWhenGoInstallFails(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{cfg: Config{
+		Project: ProjectConfig{
+			MainPackage: "nonexistent/package/that/will/fail",
+		},
+	}}
+	if err := o.Install(); err == nil {
+		t.Error("Install() with nonexistent package should return error")
+	}
+}
+
 // --- BuildAll ---
 
 func TestBuildAll_SkipsWhenNoCmdDir(t *testing.T) {

--- a/pkg/orchestrator/stitch_test.go
+++ b/pkg/orchestrator/stitch_test.go
@@ -935,12 +935,13 @@ func TestCreateWorktree_InvalidParentDir(t *testing.T) {
 	}
 }
 
-// --- resetOrphanedIssues (unit logic via branch check) ---
+// --- gitBranchExists (used by resetOrphanedIssues) ---
+//
+// resetOrphanedIssues calls listOpenCobblerIssues (GitHub API), so its
+// success paths cannot be covered by unit tests. The branch-existence
+// check it delegates to is tested here directly.
 
-func TestResetOrphanedIssues_NoBranch(t *testing.T) {
-	// Tests the branch existence check logic that resetOrphanedIssues uses.
-	// The full function calls listOpenCobblerIssues (gh API), so we test
-	// the branch-checking portion via gitBranchExists directly.
+func TestGitBranchExists_ChecksLocalBranches(t *testing.T) {
 	_ = initTestGitRepo(t)
 
 	// Branch does not exist → gitBranchExists returns false.


### PR DESCRIPTION
## Summary

Audit #7 of cobbler-scaffold. Coverage 58.5% → 58.9%. Added one test covering the `Install` error path (27.3% → 81.8%). Renamed a misleadingly-named test that exercised `gitBranchExists` directly rather than `resetOrphanedIssues`. No code issues found in GH-467/468/469 additions.

## Changes

- `build_test.go`: Add `TestInstall_ErrorsWhenGoInstallFails` — covers go install execution path
- `stitch_test.go`: Rename `TestResetOrphanedIssues_NoBranch` → `TestGitBranchExists_ChecksLocalBranches` with clarifying comment

## Stats

go_loc_prod: 11283 (+0)
go_loc_test: 14910 (+13)
Overall coverage: 58.9% (+0.4%)

## Test plan

- [x] New test passes
- [x] Full unit suite passes (22s)
- [x] `mage analyze` clean

Closes #391