### PR TITLE
GH-566: Link generation task issues as sub-issues of the parent issue

### DIFF
--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -252,7 +252,64 @@ func createCobblerIssue(repo, generation string, issue proposedIssue) (int, erro
 	}
 	logf("createCobblerIssue: created #%d %q gen=%s index=%d dep=%d",
 		number, issue.Title, generation, issue.Index, issue.Dependency)
+
+	// Link as sub-issue of the parent, if the generation name encodes one (GH-566).
+	if parentNumber := extractParentIssueNumber(generation); parentNumber > 0 {
+		if err := linkSubIssue(repo, parentNumber, number); err != nil {
+			logf("createCobblerIssue: linkSubIssue warning for #%d -> parent #%d: %v", number, parentNumber, err)
+		}
+	}
+
 	return number, nil
+}
+
+// extractParentIssueNumber parses a GitHub issue number from a generation name
+// that follows the pattern "...-gh-<N>-..." (e.g., "generation-gh-206-slug"
+// → 206). Returns 0 if the pattern is not found.
+func extractParentIssueNumber(generation string) int {
+	const marker = "-gh-"
+	idx := strings.Index(generation, marker)
+	if idx < 0 {
+		return 0
+	}
+	rest := generation[idx+len(marker):]
+	var n int
+	if _, err := fmt.Sscanf(rest, "%d", &n); err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
+// linkSubIssue attaches childNumber as a GitHub sub-issue of parentNumber.
+// It first fetches the child's database ID, then POSTs to the sub_issues API.
+// Errors are returned so the caller can log them as warnings.
+func linkSubIssue(repo string, parentNumber, childNumber int) error {
+	// Fetch the child issue's database ID (different from the display number).
+	dbIDOut, err := exec.Command(binGh, "api",
+		fmt.Sprintf("repos/%s/issues/%d", repo, childNumber),
+		"--jq", ".id",
+	).Output()
+	if err != nil {
+		return fmt.Errorf("fetching database id for #%d: %w", childNumber, err)
+	}
+	dbIDStr := strings.TrimSpace(string(dbIDOut))
+	var dbID int
+	if _, err := fmt.Sscanf(dbIDStr, "%d", &dbID); err != nil || dbID <= 0 {
+		return fmt.Errorf("parsing database id %q for #%d: %w", dbIDStr, childNumber, err)
+	}
+
+	// POST to the parent's sub_issues endpoint.
+	out, err := exec.Command(binGh, "api",
+		fmt.Sprintf("repos/%s/issues/%d/sub_issues", repo, parentNumber),
+		"--method", "POST",
+		"--field", fmt.Sprintf("sub_issue_id=%d", dbID),
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("linking #%d as sub-issue of #%d: %w (output: %s)",
+			childNumber, parentNumber, err, strings.TrimSpace(string(out)))
+	}
+	logf("linkSubIssue: linked #%d as sub-issue of #%d", childNumber, parentNumber)
+	return nil
 }
 
 // parseIssueURL extracts a GitHub issue number from a URL string like

--- a/pkg/orchestrator/issues_gh_test.go
+++ b/pkg/orchestrator/issues_gh_test.go
@@ -653,3 +653,38 @@ func TestCommentCobblerIssue_ZeroNumber_NoOp(t *testing.T) {
 	commentCobblerIssue("petar-djukic/cobbler-scaffold", 0, "test body")  // must not panic
 	commentCobblerIssue("", 1, "test body")                                // must not panic
 }
+
+// --- sub-issue linking (GH-566) ---
+
+// TestExtractParentIssueNumber covers the generation name parsing logic (GH-566).
+func TestExtractParentIssueNumber(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		generation string
+		want       int
+	}{
+		{"generation-gh-206-some-slug", 206},
+		{"generation-gh-1-x", 1},
+		{"generation-gh-566-link-sub-issues", 566},
+		{"generation-2026-03-04-12-00-00", 0}, // no gh- marker
+		{"", 0},
+		{"generation-gh-abc-slug", 0}, // non-numeric
+		{"generation-gh--slug", 0},    // empty number
+	}
+	for _, tc := range tests {
+		got := extractParentIssueNumber(tc.generation)
+		if got != tc.want {
+			t.Errorf("extractParentIssueNumber(%q) = %d, want %d", tc.generation, got, tc.want)
+		}
+	}
+}
+
+// TestLinkSubIssue_FakeRepo_Error verifies linkSubIssue returns an error (not
+// panic) when the GitHub CLI fails on a fake repo (GH-566).
+func TestLinkSubIssue_FakeRepo_Error(t *testing.T) {
+	t.Parallel()
+	err := linkSubIssue("fake/repo-that-does-not-exist", 1, 99999)
+	if err == nil {
+		t.Error("linkSubIssue with fake repo must return an error")
+	}
+}


### PR DESCRIPTION
## Summary

When `createCobblerIssue` creates a task issue during a generation run, it now also links that issue as a GitHub sub-issue of the parent issue (when the generation name encodes one via the `gh-<N>` pattern). The parent issue page will show a progress checklist tracking open and completed tasks.

## Changes

- `extractParentIssueNumber(generation string) int` — parses the parent issue number from generation names like `generation-gh-206-slug` → 206; returns 0 if the pattern is absent
- `linkSubIssue(repo string, parentNumber, childNumber int) error` — fetches the child's database ID then POSTs to the GitHub sub_issues API
- `createCobblerIssue` — calls `linkSubIssue` after issue creation; errors are logged as warnings and do not fail the create
- 2 new tests: `TestExtractParentIssueNumber` (table test covering 7 cases) and `TestLinkSubIssue_FakeRepo_Error`

## Stats

  Lines of code (Go, production): 11481 (+57)
  Lines of code (Go, tests):      15153 (+35)
  Words (documentation):          19043 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] Documentation reviewed for consistency

Closes #566