### PR TITLE
GH-520: Codify 9 Go style rules in go-style.yaml

### DIFF
--- a/docs/constitutions/go-style.yaml
+++ b/docs/constitutions/go-style.yaml
@@ -115,6 +115,18 @@ struct_and_function_design: |
   generic names (Manager, Handler, Helper, Processor) unless the struct genuinely
   manages, handles, or processes a well-defined resource.
 
+receiver_conventions: |
+  Use a pointer receiver when the method mutates the receiver, when the struct
+  contains a mutex or sync primitive, or when the struct is large enough that
+  copying it on every call is wasteful. Use a value receiver for small, immutable
+  types where copying is cheap and the method does not modify the value. All
+  methods on a given type must use the same receiver kind — do not mix pointer
+  and value receivers on one type.
+
+  Name receivers with a one- or two-letter abbreviation of the type in lowercase:
+  o for Orchestrator, c for Config, s for Server. Never use self or this. The
+  receiver name must be consistent across all methods of the type.
+
 error_handling: |
   Handle errors at the point they occur. Use guard clauses: check err != nil and
   return early so the main logic stays at minimal indentation. Wrap errors with
@@ -124,6 +136,23 @@ error_handling: |
   removing a temp file after the real work succeeded). When discarding, leave a
   comment explaining why.
 
+panic_vs_error: |
+  Return errors from all functions where the failure is a runtime condition —
+  missing files, bad user input, network failures, external API errors. Use panic
+  only for violations of a programming contract: a nil argument that must not be
+  nil by the function's documented precondition, an enum value that cannot exist,
+  an internal state that indicates a bug in the caller. Never panic on I/O
+  failures or user-provided data. A panic that can be triggered by an external
+  input is a bug.
+
+init_functions: |
+  Avoid init(). Every init() runs silently at program start, in dependency order,
+  with no way for the caller to handle errors or control timing. Acceptable uses
+  are registering stdlib drivers (e.g., _ "github.com/mattn/go-sqlite3") and
+  initializing package-level read-only lookup tables that cannot fail. If
+  initialization requires I/O or can return an error, use an explicit function
+  called from main() or from a constructor, not init().
+
 no_magic_strings: |
   Centralize all string literals that name external binaries, file paths, URLs,
   or repeated text. Binary names: const (e.g., binGit, binGo). Paths, prefixes,
@@ -132,6 +161,16 @@ no_magic_strings: |
   fmt.Sprintf at the call site. Static messages or labels: const. When adding a
   new external command or path, define the constant first, then use it. Never
   scatter raw string literals across files.
+
+constants: |
+  Prefer typed constants over bare string or integer literals for values that
+  form a fixed set. Give the type a name: type totalMode int, then define the
+  values with iota in a const block. Use iota for sequential integer enums;
+  do not assign explicit integers unless the values must match an external
+  protocol. Group related constants in a single const block. Keep constants
+  unexported unless callers outside the package need them. Program names, file
+  paths, CLI flag names, label strings, and any literal that appears more than
+  once are candidates for a named constant.
 
 project_structure: |
   cmd/: Entry points. Minimal: parse flags, wire dependencies, start.
@@ -150,6 +189,36 @@ project_structure: |
   Define interfaces between major components. The pkg/ directory holds shared
   types and interface contracts. The internal/ directory holds implementations
   that satisfy those contracts.
+
+file_organization: |
+  Name files by the concern or feature they implement: scaffold.go, stitch.go,
+  analyze.go. Do not name files by kind: types.go, helpers.go, utils.go are
+  forbidden names. Place tests in <file>_test.go alongside the file they test.
+
+  Within a file, order declarations as follows: package-level constants and
+  types first, then constructors (NewXxx), then exported methods and functions,
+  then unexported helpers. main() goes last in cmd/ entry points. This ordering
+  means a reader can scan from top to bottom and encounter definitions before
+  uses.
+
+import_organization: |
+  Group imports into three blocks separated by blank lines, in this order:
+  standard library, external modules, internal packages. Within each block,
+  goimports ordering applies (alphabetical). Never use dot imports (. "pkg")
+  except in test files where the convention is established for a specific
+  package. Never use blank imports except for side-effect registration
+  (database drivers, image format codecs).
+
+  Correct example:
+    import (
+      "fmt"
+      "os"
+
+      "github.com/spf13/cobra"
+      "gopkg.in/yaml.v3"
+
+      "github.com/myorg/myrepo/internal/config"
+    )
 
 standard_packages:
   - "Build automation: magefile/mage"
