### PR TITLE
GH-523: Fix generator:stop to merge into caller's branch, not always main

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -284,6 +284,20 @@ func (o *Orchestrator) readBaseBranch() string {
 	return branch
 }
 
+// resolveStopTarget returns the branch that generator:stop should merge into.
+// callerBranch is the branch checked out when generator:stop was invoked.
+// genBranch is the generation branch being stopped. recordedBase is the branch
+// written by generator:start. When the caller is on a branch other than the
+// generation branch and other than the recorded base, that caller branch is
+// returned so that generator:stop merges into an explicit feature branch rather
+// than always forcing a merge into the recorded base (GH-523).
+func resolveStopTarget(callerBranch, genBranch, recordedBase string) string {
+	if callerBranch != genBranch && callerBranch != recordedBase {
+		return callerBranch
+	}
+	return recordedBase
+}
+
 // GeneratorStop completes a generation trail and merges it into the base branch.
 // Reads the base branch from .cobbler/base-branch (falls back to "main").
 // Uses Config.GenerationBranch, current branch, or auto-detects.
@@ -321,13 +335,27 @@ func (o *Orchestrator) GeneratorStop() error {
 
 	logf("generator:stop: beginning")
 
+	// Capture the caller's branch before switching to the generation branch.
+	// If the caller is on a feature branch (e.g. gh-168-...) rather than
+	// the recorded base branch, prefer it as the merge target so that
+	// generator:stop respects the PR workflow described in the close-out
+	// procedure (GH-523).
+	callerBranch, err := gitCurrentBranch(".")
+	if err != nil {
+		return fmt.Errorf("getting current branch: %w", err)
+	}
+
 	// Switch to the generation branch and tag its final state.
 	if err := ensureOnBranch(branch); err != nil {
 		return fmt.Errorf("switching to generation branch: %w", err)
 	}
 
-	// Read the base branch before leaving the generation branch (prd002 R5.3).
-	baseBranch := o.readBaseBranch()
+	// Determine the merge target (GH-523).
+	recordedBase := o.readBaseBranch()
+	baseBranch := resolveStopTarget(callerBranch, branch, recordedBase)
+	if baseBranch != recordedBase {
+		logf("generator:stop: caller was on %s; using it as merge target instead of recorded base %s", callerBranch, recordedBase)
+	}
 
 	logf("generator:stop: tagging as %s", finishedTag)
 	if err := gitTag(finishedTag, "."); err != nil {

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -1341,3 +1341,51 @@ func TestRestoreFromStartTag_SkipsMagefiles(t *testing.T) {
 		t.Error("magefiles/build.go was restored, but should have been skipped")
 	}
 }
+
+// --- resolveStopTarget (pure, parallelizable) ---
+
+func TestResolveStopTarget_CallerOnFeatureBranch_UsesFeatureBranch(t *testing.T) {
+	t.Parallel()
+	// Caller checked out a feature branch before running generator:stop.
+	// Expected: merge into the feature branch, not the recorded base.
+	got := resolveStopTarget("gh-168-feature", "generation-2026-03-03", "main")
+	if got != "gh-168-feature" {
+		t.Errorf("resolveStopTarget = %q, want %q", got, "gh-168-feature")
+	}
+}
+
+func TestResolveStopTarget_CallerOnRecordedBase_UsesRecordedBase(t *testing.T) {
+	t.Parallel()
+	// Caller is on the recorded base branch (normal workflow, no change).
+	got := resolveStopTarget("main", "generation-2026-03-03", "main")
+	if got != "main" {
+		t.Errorf("resolveStopTarget = %q, want %q", got, "main")
+	}
+}
+
+func TestResolveStopTarget_CallerOnGenBranch_UsesRecordedBase(t *testing.T) {
+	t.Parallel()
+	// Caller is already on the generation branch itself; fall back to recorded base.
+	got := resolveStopTarget("generation-2026-03-03", "generation-2026-03-03", "main")
+	if got != "main" {
+		t.Errorf("resolveStopTarget = %q, want %q", got, "main")
+	}
+}
+
+func TestResolveStopTarget_CustomRecordedBase_FeatureBranchOverrides(t *testing.T) {
+	t.Parallel()
+	// Project uses a custom base branch (develop) and caller is on a feature branch.
+	got := resolveStopTarget("gh-42-my-fix", "generation-2026-03-03", "develop")
+	if got != "gh-42-my-fix" {
+		t.Errorf("resolveStopTarget = %q, want %q", got, "gh-42-my-fix")
+	}
+}
+
+func TestResolveStopTarget_CallerOnCustomBase_UsesCustomBase(t *testing.T) {
+	t.Parallel()
+	// Caller is on the custom base branch itself; no feature branch override.
+	got := resolveStopTarget("develop", "generation-2026-03-03", "develop")
+	if got != "develop" {
+		t.Errorf("resolveStopTarget = %q, want %q", got, "develop")
+	}
+}


### PR DESCRIPTION
## Summary

`generator:stop` always merged into the branch recorded at `generator:start` time (usually `main`), ignoring the branch actually checked out when the command ran. This forced a manual workaround after every generation close-out when using a feature branch for PR review. The fix captures the caller's branch before switching to the generation branch and uses it as the merge target when it differs from both the generation branch and the recorded base.

## Changes

- `pkg/orchestrator/generator.go`: extract `resolveStopTarget(callerBranch, genBranch, recordedBase) string`; capture caller branch in `GeneratorStop()` before `ensureOnBranch()` (+28 LOC)
- `pkg/orchestrator/generator_test.go`: 5 new unit tests for `resolveStopTarget` (+48 LOC)

## Behavior

| Caller branch | Result |
|---|---|
| Feature branch `gh-168-...` | Merges into `gh-168-...` (new behavior) |
| `main` (recorded base) | Merges into `main` (unchanged) |
| Generation branch itself | Merges into recorded base (unchanged) |
| Custom base `develop` | Merges into `develop` (unchanged) |

## Stats

- Lines of code (Go, production): 11,318 (+28)
- Lines of code (Go, tests): 14,958 (+48)

## Test plan

- [x] `mage analyze` passes
- [x] `go test ./pkg/orchestrator/ -count=1` passes (including 5 new `TestResolveStopTarget_*` tests)

Closes #523