### PR TITLE
GH-616: Exclude test files from measure prompt

### DIFF
--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -257,6 +257,14 @@ type CobblerConfig struct {
 	// MeasureSourcePatterns is already set (manual patterns take priority).
 	// Default false; existing behaviour is preserved when false.
 	MeasureRoadmapSource bool `yaml:"measure_roadmap_source"`
+
+	// MeasureExcludeTests excludes *_test.go files from the measure prompt
+	// context. Test files are consumers of the API, not providers; the measure
+	// agent needs to know what is tested but not how tests are implemented.
+	// Default true. Use a pointer so nil (absent) is treated as true and an
+	// explicit false opts out. Set measure_exclude_tests: false to restore
+	// the old behaviour of including test files.
+	MeasureExcludeTests *bool `yaml:"measure_exclude_tests"`
 }
 
 // PodmanConfig holds settings for the podman container runtime.
@@ -323,13 +331,24 @@ type Config struct {
 // DefaultConfigFile is the conventional configuration filename.
 const DefaultConfigFile = "configuration.yaml"
 
+// effectiveMeasureExcludeTests returns whether *_test.go files should be
+// excluded from the measure prompt. Nil (field absent in YAML) defaults to
+// true; an explicit false opts out.
+func (c *CobblerConfig) effectiveMeasureExcludeTests() bool {
+	if c.MeasureExcludeTests == nil {
+		return true
+	}
+	return *c.MeasureExcludeTests
+}
+
 // DefaultConfig returns a Config populated with all default values.
 // Project-specific fields (ModulePath, BinaryName, etc.) are left empty;
 // the caller fills them in or the user edits the generated file.
 func DefaultConfig() Config {
 	t := true
 	cfg := Config{
-		Claude: ClaudeConfig{SilenceAgent: &t},
+		Claude:  ClaudeConfig{SilenceAgent: &t},
+		Cobbler: CobblerConfig{MeasureExcludeTests: &t},
 	}
 	cfg.applyDefaults()
 	return cfg

--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -34,6 +34,10 @@ type PhaseContext struct {
 	// SourcePatterns is a newline-delimited list of glob patterns.
 	// When non-empty, only matching source files are included (GH-565).
 	SourcePatterns string `yaml:"source_patterns"`
+	// ExcludeTests excludes *_test.go files from the source code included
+	// in the prompt context. Measure prompt only — stitch needs test files
+	// to write compatible tests (GH-616).
+	ExcludeTests bool `yaml:"exclude_tests"`
 }
 
 // loadPhaseContext reads a phase context YAML file. Returns (nil, nil)
@@ -1537,6 +1541,21 @@ func buildProjectContext(existingIssuesJSON string, project ProjectConfig, phase
 					filtered = append(filtered, sf)
 				}
 			}
+			ctx.SourceCode = filtered
+		}
+
+		// Exclude *_test.go files from the measure prompt when requested (GH-616).
+		// Test files are consumers of the API; the measure agent needs to know
+		// what is tested but not how tests are implemented.
+		if phaseCtx != nil && phaseCtx.ExcludeTests {
+			var filtered []SourceFile
+			for _, sf := range ctx.SourceCode {
+				if !strings.HasSuffix(sf.File, "_test.go") {
+					filtered = append(filtered, sf)
+				}
+			}
+			logf("buildProjectContext: excluded %d _test.go file(s) from source context",
+				len(ctx.SourceCode)-len(filtered))
 			ctx.SourceCode = filtered
 		}
 	}

--- a/pkg/orchestrator/context_test.go
+++ b/pkg/orchestrator/context_test.go
@@ -1489,6 +1489,63 @@ func TestBuildProjectContext_SourcePatternsEmpty(t *testing.T) {
 	}
 }
 