@@ -175,24 +244,84 @@ naming_conventions:
   - "Constants for binaries: bin prefix + PascalCase (e.g., binGit, binClaude)"
   - "Factory functions: New prefix (e.g., NewBackend())"
   - "Interface names: Action or capability (e.g., Table, Reader)"
+  - "Receiver names: one- or two-letter abbreviation of the type (e.g., o for Orchestrator, c for Config)"
+  - "Test helpers: verb-named functions describing what they do (e.g., buildFixture, writeFile, skipIfMissing)"
+  - "Typed enum types: singular noun (e.g., type totalMode int, type blockUnit int)"
+
+comment_style: |
+  Every exported symbol — function, type, variable, constant — must have a godoc
+  comment. The comment begins with the name of the symbol: // Orchestrator holds
+  the configuration and drives all build targets. Package-level documentation
+  goes in a doc comment immediately above the package clause. Do not create a
+  separate doc.go unless the package is too large to document inline.
+
+  Unexported functions need a comment only when the logic is non-obvious; a
+  function named buildMeasurePrompt does not need a comment saying "builds the
+  measure prompt." Avoid comments that restate what the code clearly shows.
+  Write comments that explain why, not what. When discarding an error, the
+  comment must explain the reasoning: // best-effort cleanup, error ignored.
+
+  Reference requirement IDs in comments when implementing a specific requirement:
+  // R1.2: truncate output at maxLines to bound memory usage.
 
 concurrency: |
   Pass context.Context as the first parameter to any function that does I/O or
   may block. Never start a goroutine without a plan for how it exits. Use
-  sync.WaitGroup or a done channel to manage lifetimes.
+  sync.WaitGroup or a done channel to manage lifetimes. Protect package-level
+  mutable state (global variables modified at runtime) with a sync.Mutex or
+  sync.RWMutex. Document that a variable requires locking and provide paired
+  getter/setter functions rather than exposing the variable directly.
 
 testing: |
   Every exported function and every meaningful branch deserves a test. Use
-  table-driven parameterized tests for similar cases. Each row is one scenario
-  with named inputs and expected outputs. Extract shared setup into test helpers.
-  Build reusable test utilities in a testutil package. When writing tests, ask
-  what inputs break assumptions: zero values, nil pointers, empty slices,
-  duplicate keys, boundary lengths, concurrent access. If a bug could hide there,
-  write a case for it.
+  table-driven parameterized tests for similar cases. The canonical structure is
+  a slice of anonymous structs with a name field, run with t.Run:
+
+    tests := []struct {
+      name  string
+      input string
+      want  int
+    }{
+      {"empty", "", 0},
+      {"one line", "hello\n", 1},
+    }
+    for _, tc := range tests {
+      t.Run(tc.name, func(t *testing.T) {
+        got := countLines(tc.input)
+        require.Equal(t, tc.want, got)
+      })
+    }
+
+  Call t.Parallel() as the first line of every test function that is safe to
+  run concurrently. A test is safe to parallelize when it writes only to its own
+  t.TempDir(), spawns isolated subprocesses, and does not call os.Chdir() or
+  mutate package-level global state. Do NOT call t.Parallel() in tests that call
+  os.Chdir() or any function that changes the process working directory — exec.Command
+  calls without cmd.Dir observe the process cwd, so a parallel os.Chdir() will
+  corrupt other tests running concurrently. In table-driven tests, add t.Parallel()
+  inside each t.Run subtest when the rows are independent.
+
+  Call t.Helper() as the first line of every test helper function. This causes
+  test failures to point to the caller site, not the helper internals:
+
+    func writeFile(t *testing.T, path, content string) {
+      t.Helper()
+      require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+    }
+
+  Use TestMain(m *testing.M) when the package requires one-time setup — compiling
+  a test binary, creating a shared fixture directory — that must complete before
+  any test runs. Call os.Exit(m.Run()) at the end. Do not use TestMain for
+  per-test setup; use t.Cleanup or helper functions for that.
+
+  Extract shared setup into helper functions. Build reusable test utilities in a
+  testutil package. When writing tests, ask what inputs break assumptions: zero
+  values, nil pointers, empty slices, duplicate keys, boundary lengths. If a bug
+  could hide there, write a case for it.
 
 code_review_checklist:
   - "No duplicated logic exists that could be extracted into a shared function or struct."
