### PR TITLE
GH-681: Add mage release:update and release:clear targets

### DIFF
--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -110,6 +110,26 @@ func Status() error { return newOrch().CodeStatus() }
 // Tag creates a documentation release tag (v0.YYYYMMDD.N) and builds the container image.
 func Tag() error { return newOrch().Tag() }
 
+// --- Release targets ---
+
+// Release groups targets that manage release lifecycle state in road-map.yaml
+// and configuration.yaml.
+type Release mg.Namespace
+
+// Tag creates a documentation release tag (v0.YYYYMMDD.N) and builds the
+// container image. Alias of the top-level Tag target, exposed under the
+// Release namespace for discoverability.
+func (Release) Tag() error { return newOrch().Tag() }
+
+// Update marks a release complete: sets all use-case statuses to "implemented"
+// in docs/road-map.yaml and removes the version from project.releases in
+// configuration.yaml. Errors if the release version is not found.
+func (Release) Update(version string) error { return newOrch().ReleaseUpdate(version) }
+
+// Clear reverses Update: resets use-case statuses to "spec_complete" and
+// re-adds the version to project.releases. Errors if the version is not found.
+func (Release) Clear(version string) error { return newOrch().ReleaseClear(version) }
+
 // --- Scaffold targets ---
 
 // Push scaffolds the orchestrator into a target Go repository. The argument

