### PR TITLE
GH-679: Fix label name exceeding GitHub 50-char limit for long generation names

### DIFF
--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -6,6 +6,7 @@ package orchestrator
 import (
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -46,8 +47,25 @@ const (
 const cobblerGenLabelPrefix = "cobbler-gen-"
 
 // cobblerGenLabel returns the generation label for a given generation name.
+// GitHub enforces a 50-character maximum on label names. When the full label
+// would exceed 50 chars, we keep the prefix (12 chars) plus the first 29 chars
+// of the generation name, a hyphen, and an 8-char FNV-32 hex digest of the
+// full generation name — yielding exactly 50 chars and remaining deterministic.
 func cobblerGenLabel(generation string) string {
-	return cobblerGenLabelPrefix + generation
+	const maxLen = 50
+	label := cobblerGenLabelPrefix + generation
+	if len(label) <= maxLen {
+		return label
+	}
+	// Available space after the prefix: 50 - 12 (prefix) - 1 (hyphen) - 8 (hash) = 29.
+	const bodyLen = 29
+	h := fnv.New32a()
+	h.Write([]byte(generation))
+	truncated := generation
+	if len(truncated) > bodyLen {
+		truncated = truncated[:bodyLen]
+	}
+	return fmt.Sprintf("%s%s-%08x", cobblerGenLabelPrefix, truncated, h.Sum32())
 }
 
 // formatIssueFrontMatter formats the YAML front-matter block for an issue body.
@@ -635,6 +653,7 @@ func gcStaleGenerationIssues(repo, generationPrefix string) {
 
 	var raw []struct {
 		Number int `json:"number"`
+		Body   string `json:"body"`
 		Labels []struct {
 			Name string `json:"name"`
 		} `json:"labels"`
@@ -645,18 +664,28 @@ func gcStaleGenerationIssues(repo, generationPrefix string) {
 	}
 
 	// Group issue numbers by generation name.
+	// We read the generation from the YAML front-matter (cobbler_generation) in
+	// the issue body. This is the source of truth; the label name may be a
+	// truncated/hashed form when the full generation name exceeds 50 chars.
 	byGeneration := make(map[string][]int)
 	for _, issue := range raw {
+		// Only consider issues that carry a cobbler-gen-* label.
+		hasGenLabel := false
 		for _, label := range issue.Labels {
-			if !strings.HasPrefix(label.Name, cobblerGenLabelPrefix) {
-				continue
+			if strings.HasPrefix(label.Name, cobblerGenLabelPrefix) {
+				hasGenLabel = true
+				break
 			}
-			gen := strings.TrimPrefix(label.Name, cobblerGenLabelPrefix)
-			if gen == "" || !strings.HasPrefix(gen, generationPrefix) {
-				continue
-			}
-			byGeneration[gen] = append(byGeneration[gen], issue.Number)
 		}
+		if !hasGenLabel {
+			continue
+		}
+		fm, _ := parseIssueFrontMatter(issue.Body)
+		gen := fm.Generation
+		if gen == "" || !strings.HasPrefix(gen, generationPrefix) {
+			continue
+		}
+		byGeneration[gen] = append(byGeneration[gen], issue.Number)
 	}
 
 	// Close issues for generations whose branch no longer exists locally.

--- a/pkg/orchestrator/issues_gh_test.go
+++ b/pkg/orchestrator/issues_gh_test.go
@@ -117,13 +117,44 @@ func TestFormatIssueFrontMatter(t *testing.T) {
 	}
 }
 
-// TestCobblerGenLabel verifies label name construction.
+// TestCobblerGenLabel verifies label name construction and the 50-char cap
+// enforced by GitHub's label name limit.
 func TestCobblerGenLabel(t *testing.T) {
 	t.Parallel()
-	got := cobblerGenLabel("gen-2026-02-28-001")
-	want := "cobbler-gen-gen-2026-02-28-001"
-	if got != want {
-		t.Errorf("got %q want %q", got, want)
+
+	const maxLen = 50
+
+	t.Run("short name unchanged", func(t *testing.T) {
+		t.Parallel()
+		got := cobblerGenLabel("gen-2026-02-28-001")
+		want := "cobbler-gen-gen-2026-02-28-001"
+		if got != want {
+			t.Errorf("got %q want %q", got, want)
+		}
+	})
+
+	longCases := []string{
+		// Observed failure: generation-gh-262-generate-code-from-specs → 54 chars
+		"generation-gh-262-generate-code-from-specs",
+		strings.Repeat("x", 100),
+		strings.Repeat("a", maxLen-len(cobblerGenLabelPrefix)+1),
+	}
+	for _, gen := range longCases {
+		gen := gen
+		t.Run("long/"+gen[:min(len(gen), 20)], func(t *testing.T) {
+			t.Parallel()
+			label := cobblerGenLabel(gen)
+			if len(label) > maxLen {
+				t.Errorf("label len %d > %d: %q", len(label), maxLen, label)
+			}
+			if !strings.HasPrefix(label, cobblerGenLabelPrefix) {
+				t.Errorf("missing prefix: %q", label)
+			}
+			// Deterministic across calls.
+			if cobblerGenLabel(gen) != label {
+				t.Errorf("not deterministic for %q", gen)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

`cobblerGenLabel` concatenated the prefix with the full generation name, producing labels up to 54+ chars that GitHub silently rejected. This caused `upgradeMeasuringPlaceholder` and `createCobblerIssue` to fail, resulting in zero issues imported despite a successful measure run.

## Changes

- `cobblerGenLabel()`: truncate to 50 chars via `cobbler-gen-<29-char-body>-<8-char-fnv32-hex>` when the full name exceeds the limit; short names are unchanged
- `gcStaleGenerationIssues()`: read generation name from YAML front-matter (`cobbler_generation`) instead of reconstructing from the possibly-truncated label, so `gitBranchExists` checks remain correct
- `TestCobblerGenLabel`: expanded to cover short names (unchanged), the observed failure case (`generation-gh-262-generate-code-from-specs` → 54 chars), and very long names

## Stats

2 files changed, 73 insertions(+), 13 deletions(-)

## Test plan

- [x] `go test ./pkg/orchestrator/ -count=1` passes (all tests green)
- [x] `TestCobblerGenLabel` covers the exact failing generation name from run 15
- [x] Short generation names produce identical labels to before (no regression)

Closes #679