-  - "No magic strings remain: all binaries, paths, and repeated text are centralized."
+  - "No magic strings remain: all binaries, paths, and repeated text are centralized as named constants."
   - "Every error is handled or explicitly discarded with a comment."
   - "Every struct has a single, nameable responsibility."
   - "No function exceeds 200 lines without a strong reason."
@@ -201,6 +330,15 @@ code_review_checklist:
   - "Config structs embed shared fields rather than duplicating them."
   - "context.Context is threaded through I/O paths."
   - "Tests cover the contract, not the implementation."
+  - "Every test function that is safe to parallelize calls t.Parallel() as its first line."
+  - "No test calls t.Parallel() if it uses os.Chdir() or mutates package-level global state."
+  - "Every test helper calls t.Helper() as its first line."
+  - "All receiver names are one- or two-letter abbreviations, consistent across all methods of the type."
+  - "Imports are grouped: stdlib, external, internal — each group separated by a blank line."
+  - "Every exported symbol has a godoc comment starting with the symbol name."
+  - "No init() function performs I/O or returns an error."
+  - "No panic() is reachable from a runtime condition or user-provided input."
+  - "Typed iota enums are used for any fixed set of integer values."
 
 sections:
   - tag: copyright_header
@@ -216,9 +354,9 @@ sections:
   - tag: design_patterns
     title: Design Patterns
     content: |
-      Six patterns apply: Strategy, Command, Facade, Factory, Decorator, and
-      Adapter. Select patterns to eliminate if/else ladders and centralize
-      construction logic.
+      Eight patterns apply: Strategy, Command, Facade, Factory, Decorator,
+      Builder, Adapter, and Observer. Select patterns to eliminate if/else ladders
+      and centralize construction logic.
   - tag: interfaces
     title: Interfaces
     content: |
@@ -230,52 +368,104 @@ sections:
     content: |
       Each struct represents one concept; each function does one thing. Group
       more than three parameters into a config struct. Split functions exceeding
-      40 lines at a natural seam.
+      200 lines at a natural seam.
+  - tag: receiver_conventions
+    title: Receiver Conventions
+    content: |
+      Use pointer receivers for stateful or large types, value receivers for small
+      immutable types. All methods on a type use the same receiver kind. Name
+      receivers with a one- or two-letter abbreviation of the type; never use
+      self or this.
   - tag: error_handling
     title: Error Handling
     content: |
       Handle errors at the point they occur with guard clauses. Wrap errors with
       context using fmt.Errorf. Never silently discard an error except for
       best-effort cleanup, and always leave a comment when discarding.
+  - tag: panic_vs_error
+    title: Panic vs Error
+    content: |
+      Return errors for runtime conditions. Use panic only for programming
+      contract violations. Never panic on I/O failures or user-provided input.
+  - tag: init_functions
+    title: init() Usage
+    content: |
+      Avoid init(). Use it only for side-effect registration (drivers, codecs)
+      or infallible package-level lookup tables. Any initialization that can fail
+      must use an explicit function called from main() or a constructor.
   - tag: no_magic_strings
     title: No Magic Strings
     content: |
       Centralize all string literals for binary names, file paths, URLs, and
       repeated text as named constants. Never scatter raw string literals.
+  - tag: constants
+    title: Constants and Iota
+    content: |
+      Use typed constants for fixed sets of values. Use iota for sequential
+      integer enums. Group related constants in a single const block. Keep
+      constants unexported unless callers outside the package need them.
   - tag: project_structure
     title: Project Structure
     content: |
       cmd/ for entry points, internal/ for private implementation, pkg/ for
       public shared types, tests/ for integration tests, magefiles/ for build
       tooling. Align package structure to PRD component structure.
+  - tag: file_organization
+    title: File Organization
+    content: |
+      Name files by concern, not by kind (no types.go, helpers.go, utils.go).
+      Within a file: constants and types, then constructors, then exported
+      symbols, then unexported helpers, then main(). Tests go in <file>_test.go.
+  - tag: import_organization
+    title: Import Organization
+    content: |
+      Three import groups separated by blank lines: stdlib, external modules,
+      internal packages. No dot imports except by established test convention.
+      No blank imports except for driver/codec side-effect registration.
   - tag: standard_packages
     title: Standard Packages
     content: |
       Approved dependencies: mage for build automation, cobra for CLI, viper for
       configuration, testify for test assertions, yaml.v3 for YAML parsing, and
       encoding/json from the standard library.
