### PR TITLE
GH-536: Enforce numeric dotted requirement IDs (R1.1) in PRDs and mage analyze

### DIFF
--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -133,6 +133,7 @@ document_types:
       goals: "G1, G2, G3, ..."
       requirement_groups: "R1, R2, R3, ..."
       requirement_items: "R1.1, R1.2, R2.1, ..."
+      requirement_id_format: "R{group}.{item} — numeric dotted only (e.g., R1.1, R2.3). Letter suffixes (R2a) are not valid and are flagged by mage analyze."
     purpose: |
       Defines product requirements with numbered goals and requirements. Each
       requirement starts with "must" or "must not" or a concrete verb. No scope

--- a/docs/specs/product-requirements/prd003-cobbler-workflows.yaml
+++ b/docs/specs/product-requirements/prd003-cobbler-workflows.yaml
@@ -52,12 +52,12 @@ requirements:
       - R3.9: For each task, stitch must capture LOC before Claude
       - R3.10: For each task, stitch must build the prompt from the template with task data
       - R3.11: For each task, stitch must invoke Claude in the worktree directory
-      - R3.11a: The orchestrator must stage and commit Claude's changes in the worktree (Claude is forbidden from running git commands)
-      - R3.12: For each task, stitch must merge the task branch back to the base branch
-      - R3.13: For each task, stitch must capture LOC after Claude and git diff stats
-      - R3.14: For each task, stitch must clean up the worktree and delete the task branch
-      - R3.15: For each task, stitch must record an InvocationRecord and close the task
-      - R3.16: worktreeBasePath must derive the repo name from git rev-parse --git-common-dir so the temp directory for task worktrees is identical whether stitch is invoked from the main repo root or from a git worktree; it must fall back to filepath.Base(os.Getwd()) if git is unavailable
+      - R3.12: The orchestrator must stage and commit Claude's changes in the worktree (Claude is forbidden from running git commands)
+      - R3.13: For each task, stitch must merge the task branch back to the base branch
+      - R3.14: For each task, stitch must capture LOC after Claude and git diff stats
+      - R3.15: For each task, stitch must clean up the worktree and delete the task branch
+      - R3.16: For each task, stitch must record an InvocationRecord and close the task
+      - R3.17: worktreeBasePath must derive the repo name from git rev-parse --git-common-dir so the temp directory for task worktrees is identical whether stitch is invoked from the main repo root or from a git worktree; it must fall back to filepath.Base(os.Getwd()) if git is unavailable
 
   R4:
     title: Recovery

--- a/docs/specs/product-requirements/prd004-differential-comparison.yaml
+++ b/docs/specs/product-requirements/prd004-differential-comparison.yaml
@@ -43,40 +43,40 @@ requirements:
       - R3.5: The cleanup function for GNUResolver must be a no-op
       - R3.6: GNUResolver.ListUtilities must scan the Homebrew coreutils gnubin directory and the moreutils utilities available on PATH
 
-  R3b:
+  R4:
     title: Path-Based Resolution
     items:
-      - R3b.1: PathResolver must resolve pre-built binaries from a local directory; given a utility name it returns the path to that binary in the directory
-      - R3b.2: PathResolver must return an error if the binary is not found in the directory
-      - R3b.3: The cleanup function for PathResolver must be a no-op
-      - R3b.4: PathResolver.ListUtilities must list all non-directory entries in the directory
-
-  R4:
-    title: Test Case Loading
-    items:
-      - R4.1: We define a CompareTestCase struct with fields for use_case, name, utility, stdin input, arguments, and expected outputs (stdout, stderr, exit_code)
-      - R4.2: LoadCompareTestCases must read YAML test suite files matching test-*.yaml from the specs directory
-      - R4.3: LoadCompareTestCases must filter to test cases that have concrete inputs and expected outputs, skipping entries that only reference Go test functions (go_test field only)
-      - R4.4: FilterByUtility must return only test cases matching the specified utility name
+      - R4.1: PathResolver must resolve pre-built binaries from a local directory; given a utility name it returns the path to that binary in the directory
+      - R4.2: PathResolver must return an error if the binary is not found in the directory
+      - R4.3: The cleanup function for PathResolver must be a no-op
+      - R4.4: PathResolver.ListUtilities must list all non-directory entries in the directory
 
   R5:
