### PR TITLE
GH-682: Fix measure proposing tasks for implemented use cases

### DIFF
--- a/docs/constitutions/planning.yaml
+++ b/docs/constitutions/planning.yaml
@@ -13,6 +13,12 @@ articles:
       99.0 (unscheduled). Early preview of later use cases is allowed when they
       share functionality with the current release.
 
+      Use cases in road-map.yaml carry a status field. Use cases with
+      status "implemented" or "done" have existing code and are complete.
+      Do not propose any new tasks for them. Propose tasks only for use
+      cases with status "spec_complete", "pending", or any other value
+      that is not "implemented" or "done".
+
   - id: P2
     title: Task sizing
     rule: |

--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -1434,9 +1434,18 @@ func prdIDsFromUseCases(useCases []*UseCaseDoc) map[string]bool {
 // Road-map-driven source selection (GH-534)
 // ---------------------------------------------------------------------------
 
+// ucStatusDone reports whether a road-map use-case status value means the use
+// case is complete and should not be proposed for new work. Both "done" and
+// "implemented" are treated as complete: "implemented" means code already
+// exists; "done" means the full lifecycle (code + tests + review) is finished.
+func ucStatusDone(status string) bool {
+	return strings.EqualFold(status, "done") || strings.EqualFold(status, "implemented")
+}
+
 // selectNextPendingUseCase reads docs/road-map.yaml and returns the first
-// use case whose status is not "done". When a release filter is configured
-// in cfg (via Releases or Release), only releases in scope are considered.
+// use case whose status is neither "done" nor "implemented". When a release
+// filter is configured in cfg (via Releases or Release), only releases in
+// scope are considered.
 // Returns (nil, nil) when all use cases are done or the road-map is absent.
 func selectNextPendingUseCase(cfg ProjectConfig) (*UseCaseDoc, error) {
 	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
@@ -1458,7 +1467,7 @@ func selectNextPendingUseCase(cfg ProjectConfig) (*UseCaseDoc, error) {
 			}
 		}
 		for _, uc := range rel.UseCases {
-			if strings.EqualFold(uc.Status, "done") {
+			if ucStatusDone(uc.Status) {
 				continue
 			}
 			path := filepath.Join("docs", "specs", "use-cases", uc.ID+".yaml")

--- a/pkg/orchestrator/context_test.go
+++ b/pkg/orchestrator/context_test.go
@@ -1914,6 +1914,105 @@ touchpoints:
 	}
 }
 
+// TestUCStatusDone verifies that both "done" and "implemented" are treated as
+// complete, and other values are not.
+func TestUCStatusDone(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{"done", true},
+		{"Done", true},
+		{"DONE", true},
+		{"implemented", true},
+		{"Implemented", true},
+		{"IMPLEMENTED", true},
+		{"spec_complete", false},
+		{"pending", false},
+		{"in_progress", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := ucStatusDone(tc.status); got != tc.want {
+			t.Errorf("ucStatusDone(%q) = %v, want %v", tc.status, got, tc.want)
+		}
+	}
+}
+
+// TestSelectNextPendingUseCase_ImplementedSkipped verifies that use cases with
+// status "implemented" are skipped, matching the "done" behaviour (GH-682).
+func TestSelectNextPendingUseCase_ImplementedSkipped(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	roadmap := `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    name: Release 1
+    status: in_progress
+    use_cases:
+      - id: rel01.0-uc001-format
+        status: implemented
+      - id: rel01.0-uc002-next
+        status: spec_complete
+`
+	ucContent := `id: rel01.0-uc002-next
+title: Next
+touchpoints:
+  - T1: "pkg/next — prd002-next R1"
+`
+	if err := os.WriteFile("docs/road-map.yaml", []byte(roadmap), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("docs/specs/use-cases/rel01.0-uc002-next.yaml", []byte(ucContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	uc, err := selectNextPendingUseCase(ProjectConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uc == nil {
+		t.Fatal("expected non-nil use case after skipping implemented")
+	}
+	if uc.ID != "rel01.0-uc002-next" {
+		t.Errorf("expected uc002-next (implemented uc001 skipped), got %s", uc.ID)
+	}
+}
+
+// TestSelectNextPendingUseCase_AllImplemented verifies that a road-map where
+// all use cases are "implemented" is treated the same as all "done".
+func TestSelectNextPendingUseCase_AllImplemented(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	roadmap := `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    name: Release 1
+    status: done
+    use_cases:
+      - id: rel01.0-uc001-format
+        status: implemented
+      - id: rel01.0-uc002-build
+        status: implemented
+`
+	if err := os.WriteFile("docs/road-map.yaml", []byte(roadmap), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	uc, err := selectNextPendingUseCase(ProjectConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uc != nil {
+		t.Errorf("expected nil for all-implemented road-map, got %+v", uc)
+	}
+}
+
 func TestSelectNextPendingUseCase_MissingRoadmap(t *testing.T) {
 	_, cleanup := setupContextTestDir(t)
 	defer cleanup()


### PR DESCRIPTION
## Summary

`selectNextPendingUseCase` only skipped UCs with `status: done`, so UCs marked `status: implemented` were returned as pending and their specs included in the measure prompt. Claude then misread \"implemented\" as \"spec ready to implement\" and proposed duplicate tasks — wasting 5 measure cycles in run 15.

## Changes

- `pkg/orchestrator/context.go`: added `ucStatusDone()` treating both `"done"` and `"implemented"` as complete; `selectNextPendingUseCase` now uses it
- `docs/constitutions/planning.yaml`: added explicit P1 rule telling Claude not to propose tasks for `implemented`/`done` UCs
- `pkg/orchestrator/context_test.go`: `TestUCStatusDone`, `TestSelectNextPendingUseCase_ImplementedSkipped`, `TestSelectNextPendingUseCase_AllImplemented`

## Stats

3 files changed, 117 insertions(+), 3 deletions(-)

## Test plan

- [x] `go test ./pkg/orchestrator/ -count=1` passes
- [x] `TestSelectNextPendingUseCase_ImplementedSkipped` confirms `implemented` UC is skipped
- [x] `TestSelectNextPendingUseCase_AllImplemented` confirms all-implemented → nil (no pending work)

Closes #682