+  - tag: struct_embedding
+    title: Struct Embedding
+    content: |
+      Extract shared fields into a common struct and embed it. Provide
+      registerXxxFlags helpers for embedded CLI flag groups.
   - tag: naming_conventions
     title: Naming Conventions
     content: |
-      Exported names use CamelCase; unexported use camelCase. CLI flags use
+      Exported names use PascalCase; unexported use camelCase. CLI flags use
       kebab-case. Binary constants use the binXxx prefix. Factories use NewXxx.
-      Interfaces are named to describe behavior, not implementation.
+      Interfaces are named to describe behavior. Receivers use a one- or
+      two-letter abbreviation of the type. Test helpers use verb names.
+  - tag: comment_style
+    title: Comment Style
+    content: |
+      Every exported symbol has a godoc comment starting with the symbol name.
+      Unexported functions need comments only for non-obvious logic. Comments
+      explain why, not what. Reference requirement IDs when implementing a
+      specific requirement.
   - tag: concurrency
     title: Concurrency
     content: |
-      Use sync.Mutex for shared mutable state. Avoid global variables accessed
-      from goroutines. Thread context.Context through all I/O paths.
+      Thread context.Context through all I/O paths. Protect package-level mutable
+      state with sync.Mutex. Never start a goroutine without a plan for exit.
   - tag: testing
     title: Testing
     content: |
-      Write table-driven tests using t.Run subtests. Use testify assertions.
-      Mock external dependencies via interfaces. Tests cover contract, not
-      implementation; include edge cases, boundary lengths, and concurrent access.
+      Use table-driven tests with named struct rows and t.Run. Call t.Parallel()
+      at the top of every test safe to run concurrently — but never in tests that
+      call os.Chdir() or mutate global state. Call t.Helper() at the top of every
+      test helper function. Use TestMain for one-time package setup. Tests cover
+      the contract, not the implementation.
   - tag: code_review_checklist
     title: Code Review Checklist
     content: |
-      Before closing, verify: no duplicated logic, no magic strings, every error
-      handled or discarded with a comment, single-responsibility structs,
-      functions under 200 lines, small interfaces with at least two
-      implementations, no boolean-toggle parameters, and tests covering the
-      contract.
+      Before closing: no duplicated logic, no magic strings, every error handled
+      or discarded with a comment, single-responsibility structs, functions under
+      200 lines, small interfaces, no boolean-toggle parameters, t.Parallel() on
+      all safe tests, t.Helper() on all helpers, imports grouped, every exported
+      symbol documented, no init() with I/O, no panic on runtime conditions,
+      typed iota enums for fixed value sets.

--- a/pkg/orchestrator/constitutions/go-style.yaml
+++ b/pkg/orchestrator/constitutions/go-style.yaml
@@ -115,6 +115,18 @@ struct_and_function_design: |
   generic names (Manager, Handler, Helper, Processor) unless the struct genuinely
   manages, handles, or processes a well-defined resource.
 
+receiver_conventions: |
+  Use a pointer receiver when the method mutates the receiver, when the struct
+  contains a mutex or sync primitive, or when the struct is large enough that
+  copying it on every call is wasteful. Use a value receiver for small, immutable
+  types where copying is cheap and the method does not modify the value. All
+  methods on a given type must use the same receiver kind — do not mix pointer
+  and value receivers on one type.
+
+  Name receivers with a one- or two-letter abbreviation of the type in lowercase:
+  o for Orchestrator, c for Config, s for Server. Never use self or this. The
+  receiver name must be consistent across all methods of the type.
+
 error_handling: |
   Handle errors at the point they occur. Use guard clauses: check err != nil and
   return early so the main logic stays at minimal indentation. Wrap errors with
@@ -124,6 +136,23 @@ error_handling: |
   removing a temp file after the real work succeeded). When discarding, leave a
   comment explaining why.
 
