### PR TITLE
GH-535: Fix max_requirements_per_task to count expanded sub-items

### DIFF
--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -526,19 +526,13 @@ func validateMeasureOutput(issues []proposedIssue, maxReqs int, subItemCounts ma
 		// references to their sub-item counts (GH-122).
 		expandedCount := expandedRequirementCount(desc.Requirements, subItemCounts)
 
-		if maxReqs > 0 && rCount > maxReqs {
-			msg := fmt.Sprintf("[%d] %q: has %d requirements, max is %d", issue.Index, issue.Title, rCount, maxReqs)
+		// Enforce max_requirements_per_task on the expanded sub-item count,
+		// not the top-level group count (GH-535). A requirement referencing
+		// "prd003 R2" where R2 has 10 sub-items counts as 10, not 1.
+		if maxReqs > 0 && expandedCount > maxReqs {
+			msg := fmt.Sprintf("[%d] %q: expanded sub-item count is %d, max is %d", issue.Index, issue.Title, expandedCount, maxReqs)
 			logf("validateMeasureOutput: %s", msg)
 			result.Errors = append(result.Errors, msg)
-		}
-
-		// Log expanded count as warning when it exceeds the limit.
-		// This is best-effort — we never block on expanded counts.
-		if maxReqs > 0 && expandedCount > maxReqs && expandedCount != rCount {
-			msg := fmt.Sprintf("[%d] %q: expanded sub-item count is %d (max %d); consider restructuring PRD requirement groups",
-				issue.Index, issue.Title, expandedCount, maxReqs)
-			logf("validateMeasureOutput: %s", msg)
-			result.Warnings = append(result.Warnings, msg)
 		}
 
 		if desc.DeliverableType == "code" {

--- a/pkg/orchestrator/measure_test.go
+++ b/pkg/orchestrator/measure_test.go
@@ -613,16 +613,70 @@ func TestExpandedRequirementCount_FuzzyPRDStemMatch(t *testing.T) {
 	}
 }
 
-// --- validateMeasureOutput expanded count warning ---
+// --- validateMeasureOutput expanded count enforcement (GH-535) ---
 
-func TestValidateMeasureOutput_ExpandedCountWarning(t *testing.T) {
+func TestValidateMeasureOutput_ExpandedCount_ExceedsLimit_HardError(t *testing.T) {
 	t.Parallel()
+	// 4 listed requirements (within limit), but prd003 R2 expands to 10 sub-items.
+	// Expanded total = 10+3 = 13, maxReqs = 8 → hard error.
 	subItems := map[string]map[string]int{
 		"prd003": {"R2": 10},
 	}
 	issues := []proposedIssue{{
 		Index: 0,
 		Title: "Expanded task",
+		Description: `deliverable_type: code
+requirements:
+  - id: R1
+    text: Implement prd003 R2
+  - id: R2
+    text: plain req
+  - id: R3
+    text: another req
+  - id: R4
+    text: yet another
+acceptance_criteria:
+  - id: AC1
+    text: ac1
+  - id: AC2
+    text: ac2
+  - id: AC3
+    text: ac3
+  - id: AC4
+    text: ac4
+  - id: AC5
+    text: ac5
+design_decisions:
+  - id: D1
+    text: d1
+  - id: D2
+    text: d2
+  - id: D3
+    text: d3
+`,
+	}}
+	vr := validateMeasureOutput(issues, 8, subItems)
+	found := false
+	for _, e := range vr.Errors {
+		if contains(e, "expanded sub-item count") && contains(e, "max is") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected hard error for expanded count 13 > maxReqs 8, got errors: %v", vr.Errors)
+	}
+}
+
+func TestValidateMeasureOutput_ExpandedCount_WithinLimit_NoError(t *testing.T) {
+	t.Parallel()
+	// prd003 R2 has 2 sub-items; total expanded = 2+3 = 5, maxReqs = 8 → no error.
+	subItems := map[string]map[string]int{
+		"prd003": {"R2": 2},
+	}
+	issues := []proposedIssue{{
+		Index: 0,
+		Title: "Small task",
 		Description: `deliverable_type: code
 requirements:
   - id: R1
@@ -655,28 +709,16 @@ design_decisions:
     text: d3
 `,
 	}}
-	// 5 listed requirements, but expanded count = 10+4 = 14. maxReqs = 8.
-	// Should produce a warning (not an error) about expanded count.
+	// expanded = 2+4 = 6, maxReqs = 8 → no expanded-count error.
 	vr := validateMeasureOutput(issues, 8, subItems)
-	foundWarning := false
-	for _, w := range vr.Warnings {
-		if contains(w, "expanded sub-item count") {
-			foundWarning = true
-			break
-		}
-	}
-	if !foundWarning {
-		t.Errorf("expected expanded count warning, got warnings: %v, errors: %v", vr.Warnings, vr.Errors)
-	}
-	// The expanded count violation must NOT appear in errors.
 	for _, e := range vr.Errors {
-		if contains(e, "expanded") {
-			t.Errorf("expanded count violation should be warning, not error: %s", e)
+		if contains(e, "expanded sub-item count") {
+			t.Errorf("should not error when expanded count under limit, got: %s", e)
 		}
 	}
 }
 
-func TestValidateMeasureOutput_NoExpandedWarningWhenUnderLimit(t *testing.T) {
+func TestValidateMeasureOutput_NoExpandedErrorWhenUnderLimit(t *testing.T) {
 	t.Parallel()
 	subItems := map[string]map[string]int{
 		"prd003": {"R2": 2},
@@ -716,11 +758,11 @@ design_decisions:
     text: d3
 `,
 	}}
-	// 5 listed, expanded = 2+4 = 6. maxReqs = 8. Under limit.
+	// 5 listed, expanded = 2+4 = 6. maxReqs = 8. Under limit — no error.
 	vr := validateMeasureOutput(issues, 8, subItems)
-	for _, w := range vr.Warnings {
-		if contains(w, "expanded") {
-			t.Errorf("should not warn when expanded count under limit, got: %s", w)
+	for _, e := range vr.Errors {
+		if contains(e, "expanded sub-item count") {
+			t.Errorf("should not error when expanded count under limit, got: %s", e)
 		}
 	}
 }

--- a/pkg/orchestrator/prompts/measure.yaml
+++ b/pkg/orchestrator/prompts/measure.yaml
@@ -31,7 +31,7 @@ constraints: |
   - Components with a provided_by field in ARCHITECTURE.yaml are external infrastructure. Do NOT propose tasks that create or modify files in those components.
   - Do NOT exceed {limit} tasks. If more work is needed, create additional tasks in a future session.
   - Do NOT create tasks larger than {lines_max} lines of production code. Target {lines_min}-{lines_max} lines per task, touching 5-7 files. Split aggressively: a task that creates a struct and implements its methods is two tasks.
-  - Each task must contain at most {max_requirements} requirements. Split any task that would exceed this limit.
+  - Each task must contain at most {max_requirements} PRD sub-requirements (e.g., R1.1, R2.3), not requirement groups. Split any task that would exceed this limit.
   - Each task MUST be independently executable by an agent that has no context beyond the task description and the execution constitution.
   - Do NOT assume the stitch agent has access to your analysis, the existing issues list, or any context from this conversation.
   - Do NOT propose tasks that require human judgment or manual testing. Each task must have checkable acceptance criteria.


### PR DESCRIPTION
## Summary

`max_requirements_per_task` was enforced against the top-level requirement group count, not the expanded sub-item count. A task with 4 groups mapping to 18 PRD sub-items would pass a `maxReqs=4` limit and produce an oversized stitch job that the idle watchdog kills. The fix swaps the hard enforcement to use `expandedRequirementCount()`, which was already computed but only used for a warning.

## Changes

- `pkg/orchestrator/measure.go`: enforce `maxReqs` on `expandedCount` in `validateMeasureOutput()`; remove the now-redundant warning path
- `pkg/orchestrator/prompts/measure.yaml`: clarify the constraint says "PRD sub-requirements (e.g., R1.1, R2.3), not requirement groups"
- `pkg/orchestrator/measure_test.go`: replace `ExpandedCountWarning` test (was warning-only) with two new tests: `ExpandedCount_ExceedsLimit_HardError` and `ExpandedCount_WithinLimit_NoError`; rename `NoExpandedWarningWhenUnderLimit` → `NoExpandedErrorWhenUnderLimit`

## Stats

  Lines of code (Go, production): 11312 (-6)
  Lines of code (Go, tests):      15000 (+42)
  Words (documentation):          18937 (+0)

## Test plan

- [x] All unit tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] `TestValidateMeasureOutput_ExpandedCount_ExceedsLimit_HardError` passes
- [x] `TestValidateMeasureOutput_ExpandedCount_WithinLimit_NoError` passes
- [x] All existing MaxReqs tests still pass unchanged

Closes #535