### PR TITLE
GH-518: Stitch: forbid reading repository files for style/pattern inference

### DIFF
--- a/pkg/orchestrator/prompts/stitch.yaml
+++ b/pkg/orchestrator/prompts/stitch.yaml
@@ -16,6 +16,7 @@ task: |
   4. **Verify** — Check every item in Acceptance Criteria. Run tests if the criteria require it. Do not skip any criterion.
 
 constraints: |
+  - Do NOT read any file in the repository to infer style, patterns, or conventions. All style guidance is provided in go_style_constitution above. All source patterns are provided in project_context above. If a file you need is absent from project_context, write it from scratch following go_style_constitution — do not read the filesystem to fill the gap.
   - Do NOT read files already provided in project_context. They are already inline above.
   - Do NOT explore the filesystem. Do NOT run ls, find, tree, or similar commands.
   - Do NOT modify files outside the Files to Create/Modify list unless a requirement explicitly demands it.


### PR DESCRIPTION
## Summary

Adds one constraint to the stitch prompt explicitly forbidding Claude from reading any file in the repository to infer style, patterns, or conventions. The constraint directs Claude to `go_style_constitution` for style guidance and to `project_context` for source patterns, closing the loophole where files absent from `project_context` could be read to fill the gap.

## Changes

- `pkg/orchestrator/prompts/stitch.yaml`: added constraint at line 19 (1 line inserted)

## Stats

- Lines of code (Go, production): 11,283 (+0)
- Lines of code (Go, tests): 14,910 (+0)
- Words (documentation): PRD 8,204 / use-case 7,157 / test-suite 3,676

## Test plan

- [x] `mage analyze` passes
- [x] `go test ./pkg/orchestrator/ -count=1` passes (including `TestBuildStitchPrompt_ContainsGoStyleConstitution`)

Closes #518