-    title: Comparison Execution
+    title: Test Case Loading
     items:
-      - R5.1: CompareUtility must run both binaries with identical inputs for each test case
-      - R5.2: Comparison must be byte-for-byte on stdout; stderr and exit code are compared separately
-      - R5.3: Each test case execution must enforce a timeout (default 10 seconds)
-      - R5.4: We define a TestResult struct with utility name, test name, pass/fail status, and diffs for stdout, stderr, and exit code
-      - R5.5: The comparison must collect all results before formatting output
+      - R5.1: We define a CompareTestCase struct with fields for use_case, name, utility, stdin input, arguments, and expected outputs (stdout, stderr, exit_code)
+      - R5.2: LoadCompareTestCases must read YAML test suite files matching test-*.yaml from the specs directory
+      - R5.3: LoadCompareTestCases must filter to test cases that have concrete inputs and expected outputs, skipping entries that only reference Go test functions (go_test field only)
+      - R5.4: FilterByUtility must return only test cases matching the specified utility name
 
   R6:
+    title: Comparison Execution
+    items:
+      - R6.1: CompareUtility must run both binaries with identical inputs for each test case
+      - R6.2: Comparison must be byte-for-byte on stdout; stderr and exit code are compared separately
+      - R6.3: Each test case execution must enforce a timeout (default 10 seconds)
+      - R6.4: We define a TestResult struct with utility name, test name, pass/fail status, and diffs for stdout, stderr, and exit code
+      - R6.5: The comparison must collect all results before formatting output
+
+  R7:
     title: Output and Mage Integration
     items:
-      - R6.1: FormatResults must produce structured text output showing pass/fail per utility per test case with summary counts
-      - R6.2: The Compare method on Orchestrator must accept two tag arguments and an optional utility filter
-      - R6.3: The Compare method must discover utilities from both resolvers, intersect to find the common set, and compare each
-      - R6.4: The Compare method must clean up all resolver resources via deferred cleanup calls
-      - R6.5: The Compare method must return an error if any comparison test fails
-      - R6.6: We expose a mage compare:run target that invokes the Compare method
+      - R7.1: FormatResults must produce structured text output showing pass/fail per utility per test case with summary counts
+      - R7.2: The Compare method on Orchestrator must accept two tag arguments and an optional utility filter
+      - R7.3: The Compare method must discover utilities from both resolvers, intersect to find the common set, and compare each
+      - R7.4: The Compare method must clean up all resolver resources via deferred cleanup calls
+      - R7.5: The Compare method must return an error if any comparison test fails
+      - R7.6: We expose a mage compare:run target that invokes the Compare method
 
 non_goals:
   - This PRD does not define concurrent comparison execution (comparisons run sequentially per utility)

--- a/docs/specs/use-cases/rel01.0-uc010-worktree-based-invocation.yaml
+++ b/docs/specs/use-cases/rel01.0-uc010-worktree-based-invocation.yaml
@@ -29,9 +29,9 @@ flow:
   - F9: "Clean up: stale task worktrees and branches are removed; orphaned issues are reset to ready"
 
 touchpoints:
-  - T1: "Stable worktree base path: prd003-cobbler-workflows R3.16"
+  - T1: "Stable worktree base path: prd003-cobbler-workflows R3.17"
   - T2: "Recovery across invocation directories: prd003-cobbler-workflows R4.7"
-  - T3: "Stitch worktree management: prd003-cobbler-workflows R3.7, R3.14"
+  - T3: "Stitch worktree management: prd003-cobbler-workflows R3.7, R3.15"
   - T4: "Resume and recovery: prd003-cobbler-workflows R4.1, R4.2"
 
 success_criteria:

--- a/docs/specs/use-cases/rel03.0-uc001-cross-generation-comparison.yaml
+++ b/docs/specs/use-cases/rel03.0-uc001-cross-generation-comparison.yaml
@@ -29,10 +29,11 @@ touchpoints:
   - T1: "BinaryResolver interface: prd004-differential-comparison R1"
   - T2: "GitTagResolver (worktree + build): prd004-differential-comparison R2"
   - T3: "GNUResolver (Homebrew lookup): prd004-differential-comparison R3"
-  - T4: "Test case loading from YAML specs: prd004-differential-comparison R4"
-  - T5: "Comparison execution and timeout: prd004-differential-comparison R5"
-  - T6: "Output formatting and mage target: prd004-differential-comparison R6"
-  - T7: "Git worktree management: git worktree add/remove pattern reused from stitch workflow (create branch worktree, build, clean up)"
+  - T4: "Path-based resolver: prd004-differential-comparison R4"
+  - T5: "Test case loading from YAML specs: prd004-differential-comparison R5"
+  - T6: "Comparison execution and timeout: prd004-differential-comparison R6"
+  - T7: "Output formatting and mage target: prd004-differential-comparison R7"
+  - T8: "Git worktree management: git worktree add/remove pattern reused from stitch workflow (create branch worktree, build, clean up)"
 
 success_criteria:
   - S1: Two generation tags can be compared with mage compare:run and produce pass/fail results

--- a/pkg/orchestrator/analyze_test.go
+++ b/pkg/orchestrator/analyze_test.go
@@ -663,6 +663,53 @@ func TestPRDDoc_Validate_RequirementGroupEmptyItems(t *testing.T) {
 	}
 }
 