+panic_vs_error: |
+  Return errors from all functions where the failure is a runtime condition —
+  missing files, bad user input, network failures, external API errors. Use panic
+  only for violations of a programming contract: a nil argument that must not be
+  nil by the function's documented precondition, an enum value that cannot exist,
+  an internal state that indicates a bug in the caller. Never panic on I/O
+  failures or user-provided data. A panic that can be triggered by an external
+  input is a bug.
+
+init_functions: |
+  Avoid init(). Every init() runs silently at program start, in dependency order,
+  with no way for the caller to handle errors or control timing. Acceptable uses
+  are registering stdlib drivers (e.g., _ "github.com/mattn/go-sqlite3") and
+  initializing package-level read-only lookup tables that cannot fail. If
+  initialization requires I/O or can return an error, use an explicit function
+  called from main() or from a constructor, not init().
+
 no_magic_strings: |
   Centralize all string literals that name external binaries, file paths, URLs,
   or repeated text. Binary names: const (e.g., binGit, binGo). Paths, prefixes,
@@ -132,6 +161,16 @@ no_magic_strings: |
   fmt.Sprintf at the call site. Static messages or labels: const. When adding a
   new external command or path, define the constant first, then use it. Never
   scatter raw string literals across files.
+
+constants: |
+  Prefer typed constants over bare string or integer literals for values that
+  form a fixed set. Give the type a name: type totalMode int, then define the
+  values with iota in a const block. Use iota for sequential integer enums;
+  do not assign explicit integers unless the values must match an external
+  protocol. Group related constants in a single const block. Keep constants
+  unexported unless callers outside the package need them. Program names, file
+  paths, CLI flag names, label strings, and any literal that appears more than
+  once are candidates for a named constant.
 
 project_structure: |
   cmd/: Entry points. Minimal: parse flags, wire dependencies, start.
@@ -150,6 +189,36 @@ project_structure: |
   Define interfaces between major components. The pkg/ directory holds shared
   types and interface contracts. The internal/ directory holds implementations
   that satisfy those contracts.
+
+file_organization: |
+  Name files by the concern or feature they implement: scaffold.go, stitch.go,
+  analyze.go. Do not name files by kind: types.go, helpers.go, utils.go are
+  forbidden names. Place tests in <file>_test.go alongside the file they test.
+
+  Within a file, order declarations as follows: package-level constants and
+  types first, then constructors (NewXxx), then exported methods and functions,
+  then unexported helpers. main() goes last in cmd/ entry points. This ordering
+  means a reader can scan from top to bottom and encounter definitions before
+  uses.
+
+import_organization: |
+  Group imports into three blocks separated by blank lines, in this order:
+  standard library, external modules, internal packages. Within each block,
+  goimports ordering applies (alphabetical). Never use dot imports (. "pkg")
+  except in test files where the convention is established for a specific
+  package. Never use blank imports except for side-effect registration
+  (database drivers, image format codecs).
+
+  Correct example:
+    import (
+      "fmt"
+      "os"
+
+      "github.com/spf13/cobra"
+      "gopkg.in/yaml.v3"
+
+      "github.com/myorg/myrepo/internal/config"
+    )
 
 standard_packages:
   - "Build automation: magefile/mage"
@@ -175,24 +244,84 @@ naming_conventions:
   - "Constants for binaries: bin prefix + PascalCase (e.g., binGit, binClaude)"
   - "Factory functions: New prefix (e.g., NewBackend())"
   - "Interface names: Action or capability (e.g., Table, Reader)"
+  - "Receiver names: one- or two-letter abbreviation of the type (e.g., o for Orchestrator, c for Config)"
+  - "Test helpers: verb-named functions describing what they do (e.g., buildFixture, writeFile, skipIfMissing)"
+  - "Typed enum types: singular noun (e.g., type totalMode int, type blockUnit int)"
+
+comment_style: |
+  Every exported symbol — function, type, variable, constant — must have a godoc
+  comment. The comment begins with the name of the symbol: // Orchestrator holds
+  the configuration and drives all build targets. Package-level documentation
+  goes in a doc comment immediately above the package clause. Do not create a
+  separate doc.go unless the package is too large to document inline.
+
+  Unexported functions need a comment only when the logic is non-obvious; a
+  function named buildMeasurePrompt does not need a comment saying "builds the
+  measure prompt." Avoid comments that restate what the code clearly shows.
+  Write comments that explain why, not what. When discarding an error, the
+  comment must explain the reasoning: // best-effort cleanup, error ignored.
+
+  Reference requirement IDs in comments when implementing a specific requirement:
+  // R1.2: truncate output at maxLines to bound memory usage.
 
 concurrency: |
   Pass context.Context as the first parameter to any function that does I/O or
   may block. Never start a goroutine without a plan for how it exits. Use