+// --- test file exclusion (GH-616) ---
+
+// TestBuildProjectContext_ExcludeTests_True verifies that _test.go files are
+// excluded when PhaseContext.ExcludeTests is true (GH-616).
+func TestBuildProjectContext_ExcludeTests_True(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	os.WriteFile("pkg/app/app_test.go", []byte("package app\n"), 0o644)
+
+	project := ProjectConfig{GoSourceDirs: []string{"pkg/"}}
+	phaseCtx := &PhaseContext{ExcludeTests: true}
+
+	ctx, err := buildProjectContext("", project, phaseCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, sf := range ctx.SourceCode {
+		if strings.HasSuffix(sf.File, "_test.go") {
+			t.Errorf("_test.go file should be excluded when ExcludeTests=true, got %q", sf.File)
+		}
+	}
+	// Non-test files must still be present.
+	if len(ctx.SourceCode) == 0 {
+		t.Error("SourceCode should not be empty — non-test files must remain")
+	}
+}
+
+// TestBuildProjectContext_ExcludeTests_False verifies that _test.go files are
+// included when PhaseContext.ExcludeTests is false (GH-616).
+func TestBuildProjectContext_ExcludeTests_False(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	os.WriteFile("pkg/app/app_test.go", []byte("package app\n"), 0o644)
+
+	project := ProjectConfig{GoSourceDirs: []string{"pkg/"}}
+	phaseCtx := &PhaseContext{ExcludeTests: false}
+
+	ctx, err := buildProjectContext("", project, phaseCtx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, sf := range ctx.SourceCode {
+		if strings.HasSuffix(sf.File, "_test.go") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("_test.go file should be included when ExcludeTests=false")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // parseTouchpointPackages tests (GH-534)
 // ---------------------------------------------------------------------------

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -370,6 +370,12 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 		phaseCtx.SourcePatterns = o.cfg.Cobbler.MeasureSourcePatterns
 		logf("buildMeasurePrompt: measure_source_patterns set from config")
 	}
+	// Apply test exclusion setting (GH-616). Default true; file-level wins
+	// when already set to true by the phaseCtx file.
+	if o.cfg.Cobbler.effectiveMeasureExcludeTests() && !phaseCtx.ExcludeTests {
+		phaseCtx.ExcludeTests = true
+		logf("buildMeasurePrompt: measure_exclude_tests=true, _test.go files will be excluded")
+	}
 
 	// Auto-derive SourcePatterns from the road-map when MeasureRoadmapSource
 	// is enabled and no manual patterns are already set (GH-534).

--- a/pkg/orchestrator/measure_test.go
+++ b/pkg/orchestrator/measure_test.go
@@ -1732,3 +1732,50 @@ touchpoints:
 		t.Error("prompt missing role field")
 	}
 }
+
+// --- test file exclusion wiring (GH-616) ---
+
+// TestBuildMeasurePrompt_ExcludeTests_DefaultTrue verifies that _test.go files
+// are excluded from the prompt by default (nil MeasureExcludeTests → true) (GH-616).
+func TestBuildMeasurePrompt_ExcludeTests_DefaultTrue(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	os.WriteFile("pkg/app/app_test.go", []byte("package app\n"), 0o644)
+
+	cfg := Config{}
+	cfg.Project.GoSourceDirs = []string{"pkg/"}
+	// MeasureExcludeTests is nil → effectiveMeasureExcludeTests() returns true.
+	o := New(cfg)
+
+	prompt, err := o.buildMeasurePrompt("", "", 1)
+	if err != nil {
+		t.Fatalf("buildMeasurePrompt() error = %v", err)
+	}
+	if strings.Contains(prompt, "app_test.go") {
+		t.Error("_test.go should not appear in prompt when MeasureExcludeTests is unset (default true)")
+	}
+}
+
+// TestBuildMeasurePrompt_ExcludeTests_DisabledFalse verifies that _test.go files
+// appear in the prompt when MeasureExcludeTests is explicitly false (GH-616).
+func TestBuildMeasurePrompt_ExcludeTests_DisabledFalse(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	os.WriteFile("pkg/app/app_test.go", []byte("package app\n"), 0o644)
+
+	f := false
+	cfg := Config{}
+	cfg.Project.GoSourceDirs = []string{"pkg/"}
+	cfg.Cobbler.MeasureExcludeTests = &f
+	o := New(cfg)
+
+	prompt, err := o.buildMeasurePrompt("", "", 1)
+	if err != nil {
+		t.Fatalf("buildMeasurePrompt() error = %v", err)
+	}
+	if !strings.Contains(prompt, "app_test.go") {
+		t.Error("_test.go should appear in prompt when MeasureExcludeTests=false")
+	}
+}


### PR DESCRIPTION
## Summary

Adds a `measure_exclude_tests` config option (default true) that strips `*_test.go` files from the source code included in the measure prompt. This reduces prompt size and keeps Claude focused on production code during the planning step; stitch still receives test files so it can write compatible tests.

## Changes

- `MeasureExcludeTests *bool` added to `CobblerConfig` — nil means true (uses `*bool` nil=true pattern, same as `SilenceAgent`)
- `effectiveMeasureExcludeTests()` helper returns true when field is nil
- `ExcludeTests bool` added to `PhaseContext`; filtering applied in `buildProjectContext` after the existing exclude-set pass
- `buildMeasurePrompt` wires the config value into `phaseCtx.ExcludeTests` (file-level `measure_context.yaml` wins over config)
- `DefaultConfig()` initialises `MeasureExcludeTests: &true`
- 4 new tests: context direct tests (ExcludeTests_True, ExcludeTests_False) and measure prompt wiring tests (DefaultTrue, DisabledFalse)

## Stats

| Metric | Value | Delta |
|--------|-------|-------|
| Go production LOC | 12033 | +21 |
| Go test LOC | 16147 | +104 |
| Spec words | 19043 | +0 |

## Test plan

- [x] `mage analyze` passes
- [x] `go test ./pkg/orchestrator/ -count=1` passes (all tests)
- [x] New tests cover ExcludeTests=true/false and DefaultTrue/DisabledFalse wiring

Closes #616