+func TestPRDDoc_Validate_ItemIDLetterSuffix_Error(t *testing.T) {
+	t.Parallel()
+	// R2a, R2b are letter-suffix IDs — not valid; must use R2.1, R2.2 (GH-536).
+	d := &PRDDoc{
+		ID:      "prd001-core",
+		Title:   "Core",
+		Problem: "The problem",
+		Requirements: map[string]PRDRequirementGroup{
+			"R2": {Title: "Group 2", Items: []map[string]string{
+				{"R2a": "Do A"},
+				{"R2b": "Do B"},
+			}},
+		},
+	}
+	errs := d.Validate()
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 errors for R2a and R2b, got %d: %v", len(errs), errs)
+	}
+	for _, e := range errs {
+		if !contains(e, "numeric dotted format") {
+			t.Errorf("error %q should mention numeric dotted format", e)
+		}
+	}
+}
+
+func TestPRDDoc_Validate_ItemIDDotted_Valid(t *testing.T) {
+	t.Parallel()
+	// R1.1, R2.3 are valid numeric dotted IDs (GH-536).
+	d := &PRDDoc{
+		ID:      "prd001-core",
+		Title:   "Core",
+		Problem: "The problem",
+		Requirements: map[string]PRDRequirementGroup{
+			"R1": {Title: "Group 1", Items: []map[string]string{
+				{"R1.1": "Do X"},
+				{"R1.2": "Do Y"},
+			}},
+			"R2": {Title: "Group 2", Items: []map[string]string{
+				{"R2.3": "Do Z"},
+			}},
+		},
+	}
+	if errs := d.Validate(); len(errs) != 0 {
+		t.Errorf("expected no errors for valid dotted IDs, got: %v", errs)
+	}
+}
+
 func TestUseCaseDoc_Validate_AllPresent(t *testing.T) {
 	d := &UseCaseDoc{
 		ID:      "rel01.0-uc001-init",

--- a/pkg/orchestrator/constitutions/design.yaml
+++ b/pkg/orchestrator/constitutions/design.yaml
@@ -133,6 +133,7 @@ document_types:
       goals: "G1, G2, G3, ..."
       requirement_groups: "R1, R2, R3, ..."
       requirement_items: "R1.1, R1.2, R2.1, ..."
+      requirement_id_format: "R{group}.{item} — numeric dotted only (e.g., R1.1, R2.3). Letter suffixes (R2a) are not valid and are flagged by mage analyze."
     purpose: |
       Defines product requirements with numbered goals and requirements. Each
       requirement starts with "must" or "must not" or a concrete verb. No scope

--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -9,6 +9,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -1516,8 +1517,12 @@ func (d *RoadmapDoc) Validate() []string {
 	return errs
 }
 
+// prdItemIDRe matches valid PRD requirement item IDs: R{group}.{item} (e.g., R1.1, R2.3).
+// Letter suffixes like R2a are not valid (GH-536).
+var prdItemIDRe = regexp.MustCompile(`^R\d+\.\d+$`)
+
 // Validate checks that all required fields in PRDDoc are non-empty, including
-// each requirement group's title and items.
+// each requirement group's title, items, and item ID format (GH-536).
 func (d *PRDDoc) Validate() []string {
 	var errs []string
 	if d.ID == "" {
@@ -1541,6 +1546,13 @@ func (d *PRDDoc) Validate() []string {
 		}
 		if len(g.Items) == 0 {
 			errs = append(errs, fmt.Sprintf("requirements.%s.items is required", k))
+		}
+		for _, item := range g.Items {
+			for itemKey := range item {
+				if !prdItemIDRe.MatchString(itemKey) {
+					errs = append(errs, fmt.Sprintf("requirements.%s: item ID %q must use numeric dotted format (e.g., R1.1)", k, itemKey))
+				}
+			}
 		}
 	}
 	return errs


### PR DESCRIPTION
## Summary

Adds `prdItemIDRe` regex validation to `PRDDoc.Validate()` that rejects requirement item IDs not matching `^R\d+\.\d+$` (e.g., `R2a`, `R3b.1`). Since `mage analyze` already calls `Validate()` via `validateYAMLStrict`, the check runs automatically. Also fixes two existing PRDs that violated the new rule, and documents the format in both `design.yaml` copies.

## Changes

- `pkg/orchestrator/context.go`: add `prdItemIDRe`; extend `PRDDoc.Validate()` with item ID format check
- `docs/constitutions/design.yaml` + `pkg/orchestrator/constitutions/design.yaml`: add `requirement_id_format` entry under `prd.numbering`
- `docs/specs/product-requirements/prd003-cobbler-workflows.yaml`: R3.11a → R3.12; shift R3.12-R3.16 → R3.13-R3.17
- `docs/specs/product-requirements/prd004-differential-comparison.yaml`: group R3b → R4 (items R3b.1-4 → R4.1-4); shift R4-R6 → R5-R7
- `docs/specs/use-cases/rel01.0-uc010-worktree-based-invocation.yaml`: update R3.14 → R3.15, R3.16 → R3.17
- `docs/specs/use-cases/rel03.0-uc001-cross-generation-comparison.yaml`: insert T4 for R4, shift T4-T7 → T5-T8
- `pkg/orchestrator/analyze_test.go`: 2 new tests (`TestPRDDoc_Validate_ItemIDLetterSuffix_Error`, `TestPRDDoc_Validate_ItemIDDotted_Valid`)

## Stats

  Lines of code (Go, production): 11324 (+12)
  Lines of code (Go, tests):      15047 (+47)
  Words (documentation):          7163 (+6)

## Test plan

- [x] `mage analyze` passes (0 schema errors, 0 citation errors, 0 drift)
- [x] All unit tests pass
- [x] `TestPRDDoc_Validate_ItemIDLetterSuffix_Error` catches R2a/R2b as errors
- [x] `TestPRDDoc_Validate_ItemIDDotted_Valid` accepts R1.1/R2.3

Closes #536