-  sync.WaitGroup or a done channel to manage lifetimes.
+  sync.WaitGroup or a done channel to manage lifetimes. Protect package-level
+  mutable state (global variables modified at runtime) with a sync.Mutex or
+  sync.RWMutex. Document that a variable requires locking and provide paired
+  getter/setter functions rather than exposing the variable directly.
 
 testing: |
   Every exported function and every meaningful branch deserves a test. Use
-  table-driven parameterized tests for similar cases. Each row is one scenario
-  with named inputs and expected outputs. Extract shared setup into test helpers.
-  Build reusable test utilities in a testutil package. When writing tests, ask
-  what inputs break assumptions: zero values, nil pointers, empty slices,
-  duplicate keys, boundary lengths, concurrent access. If a bug could hide there,
-  write a case for it.
+  table-driven parameterized tests for similar cases. The canonical structure is
+  a slice of anonymous structs with a name field, run with t.Run:
+
+    tests := []struct {
+      name  string
+      input string
+      want  int
+    }{
+      {"empty", "", 0},
+      {"one line", "hello\n", 1},
+    }
+    for _, tc := range tests {
+      t.Run(tc.name, func(t *testing.T) {
+        got := countLines(tc.input)
+        require.Equal(t, tc.want, got)
+      })
+    }
+
+  Call t.Parallel() as the first line of every test function that is safe to
+  run concurrently. A test is safe to parallelize when it writes only to its own
+  t.TempDir(), spawns isolated subprocesses, and does not call os.Chdir() or
+  mutate package-level global state. Do NOT call t.Parallel() in tests that call
+  os.Chdir() or any function that changes the process working directory — exec.Command
+  calls without cmd.Dir observe the process cwd, so a parallel os.Chdir() will
+  corrupt other tests running concurrently. In table-driven tests, add t.Parallel()
+  inside each t.Run subtest when the rows are independent.
+
+  Call t.Helper() as the first line of every test helper function. This causes
+  test failures to point to the caller site, not the helper internals:
+
+    func writeFile(t *testing.T, path, content string) {
+      t.Helper()
+      require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+    }
+
+  Use TestMain(m *testing.M) when the package requires one-time setup — compiling
+  a test binary, creating a shared fixture directory — that must complete before
+  any test runs. Call os.Exit(m.Run()) at the end. Do not use TestMain for
+  per-test setup; use t.Cleanup or helper functions for that.
+
+  Extract shared setup into helper functions. Build reusable test utilities in a
+  testutil package. When writing tests, ask what inputs break assumptions: zero
+  values, nil pointers, empty slices, duplicate keys, boundary lengths. If a bug
+  could hide there, write a case for it.
 
 code_review_checklist:
   - "No duplicated logic exists that could be extracted into a shared function or struct."
-  - "No magic strings remain: all binaries, paths, and repeated text are centralized."
+  - "No magic strings remain: all binaries, paths, and repeated text are centralized as named constants."
   - "Every error is handled or explicitly discarded with a comment."
   - "Every struct has a single, nameable responsibility."
   - "No function exceeds 200 lines without a strong reason."
@@ -201,6 +330,15 @@ code_review_checklist:
   - "Config structs embed shared fields rather than duplicating them."
   - "context.Context is threaded through I/O paths."
   - "Tests cover the contract, not the implementation."
+  - "Every test function that is safe to parallelize calls t.Parallel() as its first line."
+  - "No test calls t.Parallel() if it uses os.Chdir() or mutates package-level global state."
+  - "Every test helper calls t.Helper() as its first line."
+  - "All receiver names are one- or two-letter abbreviations, consistent across all methods of the type."
+  - "Imports are grouped: stdlib, external, internal — each group separated by a blank line."
+  - "Every exported symbol has a godoc comment starting with the symbol name."
+  - "No init() function performs I/O or returns an error."
+  - "No panic() is reachable from a runtime condition or user-provided input."
+  - "Typed iota enums are used for any fixed set of integer values."
 
 sections:
   - tag: copyright_header
@@ -216,9 +354,9 @@ sections:
   - tag: design_patterns
     title: Design Patterns
     content: |
-      Six patterns apply: Strategy, Command, Facade, Factory, Decorator, and
-      Adapter. Select patterns to eliminate if/else ladders and centralize
-      construction logic.
+      Eight patterns apply: Strategy, Command, Facade, Factory, Decorator,
+      Builder, Adapter, and Observer. Select patterns to eliminate if/else ladders
+      and centralize construction logic.
   - tag: interfaces
     title: Interfaces
     content: |
