### PR TITLE
GH-567: Add progress comments to task issues during stitch execution

### DIFF
--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -638,6 +638,24 @@ func resolveTargetRepo(cfg Config) string {
 	return ""
 }
 
+// commentCobblerIssue posts a comment on a GitHub issue. Errors are logged
+// but do not fail the caller — commenting is best-effort.
+func commentCobblerIssue(repo string, number int, body string) {
+	if repo == "" || number <= 0 {
+		return
+	}
+	out, err := exec.Command(binGh, "issue", "comment",
+		fmt.Sprintf("%d", number),
+		"--repo", repo,
+		"--body", body,
+	).CombinedOutput()
+	if err != nil {
+		logf("commentCobblerIssue: gh issue comment failed for #%d: %v (output: %s)", number, err, strings.TrimSpace(string(out)))
+		return
+	}
+	logf("commentCobblerIssue: posted comment on #%d", number)
+}
+
 // fileTargetRepoDefects files each defect as a GitHub bug issue in repo.
 // Errors are logged but do not fail the caller — filing is best-effort
 // (prd003 R11.5, R11.6). If repo is empty the call is a no-op with a

--- a/pkg/orchestrator/issues_gh_test.go
+++ b/pkg/orchestrator/issues_gh_test.go
@@ -636,3 +636,20 @@ func TestCloseMeasuringPlaceholder_FakeRepo_NoOp(t *testing.T) {
 	t.Parallel()
 	closeMeasuringPlaceholder("fake/repo-that-does-not-exist", 99999) // must not panic
 }
+
+// --- progress comments (GH-567) ---
+
+// TestCommentCobblerIssue_FakeRepo_NoOp verifies commentCobblerIssue does not
+// panic when the GitHub CLI fails on a fake repo (GH-567).
+func TestCommentCobblerIssue_FakeRepo_NoOp(t *testing.T) {
+	t.Parallel()
+	commentCobblerIssue("fake/repo-that-does-not-exist", 99999, "test body") // must not panic
+}
+
+// TestCommentCobblerIssue_ZeroNumber_NoOp verifies commentCobblerIssue is a
+// no-op for invalid inputs (GH-567).
+func TestCommentCobblerIssue_ZeroNumber_NoOp(t *testing.T) {
+	t.Parallel()
+	commentCobblerIssue("petar-djukic/cobbler-scaffold", 0, "test body")  // must not panic
+	commentCobblerIssue("", 1, "test body")                                // must not panic
+}

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -380,10 +380,14 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	// Build and run prompt.
 	prompt, promptErr := o.buildStitchPrompt(task)
 	if promptErr != nil {
-		o.resetTask(task, "prompt build failure")
+		o.failTask(task, "prompt build failure", taskStart)
 		return promptErr
 	}
 	logf("doOneTask: prompt built, length=%d bytes", len(prompt))
+
+	// Post "started" comment so the issue reflects pickup immediately.
+	commentCobblerIssue(task.repo, task.ghNumber, fmt.Sprintf(
+		"Stitch started. Branch: `%s`, prompt: %d bytes.", task.branchName, len(prompt)))
 
 	// Save prompt BEFORE calling Claude so it's on disk even if Claude times out.
 	historyTS := time.Now().Format("2006-01-02-15-04-05")
@@ -411,7 +415,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 			CostUSD:   tokens.CostUSD,
 			LOCBefore: locBefore,
 		})
-		o.resetTask(task, "Claude failure")
+		o.failTask(task, "Claude failure", taskStart)
 		return errTaskReset
 	}
 	logf("doOneTask: Claude completed for %s in %s", task.id, time.Since(claudeStart).Round(time.Second))
@@ -433,7 +437,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 			CostUSD:   tokens.CostUSD,
 			LOCBefore: locBefore,
 		})
-		o.resetTask(task, "worktree commit failure")
+		o.failTask(task, "worktree commit failure", taskStart)
 		return errTaskReset
 	}
 
@@ -482,7 +486,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 			CostUSD:   tokens.CostUSD,
 			LOCBefore: locBefore,
 		})
-		o.resetTask(task, "merge failure")
+		o.failTask(task, "merge failure", taskStart)
 		return errTaskReset
 	}
 	logf("doOneTask: merge completed in %s", time.Since(mergeStart).Round(time.Second))
@@ -810,8 +814,28 @@ func cleanupWorktree(task stitchTask) bool {
 
 func (o *Orchestrator) closeStitchTask(task stitchTask, rec InvocationRecord) {
 	logf("closeStitchTask: closing #%d %q", task.ghNumber, task.title)
+	locDeltaProd := rec.LOCAfter.Production - rec.LOCBefore.Production
+	locDeltaTest := rec.LOCAfter.Test - rec.LOCBefore.Test
+	comment := fmt.Sprintf(
+		"Stitch completed in %dm %ds. LOC delta: %+d prod, %+d test. Cost: $%.2f.",
+		rec.DurationS/60, rec.DurationS%60,
+		locDeltaProd, locDeltaTest,
+		rec.Tokens.CostUSD,
+	)
+	commentCobblerIssue(task.repo, task.ghNumber, comment)
 	if err := closeCobblerIssue(task.repo, task.ghNumber, task.generation); err != nil {
 		logf("closeStitchTask: closeCobblerIssue warning for #%d: %v", task.ghNumber, err)
 	}
 	logf("closeStitchTask: #%d closed", task.ghNumber)
+}
+
+// failTask posts a failure comment on the task issue, then resets it.
+func (o *Orchestrator) failTask(task stitchTask, reason string, startedAt time.Time) {
+	durationS := int(time.Since(startedAt).Seconds())
+	comment := fmt.Sprintf(
+		"Stitch failed after %dm %ds. Error: %s.",
+		durationS/60, durationS%60, reason,
+	)
+	commentCobblerIssue(task.repo, task.ghNumber, comment)
+	o.resetTask(task, reason)
 }


### PR DESCRIPTION
## Summary

Adds three progress comments to every stitch task issue so operators can see what stitch is doing without checking logs. On pickup, the issue receives a "started" comment with branch and prompt size. On success, it receives a "completed" comment with duration, LOC delta, and cost. On failure, it receives a "failed" comment with duration and reason.

## Changes

- `commentCobblerIssue(repo, number, body)` — best-effort comment posting; logs on error, no-ops on invalid inputs
- `doOneTask`: posts "started" comment after prompt is built
- `closeStitchTask`: posts "completed" comment (duration, LOC delta, cost) before closing
- `failTask`: new helper that posts "failed" comment (duration, reason) then delegates to `resetTask`; replaces 4 inline `resetTask` call sites in `doOneTask`
- 3 new tests: `TestCommentCobblerIssue_FakeRepo_NoOp`, `TestCommentCobblerIssue_ZeroNumber_NoOp`

## Stats

  Lines of code (Go, production): 11424 (+42)
  Lines of code (Go, tests):      15118 (+17)
  Words (documentation):          19043 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] Documentation reviewed for consistency

Closes #567