### PR TITLE
GH-568: Create measuring placeholder issue before measure Claude call

### DIFF
--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -189,6 +189,44 @@ func ensureCobblerGenLabel(repo, generation string) error {
 	return nil
 }
 
+// createMeasuringPlaceholder creates a transient GitHub issue that signals
+// the measure agent is actively calling Claude for iteration i (1-based).
+// The issue carries no cobbler-ready label so stitch won't pick it up.
+// Callers must call closeMeasuringPlaceholder after the iteration completes.
+func createMeasuringPlaceholder(repo, generation string, iteration int) (int, error) {
+	title := fmt.Sprintf("[measuring] %s task %d", generation, iteration)
+	body := fmt.Sprintf("Cobbler measure is calling Claude to propose task %d for generation %s.\n\nThis issue will be closed automatically when measure completes.", iteration, generation)
+	// No cobbler labels: stitch ignores issues without a gen label, and the
+	// placeholder must not appear in the existing-issues context sent to Claude.
+	out, err := exec.Command(binGh, "issue", "create",
+		"--repo", repo,
+		"--title", title,
+		"--body", body,
+	).Output()
+	if err != nil {
+		return 0, fmt.Errorf("gh issue create placeholder: %w", err)
+	}
+	number, err := parseIssueURL(string(out))
+	if err != nil {
+		return 0, err
+	}
+	logf("createMeasuringPlaceholder: created #%d for iteration %d", number, iteration)
+	return number, nil
+}
+
+// closeMeasuringPlaceholder closes the placeholder issue created by
+// createMeasuringPlaceholder. Best-effort: logs and ignores errors.
+func closeMeasuringPlaceholder(repo string, number int) {
+	if err := exec.Command(binGh, "issue", "close",
+		"--repo", repo,
+		fmt.Sprintf("%d", number),
+	).Run(); err != nil {
+		logf("closeMeasuringPlaceholder: close #%d warning: %v", number, err)
+		return
+	}
+	logf("closeMeasuringPlaceholder: closed #%d", number)
+}
+
 // createCobblerIssue creates a GitHub issue on repo for the given generation
 // and proposedIssue. Returns the GitHub issue number.
 //

--- a/pkg/orchestrator/issues_gh_test.go
+++ b/pkg/orchestrator/issues_gh_test.go
@@ -617,3 +617,22 @@ func TestCloseCobblerIssue_FakeRepo_NoOp(t *testing.T) {
 		t.Error("closeCobblerIssue with fake repo must return an error")
 	}
 }
+
+// --- measuring placeholder (GH-568) ---
+
+// TestCreateMeasuringPlaceholder_FakeRepo_Error verifies createMeasuringPlaceholder
+// returns an error (not panic) when the GitHub CLI fails on a fake repo (GH-568).
+func TestCreateMeasuringPlaceholder_FakeRepo_Error(t *testing.T) {
+	t.Parallel()
+	_, err := createMeasuringPlaceholder("fake/repo-that-does-not-exist", "gen-test", 1)
+	if err == nil {
+		t.Error("createMeasuringPlaceholder with fake repo must return an error")
+	}
+}
+
+// TestCloseMeasuringPlaceholder_FakeRepo_NoOp verifies closeMeasuringPlaceholder
+// does not panic when the GitHub CLI fails on a fake repo (GH-568).
+func TestCloseMeasuringPlaceholder_FakeRepo_NoOp(t *testing.T) {
+	t.Parallel()
+	closeMeasuringPlaceholder("fake/repo-that-does-not-exist", 99999) // must not panic
+}

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -176,6 +176,15 @@ func (o *Orchestrator) RunMeasure() error {
 			}
 		}
 
+		// Create a placeholder issue so users can see measure is running Claude.
+		// The placeholder has no cobbler labels and is invisible to stitch and to
+		// the measure context prompt. It is closed after the iteration regardless
+		// of outcome (GH-568).
+		placeholderNum, placeholderErr := createMeasuringPlaceholder(repo, generation, i+1)
+		if placeholderErr != nil {
+			logf("measure: warning: createMeasuringPlaceholder: %v", placeholderErr)
+		}
+
 		var createdIDs []string
 		var lastOutputFile string
 		var lastValidationErrors []string // errors from previous attempt, fed back into retry prompt
@@ -285,6 +294,11 @@ func (o *Orchestrator) RunMeasure() error {
 		}
 
 		logf("iteration %d imported %d issue(s)", i+1, len(createdIDs))
+
+		// Close the placeholder now that the iteration is complete (GH-568).
+		if placeholderNum > 0 {
+			closeMeasuringPlaceholder(repo, placeholderNum)
+		}
 
 		// Record invocation metrics on each created issue.
 


### PR DESCRIPTION
## Summary

Before each measure Claude call, a transient GitHub issue titled \`[measuring] <generation> task <N>\` is created. It is closed automatically after the iteration completes. Users watching the GitHub issues list now see real-time indication that the generator is actively proposing tasks — closing the 3-5 minute visibility gap between cycles.

## Changes

- \`issues_gh.go\`: \`createMeasuringPlaceholder\` and \`closeMeasuringPlaceholder\`
- \`measure.go\`: create placeholder before \`runClaude\`, close after \`importIssues\` (regardless of outcome)
- 2 new unit tests (no-panic/error-on-fake-repo)

## Stats

Lines of code (Go, production): 11382 (+52)
Lines of code (Go, tests):      15101 (+19)
Words (documentation):          unchanged

## Test plan

- [x] `mage test:unit` passes (178 tests)
- [x] No cobbler labels on placeholder — stitch and measure context ignore it

Closes #568