@@ -230,52 +368,104 @@ sections:
     content: |
       Each struct represents one concept; each function does one thing. Group
       more than three parameters into a config struct. Split functions exceeding
-      40 lines at a natural seam.
+      200 lines at a natural seam.
+  - tag: receiver_conventions
+    title: Receiver Conventions
+    content: |
+      Use pointer receivers for stateful or large types, value receivers for small
+      immutable types. All methods on a type use the same receiver kind. Name
+      receivers with a one- or two-letter abbreviation of the type; never use
+      self or this.
   - tag: error_handling
     title: Error Handling
     content: |
       Handle errors at the point they occur with guard clauses. Wrap errors with
       context using fmt.Errorf. Never silently discard an error except for
       best-effort cleanup, and always leave a comment when discarding.
+  - tag: panic_vs_error
+    title: Panic vs Error
+    content: |
+      Return errors for runtime conditions. Use panic only for programming
+      contract violations. Never panic on I/O failures or user-provided input.
+  - tag: init_functions
+    title: init() Usage
+    content: |
+      Avoid init(). Use it only for side-effect registration (drivers, codecs)
+      or infallible package-level lookup tables. Any initialization that can fail
+      must use an explicit function called from main() or a constructor.
   - tag: no_magic_strings
     title: No Magic Strings
     content: |
       Centralize all string literals for binary names, file paths, URLs, and
       repeated text as named constants. Never scatter raw string literals.
+  - tag: constants
+    title: Constants and Iota
+    content: |
+      Use typed constants for fixed sets of values. Use iota for sequential
+      integer enums. Group related constants in a single const block. Keep
+      constants unexported unless callers outside the package need them.
   - tag: project_structure
     title: Project Structure
     content: |
       cmd/ for entry points, internal/ for private implementation, pkg/ for
       public shared types, tests/ for integration tests, magefiles/ for build
       tooling. Align package structure to PRD component structure.
+  - tag: file_organization
+    title: File Organization
+    content: |
+      Name files by concern, not by kind (no types.go, helpers.go, utils.go).
+      Within a file: constants and types, then constructors, then exported
+      symbols, then unexported helpers, then main(). Tests go in <file>_test.go.
+  - tag: import_organization
+    title: Import Organization
+    content: |
+      Three import groups separated by blank lines: stdlib, external modules,
+      internal packages. No dot imports except by established test convention.
+      No blank imports except for driver/codec side-effect registration.
   - tag: standard_packages
     title: Standard Packages
     content: |
       Approved dependencies: mage for build automation, cobra for CLI, viper for
       configuration, testify for test assertions, yaml.v3 for YAML parsing, and
       encoding/json from the standard library.
+  - tag: struct_embedding
+    title: Struct Embedding
+    content: |
+      Extract shared fields into a common struct and embed it. Provide
+      registerXxxFlags helpers for embedded CLI flag groups.
   - tag: naming_conventions
     title: Naming Conventions
     content: |
-      Exported names use CamelCase; unexported use camelCase. CLI flags use
+      Exported names use PascalCase; unexported use camelCase. CLI flags use
       kebab-case. Binary constants use the binXxx prefix. Factories use NewXxx.
-      Interfaces are named to describe behavior, not implementation.
+      Interfaces are named to describe behavior. Receivers use a one- or
+      two-letter abbreviation of the type. Test helpers use verb names.
+  - tag: comment_style
+    title: Comment Style
+    content: |
+      Every exported symbol has a godoc comment starting with the symbol name.
+      Unexported functions need comments only for non-obvious logic. Comments
+      explain why, not what. Reference requirement IDs when implementing a
+      specific requirement.
   - tag: concurrency
     title: Concurrency
     content: |
-      Use sync.Mutex for shared mutable state. Avoid global variables accessed
-      from goroutines. Thread context.Context through all I/O paths.
+      Thread context.Context through all I/O paths. Protect package-level mutable
+      state with sync.Mutex. Never start a goroutine without a plan for exit.
   - tag: testing
     title: Testing
     content: |
