### PR TITLE
GH-578: Upgrade measuring placeholder in-place for single-issue cycles

### DIFF
--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -228,6 +228,41 @@ func closeMeasuringPlaceholder(repo string, number int) {
 	logf("closeMeasuringPlaceholder: closed #%d", number)
 }
 
+// upgradeMeasuringPlaceholder converts the transient measuring placeholder
+// into the task issue in-place. It edits the placeholder's title and body
+// to match the proposed issue, adds the cobbler-gen label so stitch can
+// pick it up, and links it as a sub-issue of the parent generation issue
+// if the generation name encodes one (GH-578).
+func upgradeMeasuringPlaceholder(repo string, number int, generation string, issue proposedIssue) error {
+	body := formatIssueFrontMatter(generation, issue.Index, issue.Dependency) + issue.Description
+
+	// Edit title and body in one command.
+	if err := exec.Command(binGh, "issue", "edit",
+		"--repo", repo,
+		fmt.Sprintf("%d", number),
+		"--title", issue.Title,
+		"--body", body,
+	).Run(); err != nil {
+		return fmt.Errorf("gh issue edit placeholder #%d: %w", number, err)
+	}
+
+	// Add cobbler-gen label so stitch can pick it up.
+	if err := addIssueLabel(repo, number, cobblerGenLabel(generation)); err != nil {
+		return fmt.Errorf("adding gen label to #%d: %w", number, err)
+	}
+
+	logf("upgradeMeasuringPlaceholder: upgraded #%d %q gen=%s index=%d dep=%d",
+		number, issue.Title, generation, issue.Index, issue.Dependency)
+
+	// Link as sub-issue of the parent if the generation name encodes one.
+	if parentNumber := extractParentIssueNumber(generation); parentNumber > 0 {
+		if err := linkSubIssue(repo, parentNumber, number); err != nil {
+			logf("upgradeMeasuringPlaceholder: linkSubIssue warning for #%d -> parent #%d: %v", number, parentNumber, err)
+		}
+	}
+	return nil
+}
+
 // createCobblerIssue creates a GitHub issue on repo for the given generation
 // and proposedIssue. Returns the GitHub issue number.
 //

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -188,6 +188,7 @@ func (o *Orchestrator) RunMeasure() error {
 		var createdIDs []string
 		var lastOutputFile string
 		var lastValidationErrors []string // errors from previous attempt, fed back into retry prompt
+		placeholderUpgraded := false     // set when importIssues upgraded the placeholder in-place
 
 		// Attempt loop: try Claude + import, retrying on validation failure.
 		for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -274,7 +275,7 @@ func (o *Orchestrator) RunMeasure() error {
 
 			var importErr error
 			var validationErrs []string
-			createdIDs, validationErrs, importErr = o.importIssues(outputFile, repo, generation)
+			createdIDs, validationErrs, importErr = o.importIssues(outputFile, repo, generation, placeholderNum)
 			if importErr != nil {
 				logf("iteration %d import failed: %v", i+1, importErr)
 				if attempt < maxRetries {
@@ -285,7 +286,7 @@ func (o *Orchestrator) RunMeasure() error {
 				// Retries exhausted: accept with warning (R5).
 				logf("iteration %d retries exhausted, accepting last result with warnings", i+1)
 				var forceErr error
-				createdIDs, forceErr = o.importIssuesForce(outputFile, repo, generation)
+				createdIDs, forceErr = o.importIssuesForce(outputFile, repo, generation, placeholderNum)
 				if forceErr != nil {
 					logf("iteration %d force import failed: %v", i+1, forceErr)
 				}
@@ -295,8 +296,18 @@ func (o *Orchestrator) RunMeasure() error {
 
 		logf("iteration %d imported %d issue(s)", i+1, len(createdIDs))
 
-		// Close the placeholder now that the iteration is complete (GH-568).
-		if placeholderNum > 0 {
+		// Track whether the placeholder was upgraded in-place (GH-578).
+		phStr := fmt.Sprintf("%d", placeholderNum)
+		for _, id := range createdIDs {
+			if id == phStr {
+				placeholderUpgraded = true
+				break
+			}
+		}
+
+		// Close the placeholder only when it was not upgraded in-place (GH-578).
+		// An upgraded placeholder became the task issue; closing it destroys the task.
+		if placeholderNum > 0 && !placeholderUpgraded {
 			closeMeasuringPlaceholder(repo, placeholderNum)
 		}
 
@@ -452,19 +463,22 @@ type proposedIssue struct {
 
 // importIssues imports proposed issues from a YAML file into GitHub. It returns
 // the created issue IDs, any validation error strings (for retry feedback), and
-// a non-nil error when validation fails in enforcing mode.
-func (o *Orchestrator) importIssues(yamlFile, repo, generation string) ([]string, []string, error) {
-	return o.importIssuesImpl(yamlFile, repo, generation, false)
+// a non-nil error when validation fails in enforcing mode. ph is the measuring
+// placeholder issue number; when ph > 0 and exactly one issue is proposed, the
+// placeholder is upgraded in-place instead of creating a new issue (GH-578).
+func (o *Orchestrator) importIssues(yamlFile, repo, generation string, ph int) ([]string, []string, error) {
+	return o.importIssuesImpl(yamlFile, repo, generation, false, ph)
 }
 
 // importIssuesForce imports issues bypassing enforcing validation. Used when
-// retries are exhausted to accept the last result with warnings (R5).
-func (o *Orchestrator) importIssuesForce(yamlFile, repo, generation string) ([]string, error) {
-	ids, _, err := o.importIssuesImpl(yamlFile, repo, generation, true)
+// retries are exhausted to accept the last result with warnings (R5). ph is
+// the placeholder number passed through to importIssuesImpl (GH-578).
+func (o *Orchestrator) importIssuesForce(yamlFile, repo, generation string, ph int) ([]string, error) {
+	ids, _, err := o.importIssuesImpl(yamlFile, repo, generation, true, ph)
 	return ids, err
 }
 
-func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipEnforcement bool) ([]string, []string, error) {
+func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipEnforcement bool, ph int) ([]string, []string, error) {
 	logf("importIssues: reading %s", yamlFile)
 	data, err := os.ReadFile(yamlFile)
 	if err != nil {
@@ -495,17 +509,29 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 			len(vr.Errors), strings.Join(vr.Errors, "; "))
 	}
 
-	// Create all issues on GitHub. Dependencies are encoded in the front-matter;
-	// promoteReadyIssues (called by pickReadyIssue) resolves the DAG at pick time.
+	// Create all issues on GitHub. When a placeholder number is given and exactly
+	// one issue is proposed, upgrade the placeholder in-place instead of creating
+	// a new issue, eliminating the two-issue dance (GH-578).
 	var ids []string
-	for _, issue := range issues {
-		logf("importIssues: creating task %d: %s (dep=%d)", issue.Index, issue.Title, issue.Dependency)
-		ghNum, err := createCobblerIssue(repo, generation, issue)
-		if err != nil {
-			logf("importIssues: createCobblerIssue failed for %q: %v", issue.Title, err)
-			continue
+	upgraded := false
+	if ph > 0 && len(issues) == 1 {
+		if err := upgradeMeasuringPlaceholder(repo, ph, generation, issues[0]); err != nil {
+			logf("importIssues: upgradeMeasuringPlaceholder #%d failed, falling back to createCobblerIssue: %v", ph, err)
+		} else {
+			ids = append(ids, fmt.Sprintf("%d", ph))
+			upgraded = true
 		}
-		ids = append(ids, fmt.Sprintf("%d", ghNum))
+	}
+	if !upgraded {
+		for _, issue := range issues {
+			logf("importIssues: creating task %d: %s (dep=%d)", issue.Index, issue.Title, issue.Dependency)
+			ghNum, err := createCobblerIssue(repo, generation, issue)
+			if err != nil {
+				logf("importIssues: createCobblerIssue failed for %q: %v", issue.Title, err)
+				continue
+			}
+			ids = append(ids, fmt.Sprintf("%d", ghNum))
+		}
 	}
 
 	if len(ids) > 0 {

--- a/pkg/orchestrator/measure_test.go
+++ b/pkg/orchestrator/measure_test.go
@@ -1104,7 +1104,7 @@ func TestBuildMeasurePrompt_GoldenExample(t *testing.T) {
 func TestImportIssuesImpl_NonexistentFile(t *testing.T) {
 	t.Parallel()
 	o := New(Config{})
-	_, _, err := o.importIssuesImpl("/nonexistent/file.yaml", "owner/repo", "gen", false)
+	_, _, err := o.importIssuesImpl("/nonexistent/file.yaml", "owner/repo", "gen", false, 0)
 	if err == nil {
 		t.Error("expected error for nonexistent file")
 	}
@@ -1117,7 +1117,7 @@ func TestImportIssuesImpl_InvalidYAML(t *testing.T) {
 	os.WriteFile(yamlFile, []byte("{{{not valid yaml"), 0o644)
 
 	o := New(Config{})
-	_, _, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", false)
+	_, _, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", false, 0)
 	if err == nil {
 		t.Error("expected error for invalid YAML")
 	}
@@ -1137,7 +1137,7 @@ func TestImportIssuesImpl_EmptyIssueList(t *testing.T) {
 	o := New(cfg)
 
 	// Empty list should not error — no issues to create, no GitHub calls.
-	ids, _, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", false)
+	ids, _, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", false, 0)
 	if err != nil {
 		t.Fatalf("importIssuesImpl() error = %v", err)
 	}
@@ -1172,7 +1172,7 @@ acceptance_criteria:
 	cfg.Cobbler.EnforceMeasureValidation = true
 	o := New(cfg)
 
-	_, validationErrs, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", false)
+	_, validationErrs, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", false, 0)
 	if err == nil {
 		t.Error("expected validation error in enforcing mode")
 	}
@@ -1213,11 +1213,90 @@ acceptance_criteria:
 	// skipEnforcement=true should bypass validation errors.
 	// This will fail at createCobblerIssue (no real GitHub), but should NOT
 	// fail at validation.
-	ids, _, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", true)
+	ids, _, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", true, 0)
 	if err != nil {
 		t.Fatalf("importIssuesImpl() with skipEnforcement should not return validation error, got: %v", err)
 	}
 	// ids will be empty because createCobblerIssue fails (no GitHub), but no error returned.
+	_ = ids
+}
+
+// --- importIssuesImpl upgrade path (GH-578) ---
+
+// singleDocIssue returns YAML for one minimal documentation issue.
+func singleDocIssue(index int, title string) []proposedIssue {
+	desc := "deliverable_type: documentation\nrequirements:\n  - id: R1\n    text: r1\n  - id: R2\n    text: r2\nacceptance_criteria:\n  - id: AC1\n    text: ac1\n  - id: AC2\n    text: ac2\n  - id: AC3\n    text: ac3\n"
+	return []proposedIssue{{Index: index, Title: title, Description: desc}}
+}
+
+// TestImportIssuesImpl_UpgradePath_PhZero_SingleIssue verifies that ph=0
+// skips the upgrade path even when exactly one issue is proposed, falling
+// through to createCobblerIssue (which fails gracefully without real GitHub).
+func TestImportIssuesImpl_UpgradePath_PhZero_SingleIssue(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlFile := filepath.Join(dir, "issues.yaml")
+	data, _ := yaml.Marshal(singleDocIssue(1, "only task"))
+	os.WriteFile(yamlFile, data, 0o644)
+
+	cfg := Config{}
+	cfg.Cobbler.Dir = dir
+	o := New(cfg)
+
+	ids, _, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", false, 0)
+	if err != nil {
+		t.Fatalf("importIssuesImpl() unexpected error: %v", err)
+	}
+	// createCobblerIssue fails (no real GitHub); ids empty is expected.
+	_ = ids
+}
+
+// TestImportIssuesImpl_UpgradePath_PhPositive_SingleIssue verifies that when
+// ph > 0 and exactly one issue is proposed, the upgrade path is attempted.
+// Since gh is not available, upgradeMeasuringPlaceholder fails and the fallback
+// createCobblerIssue is invoked. Both fail gracefully; no top-level error.
+func TestImportIssuesImpl_UpgradePath_PhPositive_SingleIssue(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlFile := filepath.Join(dir, "issues.yaml")
+	data, _ := yaml.Marshal(singleDocIssue(1, "only task"))
+	os.WriteFile(yamlFile, data, 0o644)
+
+	cfg := Config{}
+	cfg.Cobbler.Dir = dir
+	o := New(cfg)
+
+	// ph=99 triggers the upgrade path; both gh calls fail without real GitHub.
+	ids, _, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", false, 99)
+	if err != nil {
+		t.Fatalf("importIssuesImpl() unexpected error: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("expected 0 ids when gh unavailable, got %d", len(ids))
+	}
+}
+
+// TestImportIssuesImpl_UpgradePath_PhPositive_MultipleIssues verifies that when
+// ph > 0 but more than one issue is proposed, the upgrade path is skipped and
+// createCobblerIssue is invoked for each issue (fails gracefully without gh).
+func TestImportIssuesImpl_UpgradePath_PhPositive_MultipleIssues(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlFile := filepath.Join(dir, "issues.yaml")
+	issues := append(singleDocIssue(1, "task one"), singleDocIssue(2, "task two")...)
+	data, _ := yaml.Marshal(issues)
+	os.WriteFile(yamlFile, data, 0o644)
+
+	cfg := Config{}
+	cfg.Cobbler.Dir = dir
+	o := New(cfg)
+
+	// ph=42 but 2 issues: upgrade path must not be taken.
+	ids, _, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", false, 42)
+	if err != nil {
+		t.Fatalf("importIssuesImpl() unexpected error: %v", err)
+	}
+	// createCobblerIssue fails (no real GitHub); ids empty is expected.
 	_ = ids
 }
 


### PR DESCRIPTION
## Summary

Replaces the two-issue dance (create placeholder → close placeholder + create task) with an in-place upgrade: when Claude proposes exactly one issue, the measuring placeholder is edited to become the task issue, eliminating a superfluous close+create round-trip.

## Changes

- `issues_gh.go`: add `upgradeMeasuringPlaceholder` — edits placeholder title/body, adds cobbler-gen label, links as sub-issue if generation encodes a parent
- `measure.go`: add `ph int` to `importIssues`, `importIssuesForce`, `importIssuesImpl`; upgrade path taken when `ph > 0 && len(issues) == 1`; falls back to `createCobblerIssue` on upgrade failure; `closeMeasuringPlaceholder` skipped when placeholder was upgraded
- `measure_test.go`: 3 new upgrade-path tests; 5 existing call sites updated with `ph=0`

## Stats

```
Lines of code (Go, production): 11989 (+61)
Lines of code (Go, tests):      16043 (+79)
Words (documentation):          19043 (0)
```

## Test plan

- [x] `go test ./pkg/orchestrator/` passes
- [x] New tests cover ph=0, ph>0 single-issue, ph>0 multi-issue paths

Closes #578