### PR TITLE
GH-571: Add mage stats:generator target for generation status reporting

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -280,6 +280,9 @@ func (Stats) Tokens() error { return newOrch().TokenStats() }
 // Outcomes prints a summary table of task outcome trailers from git history.
 func (Stats) Outcomes() error { return newOrch().Outcomes() }
 
+// Generator prints a live status report for the current generation run.
+func (Stats) Generator() error { return newOrch().GeneratorStats() }
+
 // --- Prompt targets ---
 
 // Measure prints the assembled measure prompt to stdout.

--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -1,0 +1,228 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package orchestrator
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+)
+
+// generatorIssueStats holds per-issue stats derived from labels and comments.
+type generatorIssueStats struct {
+	cobblerIssue
+	status    string  // "done", "failed", "in-progress", "pending"
+	costUSD   float64
+	durationS int
+	prds      []string
+}
+
+// GeneratorStats prints a status report for the current generation run.
+// It discovers active generation branches, fetches all task issues, parses
+// progress comments, and prints an issue table with aggregate totals.
+func (o *Orchestrator) GeneratorStats() error {
+	branches := o.listGenerationBranches()
+	if len(branches) == 0 {
+		fmt.Println("no active generation branches found")
+		return nil
+	}
+
+	// Prefer the configured branch; fall back to the first detected branch.
+	genBranch := o.cfg.Generation.Branch
+	if genBranch == "" {
+		genBranch = branches[0]
+	}
+
+	repo, err := detectGitHubRepo(".", o.cfg)
+	if err != nil || repo == "" {
+		return fmt.Errorf("detecting GitHub repo: %w", err)
+	}
+
+	issues, err := listAllCobblerIssues(repo, genBranch)
+	if err != nil {
+		return fmt.Errorf("listing cobbler issues for %s: %w", genBranch, err)
+	}
+	if len(issues) == 0 {
+		fmt.Printf("generation %s: no task issues found\n", genBranch)
+		return nil
+	}
+
+	// Collect per-issue stats.
+	rows := make([]generatorIssueStats, 0, len(issues))
+	var totalCost float64
+	var nDone, nFailed, nInProgress, nPending int
+	prdStatus := make(map[string]string) // prd name → highest-priority status
+
+	for _, iss := range issues {
+		s := generatorIssueStats{cobblerIssue: iss}
+
+		switch {
+		case iss.State == "closed" && !hasLabel(iss, "failed"):
+			s.status = "done"
+			nDone++
+		case iss.State == "closed":
+			s.status = "failed"
+			nFailed++
+		case hasLabel(iss, cobblerLabelInProgress):
+			s.status = "in-progress"
+			nInProgress++
+		default:
+			s.status = "pending"
+			nPending++
+		}
+
+		// Parse stitch progress comments for cost and duration.
+		comments, _ := fetchIssueComments(repo, iss.Number)
+		for _, c := range comments {
+			if p := parseStitchComment(c); p.costUSD > 0 {
+				s.costUSD += p.costUSD
+			}
+			if p := parseStitchComment(c); p.durationS > 0 {
+				s.durationS = p.durationS
+			}
+		}
+		totalCost += s.costUSD
+
+		// Extract PRD references and track coverage.
+		s.prds = extractPRDRefs(iss.Title + " " + iss.Description)
+		for _, prd := range s.prds {
+			existing := prdStatus[prd]
+			switch s.status {
+			case "in-progress":
+				prdStatus[prd] = "in-progress"
+			case "pending":
+				if existing == "" {
+					prdStatus[prd] = "pending"
+				}
+			case "done", "failed":
+				if existing == "" {
+					prdStatus[prd] = s.status
+				}
+			}
+		}
+
+		rows = append(rows, s)
+	}
+
+	sort.Slice(rows, func(i, j int) bool { return rows[i].Index < rows[j].Index })
+
+	// Header.
+	fmt.Printf("Generation: %s\n", genBranch)
+	if len(branches) > 1 {
+		fmt.Printf("Other branches: %s\n", strings.Join(branches[1:], ", "))
+	}
+	fmt.Printf("Tasks: %d done, %d in-progress, %d pending", nDone, nInProgress, nPending)
+	if nFailed > 0 {
+		fmt.Printf(", %d failed", nFailed)
+	}
+	fmt.Println()
+	fmt.Printf("Total cost: $%.2f\n\n", totalCost)
+
+	// Issue table.
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "#\tIdx\tStatus\tCost\tDuration\tTitle")
+	for _, r := range rows {
+		cost := "-"
+		if r.costUSD > 0 {
+			cost = fmt.Sprintf("$%.2f", r.costUSD)
+		}
+		dur := "-"
+		if r.durationS > 0 {
+			dur = formatDuration(r.durationS)
+		}
+		title := r.Title
+		if len(title) > 48 {
+			title = title[:45] + "..."
+		}
+		fmt.Fprintf(w, "%d\t%d\t%s\t%s\t%s\t%s\n",
+			r.Number, r.Index, r.status, cost, dur, title)
+	}
+	if err := w.Flush(); err != nil {
+		return err
+	}
+
+	// PRD coverage table.
+	if len(prdStatus) > 0 {
+		prds := make([]string, 0, len(prdStatus))
+		for prd := range prdStatus {
+			prds = append(prds, prd)
+		}
+		sort.Strings(prds)
+
+		fmt.Println()
+		pw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(pw, "PRD\tStatus")
+		for _, prd := range prds {
+			fmt.Fprintf(pw, "%s\t%s\n", prd, prdStatus[prd])
+		}
+		if err := pw.Flush(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// stitchCommentData holds metrics extracted from a stitch progress comment.
+type stitchCommentData struct {
+	costUSD   float64
+	durationS int
+}
+
+// parseStitchComment extracts cost and duration from a stitch progress comment
+// produced by closeStitchTask or failTask (GH-567 format):
+//
+//	"Stitch completed in 5m 32s. LOC delta: +45 prod, +17 test. Cost: $0.42."
+//	"Stitch failed after 2m 10s. Error: ..."
+func parseStitchComment(body string) stitchCommentData {
+	var d stitchCommentData
+
+	// Parse "Cost: $X.XX"
+	if i := strings.Index(body, "Cost: $"); i >= 0 {
+		rest := body[i+7:]
+		var costStr string
+		fmt.Sscanf(rest, "%s", &costStr)
+		costStr = strings.TrimRight(costStr, ".,;")
+		if v, err := strconv.ParseFloat(costStr, 64); err == nil {
+			d.costUSD = v
+		}
+	}
+
+	// Parse "in Xm Ys" or "after Xm Ys" for duration.
+	for _, marker := range []string{"in ", "after "} {
+		if i := strings.Index(body, marker); i >= 0 {
+			rest := body[i+len(marker):]
+			var mins, secs int
+			if n, _ := fmt.Sscanf(rest, "%dm %ds", &mins, &secs); n == 2 {
+				d.durationS = mins*60 + secs
+				break
+			}
+			if n, _ := fmt.Sscanf(rest, "%ds", &secs); n == 1 {
+				d.durationS = secs
+				break
+			}
+		}
+	}
+
+	return d
+}
+
+// extractPRDRefs returns deduplicated prd-* tokens found in text.
+func extractPRDRefs(text string) []string {
+	seen := make(map[string]bool)
+	var prds []string
+	for _, word := range strings.Fields(text) {
+		w := strings.ToLower(strings.Trim(word, ".,;:()[]`\"'"))
+		if strings.HasPrefix(w, "prd-") && len(w) > 4 {
+			if !seen[w] {
+				seen[w] = true
+				prds = append(prds, w)
+			}
+		}
+	}
+	return prds
+}

--- a/pkg/orchestrator/generator_stats_test.go
+++ b/pkg/orchestrator/generator_stats_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package orchestrator
+
+import "testing"
+
+// --- parseStitchComment (GH-571) ---
+
+func TestParseStitchComment_Completed(t *testing.T) {
+	t.Parallel()
+	body := "Stitch completed in 5m 32s. LOC delta: +45 prod, +17 test. Cost: $0.42."
+	d := parseStitchComment(body)
+	if d.costUSD != 0.42 {
+		t.Errorf("costUSD = %v, want 0.42", d.costUSD)
+	}
+	if d.durationS != 5*60+32 {
+		t.Errorf("durationS = %d, want %d", d.durationS, 5*60+32)
+	}
+}
+
+func TestParseStitchComment_Failed(t *testing.T) {
+	t.Parallel()
+	body := "Stitch failed after 2m 10s. Error: Claude failure."
+	d := parseStitchComment(body)
+	if d.durationS != 2*60+10 {
+		t.Errorf("durationS = %d, want %d", d.durationS, 2*60+10)
+	}
+	if d.costUSD != 0 {
+		t.Errorf("costUSD = %v, want 0", d.costUSD)
+	}
+}
+
+func TestParseStitchComment_SubMinuteDuration(t *testing.T) {
+	t.Parallel()
+	body := "Stitch completed in 45s. LOC delta: +0 prod, +0 test. Cost: $0.10."
+	d := parseStitchComment(body)
+	if d.durationS != 45 {
+		t.Errorf("durationS = %d, want 45", d.durationS)
+	}
+	if d.costUSD != 0.10 {
+		t.Errorf("costUSD = %v, want 0.10", d.costUSD)
+	}
+}
+
+func TestParseStitchComment_NoMatch(t *testing.T) {
+	t.Parallel()
+	d := parseStitchComment("unrelated comment text")
+	if d.costUSD != 0 || d.durationS != 0 {
+		t.Errorf("expected zero values, got cost=%v dur=%d", d.costUSD, d.durationS)
+	}
+}
+
+// --- extractPRDRefs (GH-571) ---
+
+func TestExtractPRDRefs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		text string
+		want []string
+	}{
+		{
+			text: "Implement prd-auth-flow for login",
+			want: []string{"prd-auth-flow"},
+		},
+		{
+			text: "Covers prd-user-model, prd-auth-flow.",
+			want: []string{"prd-user-model", "prd-auth-flow"},
+		},
+		{
+			text: "no prd references here",
+			want: nil,
+		},
+		{
+			text: "prd- alone is not a ref",
+			want: nil,
+		},
+		{
+			// Duplicates should be deduplicated.
+			text: "prd-foo prd-bar prd-foo",
+			want: []string{"prd-foo", "prd-bar"},
+		},
+	}
+	for _, tc := range tests {
+		got := extractPRDRefs(tc.text)
+		if len(got) != len(tc.want) {
+			t.Errorf("extractPRDRefs(%q): got %v, want %v", tc.text, got, tc.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != tc.want[i] {
+				t.Errorf("extractPRDRefs(%q)[%d]: got %q, want %q", tc.text, i, got[i], tc.want[i])
+			}
+		}
+	}
+}
+
+// --- listAllCobblerIssues / fetchIssueComments (GH-571) ---
+
+// TestListAllCobblerIssues_FakeRepo_Error verifies listAllCobblerIssues returns
+// an error (not panic) when the GitHub CLI fails on a fake repo (GH-571).
+func TestListAllCobblerIssues_FakeRepo_Error(t *testing.T) {
+	t.Parallel()
+	_, err := listAllCobblerIssues("fake/repo-that-does-not-exist", "gen-test")
+	if err == nil {
+		t.Error("listAllCobblerIssues with fake repo must return an error")
+	}
+}
+
+// TestFetchIssueComments_FakeRepo_Error verifies fetchIssueComments returns
+// an error (not panic) when the GitHub CLI fails on a fake repo (GH-571).
+func TestFetchIssueComments_FakeRepo_Error(t *testing.T) {
+	t.Parallel()
+	_, err := fetchIssueComments("fake/repo-that-does-not-exist", 99999)
+	if err == nil {
+		t.Error("fetchIssueComments with fake repo must return an error")
+	}
+}
+
+// TestParseCobblerIssuesJSON_State verifies that the State field is populated
+// from the JSON response (GH-571).
+func TestParseCobblerIssuesJSON_State(t *testing.T) {
+	t.Parallel()
+	data := []byte(`[
+		{"number": 1, "title": "Open task", "state": "open", "body": "", "labels": []},
+		{"number": 2, "title": "Done task", "state": "closed", "body": "", "labels": []}
+	]`)
+	issues, err := parseCobblerIssuesJSON(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("want 2 issues, got %d", len(issues))
+	}
+	if issues[0].State != "open" {
+		t.Errorf("issues[0].State = %q, want \"open\"", issues[0].State)
+	}
+	if issues[1].State != "closed" {
+		t.Errorf("issues[1].State = %q, want \"closed\"", issues[1].State)
+	}
+}

--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -19,6 +19,7 @@ import (
 type cobblerIssue struct {
 	Number      int    // GitHub issue number
 	Title       string // Issue title
+	State       string // "open" or "closed"
 	Index       int    // cobbler_index from front-matter
 	DependsOn   int    // cobbler_depends_on (-1 = no dependency)
 	Generation  string // cobbler_generation label value
@@ -350,12 +351,51 @@ func listOpenCobblerIssues(repo, generation string) ([]cobblerIssue, error) {
 	return parseCobblerIssuesJSON(out)
 }
 
+// listAllCobblerIssues returns all GitHub issues (open and closed) for a
+// generation. Used by GeneratorStats to report completed tasks.
+func listAllCobblerIssues(repo, generation string) ([]cobblerIssue, error) {
+	label := cobblerGenLabel(generation)
+	out, err := exec.Command(binGh, "api",
+		"--method", "GET",
+		fmt.Sprintf("repos/%s/issues", repo),
+		"-f", "state=all",
+		"-f", "labels="+label,
+		"-f", "per_page=100",
+	).Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh api repos issues: %w", err)
+	}
+	return parseCobblerIssuesJSON(out)
+}
+
+// fetchIssueComments returns the body text of all comments on the given issue.
+func fetchIssueComments(repo string, number int) ([]string, error) {
+	out, err := exec.Command(binGh, "api",
+		fmt.Sprintf("repos/%s/issues/%d/comments", repo, number),
+	).Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh api issue comments for #%d: %w", number, err)
+	}
+	var raw []struct {
+		Body string `json:"body"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parsing issue comments for #%d: %w", number, err)
+	}
+	bodies := make([]string, 0, len(raw))
+	for _, r := range raw {
+		bodies = append(bodies, r.Body)
+	}
+	return bodies, nil
+}
+
 // parseCobblerIssuesJSON parses the JSON output from the GitHub REST API issues
 // endpoint into a slice of cobblerIssue structs.
 func parseCobblerIssuesJSON(data []byte) ([]cobblerIssue, error) {
 	var raw []struct {
 		Number int    `json:"number"`
 		Title  string `json:"title"`
+		State  string `json:"state"`
 		Body   string `json:"body"`
 		Labels []struct {
 			Name string `json:"name"`
@@ -375,6 +415,7 @@ func parseCobblerIssuesJSON(data []byte) ([]cobblerIssue, error) {
 		issues = append(issues, cobblerIssue{
 			Number:      r.Number,
 			Title:       r.Title,
+			State:       r.State,
 			Index:       fm.Index,
 			DependsOn:   fm.DependsOn,
 			Generation:  fm.Generation,


### PR DESCRIPTION
## Summary

Adds `mage stats:generator`, which discovers the active generation branch, fetches all task issues (open and closed), parses stitch progress comments for cost and duration, and prints an issue table with aggregate totals and a PRD coverage summary.

## Changes

- `cobblerIssue.State` field + `parseCobblerIssuesJSON` now populates it from the GitHub API response
- `listAllCobblerIssues` (state=all) and `fetchIssueComments` added to `issues_gh.go`
- `generator_stats.go`: `GeneratorStats()`, `parseStitchComment()`, `extractPRDRefs()`, `generatorIssueStats` type
- `mage stats:generator` wired in magefile
- 8 new tests: comment parsing (completed, failed, sub-minute, no-match), PRD extraction (dedup, edge cases), state field, fake-repo error paths

## Stats

  Lines of code (Go, production): 11750 (+269)
  Lines of code (Go, tests):      15294 (+141)
  Words (documentation):          19043 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] Documentation reviewed for consistency

Closes #571