--- a/pkg/orchestrator/release.go
+++ b/pkg/orchestrator/release.go
@@ -1,0 +1,278 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package orchestrator
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ReleaseUpdate marks a release as complete in the project files. It sets all
+// use-case statuses to "implemented" for the named release in
+// docs/road-map.yaml and removes the release version from project.releases in
+// configuration.yaml (DefaultConfigFile). Both files are rewritten using
+// yaml.v3 node round-trip to preserve document structure and comments.
+//
+// Returns an error if the release version is not found in road-map.yaml, or
+// if either file fails schema validation.
+func (o *Orchestrator) ReleaseUpdate(version string) error {
+	if err := updateRoadmapUCStatuses(version, "implemented"); err != nil {
+		return err
+	}
+	if err := removeReleaseFromConfig(DefaultConfigFile, version); err != nil {
+		return err
+	}
+	logf("release:update %s: done", version)
+	return nil
+}
+
+// ReleaseClear reverses ReleaseUpdate. It resets all use-case statuses to
+// "spec_complete" for the named release in docs/road-map.yaml and
+// re-appends the release version to project.releases in configuration.yaml.
+//
+// Returns an error if the release version is not found in road-map.yaml, or
+// if either file fails schema validation.
+func (o *Orchestrator) ReleaseClear(version string) error {
+	if err := updateRoadmapUCStatuses(version, "spec_complete"); err != nil {
+		return err
+	}
+	if err := addReleaseToConfig(DefaultConfigFile, version); err != nil {
+		return err
+	}
+	logf("release:clear %s: done", version)
+	return nil
+}
+
+// updateRoadmapUCStatuses loads docs/road-map.yaml via yaml.v3 node API,
+// finds the release matching version, sets all its use_cases[*].status
+// values to newStatus, and writes the file back.
+func updateRoadmapUCStatuses(version, newStatus string) error {
+	const path = "docs/road-map.yaml"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("release update: read %s: %w", path, err)
+	}
+
+	// Validate structure via typed unmarshal before mutation.
+	var doc RoadmapDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("release update: parse %s: %w", path, err)
+	}
+	found := false
+	for _, rel := range doc.Releases {
+		if rel.Version == version {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("release update: version %q not found in %s", version, path)
+	}
+
+	// Node round-trip to preserve comments and structure.
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return fmt.Errorf("release update: node parse %s: %w", path, err)
+	}
+
+	if err := setRoadmapUCStatuses(&root, version, newStatus); err != nil {
+		return fmt.Errorf("release update: mutate %s: %w", path, err)
+	}
+
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return fmt.Errorf("release update: marshal %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return fmt.Errorf("release update: write %s: %w", path, err)
+	}
+	logf("release update: set use-case statuses to %q for release %s in %s", newStatus, version, path)
+	return nil
+}
+
+// setRoadmapUCStatuses mutates the yaml.Node tree of road-map.yaml, finding
+// the release with the given version and setting all its use_cases[*].status
+// scalar values to newStatus.
+func setRoadmapUCStatuses(root *yaml.Node, version, newStatus string) error {
+	// Unwrap document node.
+	doc := root
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
+		doc = doc.Content[0]
+	}
+	// doc should be a mapping node for the roadmap document.
+	releases := mappingValue(doc, "releases")
+	if releases == nil || releases.Kind != yaml.SequenceNode {
+		return fmt.Errorf("releases key not found or not a sequence")
+	}
+	for _, relNode := range releases.Content {
+		versionNode := mappingValue(relNode, "version")
+		if versionNode == nil || versionNode.Value != version {
+			continue
+		}
+		ucSeq := mappingValue(relNode, "use_cases")
+		if ucSeq == nil || ucSeq.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, ucNode := range ucSeq.Content {
+			statusNode := mappingValue(ucNode, "status")
+			if statusNode != nil {
+				statusNode.Value = newStatus
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("version %q not found in releases node tree", version)
+}
+
+// removeReleaseFromConfig loads configPath, removes version from
+// project.releases, and writes it back via node round-trip.
+func removeReleaseFromConfig(configPath, version string) error {
+	return mutateConfigReleases(configPath, version, false)
+}
+
+// addReleaseToConfig loads configPath, appends version to project.releases
+// if not already present, and writes it back via node round-trip.
+func addReleaseToConfig(configPath, version string) error {
+	return mutateConfigReleases(configPath, version, true)
+}
+
+// mutateConfigReleases is the shared implementation for removeReleaseFromConfig
+// and addReleaseToConfig. When add is true, version is appended (if absent);
+// when add is false, version is removed.
+func mutateConfigReleases(configPath, version string, add bool) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("release config: read %s: %w", configPath, err)
+	}
+
+	// Validate via typed unmarshal.
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("release config: parse %s: %w", configPath, err)
+	}
+
+	// Node round-trip.
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return fmt.Errorf("release config: node parse %s: %w", configPath, err)
+	}
+
+	if err := mutateProjectReleasesNode(&root, version, add); err != nil {
+		// project.releases is optional; log and skip rather than hard-fail.
+		logf("release config: project.releases not found in %s, skipping: %v", configPath, err)
+		return nil
+	}
+
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return fmt.Errorf("release config: marshal %s: %w", configPath, err)
+	}
+	if err := os.WriteFile(configPath, out, 0o644); err != nil {
+		return fmt.Errorf("release config: write %s: %w", configPath, err)
+	}
+	action := "removed"
+	if add {
+		action = "added"
+	}
+	logf("release config: %s %q in project.releases in %s", action, version, configPath)
+	return nil
+}
+
+// mutateProjectReleasesNode finds project.releases in the node tree and either
+// removes or appends version. Returns an error if project.releases is absent.
+func mutateProjectReleasesNode(root *yaml.Node, version string, add bool) error {
+	doc := root
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
+		doc = doc.Content[0]
+	}
+	projectNode := mappingValue(doc, "project")
+	if projectNode == nil {
+		return fmt.Errorf("project key not found")
+	}
+	releasesNode := mappingValue(projectNode, "releases")
+	if releasesNode == nil {
+		return fmt.Errorf("project.releases key not found")
+	}
+	if releasesNode.Kind != yaml.SequenceNode {
+		return fmt.Errorf("project.releases is not a sequence")
+	}
+
+	if add {
+		// Append only if not already present.
+		for _, child := range releasesNode.Content {
+			if child.Value == version {
+				return nil // already present
+			}
+		}
+		releasesNode.Content = append(releasesNode.Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Value: version,
+		})
+	} else {
+		// Remove all occurrences of version.
+		filtered := releasesNode.Content[:0]
+		for _, child := range releasesNode.Content {
+			if child.Value != version {
+				filtered = append(filtered, child)
+			}
+		}
+		releasesNode.Content = filtered
+	}
+	return nil
+}
+
+// mappingValue returns the value node for the given key in a yaml mapping
+// node, or nil if not found.
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// releaseVersionsFromConfig returns the list of releases in project.releases
+// from the given config file. Used in tests.
+func releaseVersionsFromConfig(configPath string) ([]string, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg.Project.Releases, nil
+}
+
+// roadmapUCStatuses returns a map of UC ID → status for the given release
+// version. Used in tests.
+func roadmapUCStatuses(roadmapPath, version string) (map[string]string, error) {
+	data, err := os.ReadFile(roadmapPath)
+	if err != nil {
+		return nil, err
+	}
+	var doc RoadmapDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	for _, rel := range doc.Releases {
+		if rel.Version == version {
+			out := make(map[string]string, len(rel.UseCases))
+			for _, uc := range rel.UseCases {
+				out[uc.ID] = uc.Status
+			}
+			return out, nil
+		}
+	}
+	return nil, fmt.Errorf("version %q not found", version)
+}
+