-      Write table-driven tests using t.Run subtests. Use testify assertions.
-      Mock external dependencies via interfaces. Tests cover contract, not
-      implementation; include edge cases, boundary lengths, and concurrent access.
+      Use table-driven tests with named struct rows and t.Run. Call t.Parallel()
+      at the top of every test safe to run concurrently — but never in tests that
+      call os.Chdir() or mutate global state. Call t.Helper() at the top of every
+      test helper function. Use TestMain for one-time package setup. Tests cover
+      the contract, not the implementation.
   - tag: code_review_checklist
     title: Code Review Checklist
     content: |
-      Before closing, verify: no duplicated logic, no magic strings, every error
-      handled or discarded with a comment, single-responsibility structs,
-      functions under 200 lines, small interfaces with at least two
-      implementations, no boolean-toggle parameters, and tests covering the
-      contract.
+      Before closing: no duplicated logic, no magic strings, every error handled
+      or discarded with a comment, single-responsibility structs, functions under
+      200 lines, small interfaces, no boolean-toggle parameters, t.Parallel() on
+      all safe tests, t.Helper() on all helpers, imports grouped, every exported
+      symbol documented, no init() with I/O, no panic on runtime conditions,
+      typed iota enums for fixed value sets.

--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -426,12 +426,19 @@ type GoStyleDoc struct {
 	DesignPatterns          []GoStylePattern      `yaml:"design_patterns"`
 	Interfaces              string                `yaml:"interfaces"`
 	StructAndFunctionDesign string                `yaml:"struct_and_function_design"`
+	ReceiverConventions     string                `yaml:"receiver_conventions"`
 	ErrorHandling           string                `yaml:"error_handling"`
+	PanicVsError            string                `yaml:"panic_vs_error"`
+	InitFunctions           string                `yaml:"init_functions"`
 	NoMagicStrings          string                `yaml:"no_magic_strings"`
+	Constants               string                `yaml:"constants"`
 	ProjectStructure        string                `yaml:"project_structure"`
+	FileOrganization        string                `yaml:"file_organization"`
+	ImportOrganization      string                `yaml:"import_organization"`
 	StandardPackages        []string              `yaml:"standard_packages"`
 	StructEmbedding         string                `yaml:"struct_embedding"`
 	NamingConventions       []string              `yaml:"naming_conventions"`
+	CommentStyle            string                `yaml:"comment_style"`
 	Concurrency             string                `yaml:"concurrency"`
 	Testing                 string                `yaml:"testing"`
 	CodeReviewChecklist     []string              `yaml:"code_review_checklist"`


### PR DESCRIPTION
## Summary

Adds seven new top-level sections and expands two existing ones in \`go-style.yaml\`, making the Go style constitution fully prescriptive. The additions cover every area identified in the go-unix-utils v1.20260302.3 code audit as either absent or too thin to guide Claude reliably. The \`GoStyleDoc\` struct is updated to maintain schema validation for all new fields.

## Changes

- \`pkg/orchestrator/constitutions/go-style.yaml\` — 7 new sections, expanded testing and concurrency, 8 new checklist items, 3 new naming convention entries
- \`docs/constitutions/go-style.yaml\` — synced copy
- \`pkg/orchestrator/context.go\` — 7 new fields in \`GoStyleDoc\` struct (+7 LOC)

**New sections:**
- \`receiver_conventions\` — pointer vs value receivers; one/two-letter abbreviation naming; consistency across a type
- \`panic_vs_error\` — panic only for contract violations; never on I/O or user input
- \`init_functions\` — avoid init(); acceptable uses only (driver registration, infallible tables)
- \`constants\` — typed iota enums; const blocks; no bare literals
- \`file_organization\` — name files by concern not kind; declaration order within files
- \`import_organization\` — three groups (stdlib / external / internal) with blank line separators; no dot imports
- \`comment_style\` — godoc on all exported symbols; comments explain why; requirement ID tracing

**Expanded sections:**
- \`testing\` — canonical table-driven struct pattern; t.Parallel() rules (when to use AND when NOT to — os.Chdir constraint); t.Helper() on helpers; TestMain pattern
- \`concurrency\` — sync.Mutex for package-level mutable global state

## Stats

- Lines of code (Go, production): 11,290 (+7)
- Lines of code (Go, tests): 14,910 (+0)
- Words (documentation): PRD 8,204 / use-case 7,157 / test-suite 3,676

## Test plan

- [x] \`mage analyze\` passes (schema validation + constitution drift = 0 errors)
- [x] \`go test ./pkg/orchestrator/ -count=1\` passes

Closes #520