### PR TITLE
GH-534: Measure: use road-map to select PRD instead of scanning all source files

### DIFF
--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -246,6 +246,17 @@ type CobblerConfig struct {
 	// MeasureExcludeSource is true. When empty, all GoSourceDirs files
 	// are included.
 	MeasureSourcePatterns string `yaml:"measure_source_patterns"`
+
+	// MeasureRoadmapSource enables automatic source filtering based on the
+	// next pending use case in docs/road-map.yaml. When true, the orchestrator
+	// reads road-map.yaml, identifies the first use case whose status is not
+	// "done", parses its touchpoints to extract package directory paths, and
+	// restricts the measure prompt to source files under those directories.
+	// This bounds prompt size by the PRD's dependency graph rather than the
+	// full codebase. Ignored when MeasureExcludeSource is true or when
+	// MeasureSourcePatterns is already set (manual patterns take priority).
+	// Default false; existing behaviour is preserved when false.
+	MeasureRoadmapSource bool `yaml:"measure_roadmap_source"`
 }
 
 // PodmanConfig holds settings for the podman container runtime.

--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -1223,6 +1223,96 @@ func prdIDsFromUseCases(useCases []*UseCaseDoc) map[string]bool {
 	return ids
 }
 
+// ---------------------------------------------------------------------------
+// Road-map-driven source selection (GH-534)
+// ---------------------------------------------------------------------------
+
+// selectNextPendingUseCase reads docs/road-map.yaml and returns the first
+// use case whose status is not "done". When a release filter is configured
+// in cfg (via Releases or Release), only releases in scope are considered.
+// Returns (nil, nil) when all use cases are done or the road-map is absent.
+func selectNextPendingUseCase(cfg ProjectConfig) (*UseCaseDoc, error) {
+	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
+	if rm == nil {
+		logf("selectNextPendingUseCase: docs/road-map.yaml not found or empty")
+		return nil, nil
+	}
+
+	rf := newReleaseFilter(cfg.Releases, cfg.Release)
+	for i := range rm.Releases {
+		rel := &rm.Releases[i]
+		// Skip releases outside the configured scope.
+		if rf.active() {
+			if rf.ReleaseSet != nil && !rf.ReleaseSet[rel.Version] {
+				continue
+			}
+			if rf.ReleaseSet == nil && rel.Version > rf.MaxRelease {
+				continue
+			}
+		}
+		for _, uc := range rel.UseCases {
+			if strings.EqualFold(uc.Status, "done") {
+				continue
+			}
+			path := filepath.Join("docs", "specs", "use-cases", uc.ID+".yaml")
+			doc := loadYAML[UseCaseDoc](path)
+			if doc == nil {
+				logf("selectNextPendingUseCase: use case file not found: %s", path)
+				return nil, nil
+			}
+			doc.File = path
+			logf("selectNextPendingUseCase: next pending UC=%s status=%s", uc.ID, uc.Status)
+			return doc, nil
+		}
+	}
+	logf("selectNextPendingUseCase: all use cases done")
+	return nil, nil
+}
+
+// parseTouchpointPackages extracts Go package directory paths from a use
+// case's touchpoints. Each touchpoint value is expected to use the format:
+//
+//	"<pkg-path> — <prd-id> R1, R2"   (em-dash U+2014 or en-dash U+2013)
+//
+// where <pkg-path> may be a single directory or a comma-separated list.
+// Only segments that contain a "/" are treated as paths; others are ignored.
+// The returned list is deduplicated and sorted.
+func parseTouchpointPackages(touchpoints []map[string]string) []string {
+	seen := make(map[string]bool)
+	for _, m := range touchpoints {
+		for _, val := range m {
+			// Split on em-dash (U+2014) or en-dash (U+2013), with any surrounding
+			// whitespace. Take the left-hand side as the potential package path(s).
+			var left string
+			if idx := strings.Index(val, "\u2014"); idx >= 0 {
+				left = strings.TrimSpace(val[:idx])
+			} else if idx := strings.Index(val, "\u2013"); idx >= 0 {
+				left = strings.TrimSpace(val[:idx])
+			} else {
+				continue
+			}
+			// left may be comma-separated (e.g., "cmd/cp, cmd/mv").
+			for _, part := range strings.Split(left, ",") {
+				part = strings.TrimSpace(part)
+				// Only accept path-like segments (must contain "/").
+				if part == "" || !strings.Contains(part, "/") {
+					continue
+				}
+				seen[strings.TrimSuffix(part, "/")] = true
+			}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
 // loadContextFileInto loads a single file into the appropriate field
 // of ctx based on its classified category. Applies release filtering
 // for use_case and test_suite categories. Does not handle constitution

--- a/pkg/orchestrator/context_test.go
+++ b/pkg/orchestrator/context_test.go
@@ -1488,3 +1488,219 @@ func TestBuildProjectContext_SourcePatternsEmpty(t *testing.T) {
 		t.Errorf("expected >=2 source files with empty SourcePatterns, got %d", len(ctx.SourceCode))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// parseTouchpointPackages tests (GH-534)
+// ---------------------------------------------------------------------------
+
+func TestParseTouchpointPackages_EmDash(t *testing.T) {
+	t.Parallel()
+	touchpoints := []map[string]string{
+		{"T1": "cmd/du \u2014 prd009-du R1, R2, R3"},
+		{"T2": "pkg/sys \u2014 prd003-sys"},
+	}
+	got := parseTouchpointPackages(touchpoints)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 packages, got %v", got)
+	}
+	if got[0] != "cmd/du" || got[1] != "pkg/sys" {
+		t.Errorf("unexpected packages: %v", got)
+	}
+}
+
+func TestParseTouchpointPackages_EnDash(t *testing.T) {
+	t.Parallel()
+	touchpoints := []map[string]string{
+		{"T1": "pkg/format \u2013 prd007-format R1"},
+	}
+	got := parseTouchpointPackages(touchpoints)
+	if len(got) != 1 || got[0] != "pkg/format" {
+		t.Errorf("expected [pkg/format], got %v", got)
+	}
+}
+
+func TestParseTouchpointPackages_MultiplePathsCommaSeparated(t *testing.T) {
+	t.Parallel()
+	touchpoints := []map[string]string{
+		{"T1": "cmd/cp, cmd/mv \u2014 prd001-cp R1"},
+	}
+	got := parseTouchpointPackages(touchpoints)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 packages, got %v", got)
+	}
+	if got[0] != "cmd/cp" || got[1] != "cmd/mv" {
+		t.Errorf("unexpected packages: %v", got)
+	}
+}
+
+func TestParseTouchpointPackages_NoDash_Ignored(t *testing.T) {
+	t.Parallel()
+	// Cobbler-style touchpoints without em/en-dash should yield no packages.
+	touchpoints := []map[string]string{
+		{"T1": "Config (workflow fields): prd001-orchestrator-core R1"},
+		{"T2": "Prompt templates: prd003-cobbler-workflows R5"},
+	}
+	got := parseTouchpointPackages(touchpoints)
+	if len(got) != 0 {
+		t.Errorf("expected no packages for colon-separated touchpoints, got %v", got)
+	}
+}
+
+func TestParseTouchpointPackages_TrailingSlashNormalized(t *testing.T) {
+	t.Parallel()
+	touchpoints := []map[string]string{
+		{"T1": "pkg/util/ \u2014 prd002-util R1"},
+	}
+	got := parseTouchpointPackages(touchpoints)
+	if len(got) != 1 || got[0] != "pkg/util" {
+		t.Errorf("expected [pkg/util] (trailing slash stripped), got %v", got)
+	}
+}
+
+func TestParseTouchpointPackages_Empty(t *testing.T) {
+	t.Parallel()
+	if got := parseTouchpointPackages(nil); got != nil {
+		t.Errorf("expected nil for nil input, got %v", got)
+	}
+	if got := parseTouchpointPackages([]map[string]string{}); got != nil {
+		t.Errorf("expected nil for empty input, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// selectNextPendingUseCase tests (GH-534)
+// ---------------------------------------------------------------------------
+
+func TestSelectNextPendingUseCase_AllDone(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	roadmap := `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    name: Release 1
+    status: done
+    use_cases:
+      - id: rel01.0-uc001-init
+        status: done
+`
+	if err := os.WriteFile("docs/road-map.yaml", []byte(roadmap), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	uc, err := selectNextPendingUseCase(ProjectConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uc != nil {
+		t.Errorf("expected nil for all-done road-map, got %+v", uc)
+	}
+}
+
+func TestSelectNextPendingUseCase_PendingFound(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	roadmap := `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    name: Release 1
+    status: in_progress
+    use_cases:
+      - id: rel01.0-uc001-init
+        status: done
+      - id: rel01.0-uc002-workflow
+        status: in_progress
+`
+	ucContent := `id: rel01.0-uc002-workflow
+title: Workflow
+touchpoints:
+  - T1: "pkg/workflow \u2014 prd003-wf R1"
+`
+	if err := os.WriteFile("docs/road-map.yaml", []byte(roadmap), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("docs/specs/use-cases/rel01.0-uc002-workflow.yaml", []byte(ucContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	uc, err := selectNextPendingUseCase(ProjectConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uc == nil {
+		t.Fatal("expected non-nil use case")
+	}
+	if uc.ID != "rel01.0-uc002-workflow" {
+		t.Errorf("expected uc002-workflow, got %s", uc.ID)
+	}
+}
+
+func TestSelectNextPendingUseCase_ReleaseFilter(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	roadmap := `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    name: Release 1
+    status: done
+    use_cases:
+      - id: rel01.0-uc001-init
+        status: done
+  - version: "02.0"
+    name: Release 2
+    status: in_progress
+    use_cases:
+      - id: rel02.0-uc001-ext
+        status: not started
+`
+	ucContent := `id: rel02.0-uc001-ext
+title: Extension
+touchpoints:
+  - T1: "pkg/ext \u2014 prd004-ext R1"
+`
+	if err := os.WriteFile("docs/road-map.yaml", []byte(roadmap), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("docs/specs/use-cases/rel02.0-uc001-ext.yaml", []byte(ucContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without release filter, uc002 is the next pending (in release 02.0).
+	uc, err := selectNextPendingUseCase(ProjectConfig{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uc == nil || uc.ID != "rel02.0-uc001-ext" {
+		t.Errorf("expected rel02.0-uc001-ext without filter, got %v", uc)
+	}
+
+	// With release filter ["01.0"], release 02.0 is excluded → no pending UC.
+	uc2, err2 := selectNextPendingUseCase(ProjectConfig{Releases: []string{"01.0"}})
+	if err2 != nil {
+		t.Fatal(err2)
+	}
+	if uc2 != nil {
+		t.Errorf("expected nil with release filter [01.0], got %+v", uc2)
+	}
+}
+
+func TestSelectNextPendingUseCase_MissingRoadmap(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	// Remove the road-map written by setupContextTestDir.
+	os.Remove("docs/road-map.yaml")
+
+	uc, err := selectNextPendingUseCase(ProjectConfig{})
+	if err != nil {
+		t.Fatalf("expected nil error for missing road-map, got %v", err)
+	}
+	if uc != nil {
+		t.Errorf("expected nil for missing road-map, got %+v", uc)
+	}
+}

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -360,6 +360,29 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 		logf("buildMeasurePrompt: measure_source_patterns set from config")
 	}
 
+	// Auto-derive SourcePatterns from the road-map when MeasureRoadmapSource
+	// is enabled and no manual patterns are already set (GH-534).
+	if o.cfg.Cobbler.MeasureRoadmapSource && !phaseCtx.ExcludeSource && phaseCtx.SourcePatterns == "" {
+		uc, err := selectNextPendingUseCase(o.cfg.Project)
+		if err != nil {
+			logf("buildMeasurePrompt: road-map source selection error: %v", err)
+		} else if uc != nil {
+			pkgPaths := parseTouchpointPackages(uc.Touchpoints)
+			if len(pkgPaths) > 0 {
+				var patterns []string
+				for _, p := range pkgPaths {
+					patterns = append(patterns, p+"/**/*.go")
+				}
+				phaseCtx.SourcePatterns = strings.Join(patterns, "\n")
+				logf("buildMeasurePrompt: road-map source: UC=%s packages=%v", uc.ID, pkgPaths)
+			} else {
+				logf("buildMeasurePrompt: road-map source: UC=%s has no package touchpoints, loading all source", uc.ID)
+			}
+		} else {
+			logf("buildMeasurePrompt: road-map source: all use cases done, loading all source")
+		}
+	}
+
 	projectCtx, ctxErr := buildProjectContext(existingIssues, o.cfg.Project, phaseCtx)
 	if ctxErr != nil {
 		logf("buildMeasurePrompt: buildProjectContext error: %v", ctxErr)


### PR DESCRIPTION
## Summary

Adds road-map-driven source filtering for the measure prompt. When `measure_roadmap_source: true` is set in `configuration.yaml`, the orchestrator reads `docs/road-map.yaml`, finds the first pending use case, parses its touchpoints to extract package paths, and restricts the measure context to only those Go source files. This bounds prompt size by the PRD's dependency graph rather than the full codebase.

## Changes

- `config.go`: Added `MeasureRoadmapSource bool` to `CobblerConfig`
- `context.go`: Added `selectNextPendingUseCase()` — reads road-map, finds first UC with status ≠ done, respects Releases/Release filter, loads and returns the `UseCaseDoc`
- `context.go`: Added `parseTouchpointPackages()` — extracts package directory paths from UC touchpoints using em-dash (U+2014) or en-dash (U+2013) separator; ignores cobbler-style colon-format touchpoints
- `measure.go`: Wired into `buildMeasurePrompt()` — when `MeasureRoadmapSource=true`, auto-computes `SourcePatterns` from the next pending UC before calling `buildProjectContext`; manual `MeasureSourcePatterns` and file-level phase context take priority; gracefully no-ops when all UCs are done or road-map is absent
- `context_test.go`: 10 new tests covering em/en-dash parsing, comma-separated paths, colon-style (no-op), release filtering, missing road-map

## Stats

```
go_loc_prod: 11928 (+~100)
go_loc_test: 15598 (+~160)
spec_words:  19043 (unchanged)
```

## Test plan

- [x] `go test ./pkg/orchestrator/ -count=1` passes (all tests)
- [x] 10 new unit tests for `parseTouchpointPackages` and `selectNextPendingUseCase`
- [x] Build clean

Closes #534