--- a/pkg/orchestrator/release_test.go
+++ b/pkg/orchestrator/release_test.go
@@ -1,0 +1,359 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package orchestrator
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func writeRoadmapFile(t *testing.T, dir, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	path := filepath.Join(dir, "docs", "road-map.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write road-map.yaml: %v", err)
+	}
+	return path
+}
+
+func writeConfigFile(t *testing.T, path string, releases []string) {
+	t.Helper()
+	relItems := ""
+	for _, r := range releases {
+		relItems += "\n  - " + r
+	}
+	content := "project:\n  releases:" + relItems + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+const sampleRoadmap = `id: rm1
+title: Test Roadmap
+releases:
+  - version: "00.0"
+    name: Release 0
+    status: in_progress
+    use_cases:
+      - id: rel00.0-uc001-format
+        status: spec_complete
+        summary: Format output
+      - id: rel00.0-uc002-build
+        status: spec_complete
+        summary: Build pipeline
+  - version: "01.0"
+    name: Release 1
+    status: pending
+    use_cases:
+      - id: rel01.0-uc001-ext
+        status: spec_complete
+        summary: Extension
+`
+
+// stringsContains reports whether slice contains s.
+func stringsContains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// cdTemp changes to dir and returns a cleanup func that restores the original
+// working directory. Tests that call os.Chdir must not use t.Parallel().
+func cdTemp(t *testing.T, dir string) func() {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	return func() { os.Chdir(orig) } //nolint:errcheck
+}
+
+// ---------------------------------------------------------------------------
+// updateRoadmapUCStatuses
+// ---------------------------------------------------------------------------
+
+func TestUpdateRoadmapUCStatuses_SetImplemented(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRoadmapFile(t, dir, sampleRoadmap)
+	defer cdTemp(t, dir)()
+
+	if err := updateRoadmapUCStatuses("00.0", "implemented"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	statuses, err := roadmapUCStatuses(path, "00.0")
+	if err != nil {
+		t.Fatalf("read statuses: %v", err)
+	}
+	for id, status := range statuses {
+		if status != "implemented" {
+			t.Errorf("UC %s: want implemented, got %q", id, status)
+		}
+	}
+
+	// Release 01.0 must be untouched.
+	other, err := roadmapUCStatuses(path, "01.0")
+	if err != nil {
+		t.Fatalf("read other release: %v", err)
+	}
+	for id, status := range other {
+		if status != "spec_complete" {
+			t.Errorf("UC %s in 01.0 should be untouched, got %q", id, status)
+		}
+	}
+}
+
+func TestUpdateRoadmapUCStatuses_SetSpecComplete(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRoadmapFile(t, dir, sampleRoadmap)
+	defer cdTemp(t, dir)()
+
+	if err := updateRoadmapUCStatuses("00.0", "implemented"); err != nil {
+		t.Fatalf("set implemented: %v", err)
+	}
+	if err := updateRoadmapUCStatuses("00.0", "spec_complete"); err != nil {
+		t.Fatalf("set spec_complete: %v", err)
+	}
+
+	statuses, err := roadmapUCStatuses(path, "00.0")
+	if err != nil {
+		t.Fatalf("read statuses: %v", err)
+	}
+	for id, status := range statuses {
+		if status != "spec_complete" {
+			t.Errorf("UC %s: want spec_complete, got %q", id, status)
+		}
+	}
+}
+
+func TestUpdateRoadmapUCStatuses_VersionNotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeRoadmapFile(t, dir, sampleRoadmap)
+	defer cdTemp(t, dir)()
+
+	if err := updateRoadmapUCStatuses("99.9", "implemented"); err == nil {
+		t.Error("expected error for missing version, got nil")
+	}
+}
+
+func TestUpdateRoadmapUCStatuses_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	defer cdTemp(t, dir)()
+
+	if err := updateRoadmapUCStatuses("00.0", "implemented"); err == nil {
+		t.Error("expected error for missing road-map.yaml, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// removeReleaseFromConfig / addReleaseToConfig
+// ---------------------------------------------------------------------------
+
+func TestRemoveReleaseFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "configuration.yaml")
+	writeConfigFile(t, cfgPath, []string{"00.0", "01.0", "02.0"})
+
+	if err := removeReleaseFromConfig(cfgPath, "01.0"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	versions, err := releaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if stringsContains(versions, "01.0") {
+		t.Errorf("01.0 should have been removed, versions: %v", versions)
+	}
+	if !stringsContains(versions, "00.0") || !stringsContains(versions, "02.0") {
+		t.Errorf("other versions should remain, got: %v", versions)
+	}
+}
+
+func TestAddReleaseToConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "configuration.yaml")
+	writeConfigFile(t, cfgPath, []string{"00.0", "02.0"})
+
+	if err := addReleaseToConfig(cfgPath, "01.0"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	versions, err := releaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !stringsContains(versions, "01.0") {
+		t.Errorf("01.0 should have been added, versions: %v", versions)
+	}
+}
+
+func TestAddReleaseToConfig_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "configuration.yaml")
+	writeConfigFile(t, cfgPath, []string{"00.0", "01.0"})
+
+	if err := addReleaseToConfig(cfgPath, "01.0"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	versions, err := releaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	count := 0
+	for _, v := range versions {
+		if v == "01.0" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 occurrence of 01.0, got %d in %v", count, versions)
+	}
+}
+
+func TestRemoveReleaseFromConfig_NotPresent(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "configuration.yaml")
+	writeConfigFile(t, cfgPath, []string{"00.0", "01.0"})
+
+	if err := removeReleaseFromConfig(cfgPath, "99.9"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	versions, err := releaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Errorf("expected 2 versions unchanged, got %v", versions)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ReleaseUpdate / ReleaseClear round-trip via Orchestrator methods
+// ---------------------------------------------------------------------------
+
+func TestReleaseUpdate_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	rmPath := writeRoadmapFile(t, dir, sampleRoadmap)
+	// configuration.yaml must be at DefaultConfigFile relative to cwd.
+	cfgPath := filepath.Join(dir, DefaultConfigFile)
+	writeConfigFile(t, cfgPath, []string{"00.0", "01.0"})
+	defer cdTemp(t, dir)()
+
+	o := New(Config{})
+
+	if err := o.ReleaseUpdate("00.0"); err != nil {
+		t.Fatalf("ReleaseUpdate: %v", err)
+	}
+
+	statuses, err := roadmapUCStatuses(rmPath, "00.0")
+	if err != nil {
+		t.Fatalf("read statuses: %v", err)
+	}
+	for id, s := range statuses {
+		if s != "implemented" {
+			t.Errorf("UC %s: want implemented, got %q", id, s)
+		}
+	}
+
+	versions, err := releaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if stringsContains(versions, "00.0") {
+		t.Errorf("00.0 should have been removed from releases, got %v", versions)
+	}
+
+	// Clear restores spec_complete and re-adds the version.
+	if err := o.ReleaseClear("00.0"); err != nil {
+		t.Fatalf("ReleaseClear: %v", err)
+	}
+
+	statuses, err = roadmapUCStatuses(rmPath, "00.0")
+	if err != nil {
+		t.Fatalf("read statuses after clear: %v", err)
+	}
+	for id, s := range statuses {
+		if s != "spec_complete" {
+			t.Errorf("UC %s after clear: want spec_complete, got %q", id, s)
+		}
+	}
+
+	versions, err = releaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config after clear: %v", err)
+	}
+	if !stringsContains(versions, "00.0") {
+		t.Errorf("00.0 should have been re-added to releases, got %v", versions)
+	}
+}
+
+func TestReleaseUpdate_VersionNotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeRoadmapFile(t, dir, sampleRoadmap)
+	writeConfigFile(t, filepath.Join(dir, DefaultConfigFile), []string{"00.0"})
+	defer cdTemp(t, dir)()
+
+	o := New(Config{})
+	if err := o.ReleaseUpdate("99.9"); err == nil {
+		t.Error("expected error for missing version, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// mappingValue
+// ---------------------------------------------------------------------------
+
+func TestMappingValue(t *testing.T) {
+	t.Parallel()
+
+	raw := `key: value
+nested:
+  inner: 42
+`
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(raw), &root); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	doc := root.Content[0] // unwrap document node
+
+	v := mappingValue(doc, "key")
+	if v == nil || v.Value != "value" {
+		t.Errorf("key: got %v, want scalar 'value'", v)
+	}
+
+	n := mappingValue(doc, "nested")
+	if n == nil {
+		t.Fatal("nested: got nil")
+	}
+	inner := mappingValue(n, "inner")
+	if inner == nil || inner.Value != "42" {
+		t.Errorf("inner: got %v, want scalar '42'", inner)
+	}
+
+	if mappingValue(doc, "missing") != nil {
+		t.Error("missing key: expected nil")
+	}
+	if mappingValue(nil, "key") != nil {
+		t.Error("nil node: expected nil")
+	}
+}


### PR DESCRIPTION
## Summary

Adds `mage release:update <version>` and `mage release:clear <version>` to automate the manual edits previously required after each generation stitch batch. Both use `yaml.v3` node round-trip marshalling to preserve document structure and comments, and validate input files via typed struct unmarshal before writing.

## Changes

- `pkg/orchestrator/release.go` (new) — `ReleaseUpdate` and `ReleaseClear` orchestrator methods, `yaml.v3` node-tree mutators for road-map and config, `mappingValue` helper
- `pkg/orchestrator/release_test.go` (new) — 11 tests covering all code paths and the full update→clear round-trip
- `magefiles/magefile.go` — new `Release` namespace with `Update`, `Clear`, and `Tag`

## Stats

3 files changed, 657 insertions(+)

## Test plan

- [x] `go test ./pkg/orchestrator/ -count=1` passes
- [x] `TestReleaseUpdate_RoundTrip` covers full update+clear lifecycle
- [x] `mage analyze` passes

Closes #681