### PR TITLE
GH-685: mage analyze — validate semantic models

### DIFF
--- a/docs/constitutions/semantic-model.yaml
+++ b/docs/constitutions/semantic-model.yaml
@@ -1,0 +1,237 @@
+# Semantic Model Constitution
+#
+# This constitution governs the authoring and validation of semantic models.
+# It is injected into the specification authoring phase so the Generator
+# (human or machine) knows how to produce well-formed, complete behavioral
+# specifications.
+#
+# A semantic model is the mutable behavioral layer of an agent specification.
+# It declares what the agent observes, how it reasons, and what it produces—
+# without prescribing code structure. The PRD defines architecture (stable).
+# The semantic model defines behavior (mutable). Constitutions and guidelines
+# constrain how behavior is implemented (prohibitive). The semantic model
+# declares what behavior IS (declarative).
+
+articles:
+  - id: SM1
+    title: Four mandatory sections
+    rule: |
+      Every semantic model must contain exactly four top-level sections:
+      data_sources, features, algorithm, and output_format. A semantic
+      model that omits any section is incomplete. A semantic model that
+      adds sections beyond these four is overspecified—move the extra
+      content to the PRD, architectural guidelines, or domain knowledge.
+
+      data_sources: what the agent observes (inputs)
+      features: how the agent interprets observations (derived signals)
+      algorithm: how the agent reasons (decision logic)
+      output_format: what the agent produces (outputs)
+
+  - id: SM2
+    title: Data sources are connectors, not implementations
+    rule: |
+      Each data source declares a connector type and a set of named
+      queries. The connector type names an interface or protocol—not a
+      library, endpoint URL, or implementation class. Queries declare
+      parameters and return types using domain types, not language-specific
+      types.
+
+      Good:
+        connector: INetworkState
+        queries:
+          - name: site_capacity
+            parameters: [site_id]
+            returns: {compute_available: float, memory_available: float}
+
+      Bad:
+        connector: "http://10.0.1.5:8080/api/v2"
+        queries:
+          - name: get_capacity
+            parameters: ["string siteId"]
+            returns: "json.RawMessage"
+
+      The semantic model specifies what data the agent needs, not where
+      or how it fetches it. Binding data sources to concrete endpoints
+      happens at deployment through configuration, not at specification
+      time through the semantic model.
+
+  - id: SM3
+    title: Features derive from data sources
+    rule: |
+      Every feature must reference at least one data source by id and
+      query name using dot notation (e.g., network_state.site_capacity).
+      Features that do not trace to a declared data source are untethered—
+      they claim to observe something the agent has no access to.
+
+      The extraction field describes the derivation in domain language,
+      not in code. It should be readable by a domain expert who does not
+      program. The Generator translates extraction descriptions into code;
+      the semantic model author describes the intent.
+
+      Features may reference other features to build derived signals.
+      Feature references must not form cycles. The dependency graph of
+      features must be a DAG.
+
+  - id: SM4
+    title: Algorithm declares logic, not code
+    rule: |
+      The algorithm section specifies the agent's reasoning as a named
+      type, a parameter set, and a logic block written in structured
+      pseudocode or domain language.
+
+      The type field names the reasoning pattern (e.g.,
+      threshold_with_trend, gap_ordered_task_generation,
+      ensemble_prediction). Types should be reusable across semantic
+      models—they name a family of algorithms, not a specific
+      implementation.
+
+      The parameters field declares the tunable knobs of the algorithm.
+      Parameters are the primary target of runtime configuration changes—
+      a threshold change should not require a specification delta if the
+      parameter is already declared.
+
+      The logic block is pseudocode, not executable code. It describes
+      the decision flow using feature names and domain concepts. The
+      Generator reads the logic block to understand the intended behavior
+      and produces the implementation. If the logic block is precise
+      enough to be executable, it is overspecified—it has become code
+      in disguise.
+
+  - id: SM5
+    title: Output format matches the functional interface
+    rule: |
+      The output_format section must align with the agent's IFunctional
+      interface as declared in the PRD. Every field in the output format
+      must correspond to a return type or response structure in the
+      functional interface.
+
+      If the semantic model produces outputs that IFunctional cannot
+      express, either the semantic model is wrong (specifying behavior
+      the architecture does not support) or the PRD needs a delta (the
+      architecture must grow to support the new behavior). This cross-
+      reference between semantic model and PRD is what makes specification
+      layers a graph, not a stack.
+
+  - id: SM6
+    title: One semantic model per behavior
+    rule: |
+      Each semantic model specifies one coherent behavior—one
+      observation-reasoning-output pipeline. An agent that performs
+      multiple behaviors (e.g., capacity prediction AND fault diagnosis)
+      has multiple semantic models, not one large one.
+
+      Semantic models are composed at the specification level. The
+      Specification Selector assembles the set of semantic models an
+      agent instance needs. The PRD defines the architectural slots
+      these models fill. Each slot corresponds to one behavioral
+      capability.
+
+      Splitting behaviors into separate semantic models enables
+      independent evolution. A new fault diagnosis algorithm does not
+      require re-specifying capacity prediction. The evolution pipeline
+      applies the delta to one semantic model without touching others.
+
+  - id: SM7
+    title: Naming and versioning
+    rule: |
+      Every semantic model has a name and a version.
+
+      The name follows the pattern: {domain}-{behavior}
+      Examples: edge-compute-capacity-predictor, transport-fault-diagnoser,
+      cobbler-measure, ran-latency-monitor.
+
+      The version follows semantic versioning (MAJOR.MINOR.PATCH):
+      - MAJOR: breaking changes to data sources or output format
+      - MINOR: new features or algorithm changes (backward compatible)
+      - PATCH: parameter tuning or extraction refinements
+
+      Version changes trigger different evolution responses. A PATCH
+      change may only require regenerating the algorithm implementation.
+      A MAJOR change may require regenerating data connectors, feature
+      extractors, and output formatters—touching multiple components.
+
+  - id: SM8
+    title: Semantic models are declarative, not prohibitive
+    rule: |
+      A semantic model declares what the agent DOES. It does not declare
+      what the agent must NOT do. Prohibitions belong in architectural
+      guidelines or constitutions.
+
+      Declarative (semantic model):
+        "Observe the specification tree, identify unimplemented use cases,
+        order by release priority, decompose into sized tasks."
+
+      Prohibitive (constitution/guideline):
+        "Do NOT propose tasks for implemented use cases."
+        "Do NOT exceed 350 lines per task."
+
+      If a statement in the semantic model begins with "do not," "never,"
+      "must not," or "avoid," it is a constraint and belongs in the
+      architectural guidelines layer. Move it there.
+
+      This separation matters because constraints are stable across
+      instances (every Analyst follows the same coding standards) while
+      behaviors are mutable per instance (each Analyst observes different
+      data and runs different algorithms).
+
+  - id: SM9
+    title: Testability
+    rule: |
+      Every semantic model must be testable through its output format.
+      Given known inputs to data_sources and known feature extractions,
+      the algorithm must produce deterministic or bounded outputs that
+      tests can verify.
+
+      When authoring a semantic model, ask: "Can I write a test that
+      provides mock data sources, runs the algorithm, and checks the
+      output?" If the answer is no, the semantic model is underspecified—
+      it does not declare enough about the algorithm's behavior for the
+      Generator to produce testable code.
+
+      The test suite layer of the agent specification contains tests
+      derived from the semantic model. Each feature should have at least
+      one test validating its extraction. The algorithm should have tests
+      for each branch of its logic. The output format should have tests
+      validating structure and value ranges.
+
+  - id: SM10
+    title: Domain knowledge references, not domain knowledge
+    rule: |
+      The semantic model may reference domain knowledge (ontologies,
+      protocol specs, vendor documentation) but must not embed it.
+      Data source connectors reference interface names defined in
+      domain knowledge. Feature extractions reference domain concepts
+      explained in domain knowledge. The semantic model says "use X";
+      domain knowledge defines what X is.
+
+      This separation keeps the semantic model portable. The same
+      capacity prediction semantic model can apply to different vendors
+      by swapping the domain knowledge binding—different equipment APIs,
+      same behavioral specification.
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Ten principles govern semantic model authoring: four mandatory
+      sections (SM1), connector-based data sources (SM2), traceable
+      features (SM3), declarative algorithms (SM4), interface-aligned
+      outputs (SM5), one behavior per model (SM6), semantic versioning
+      (SM7), declarative not prohibitive (SM8), testability (SM9), and
+      referenced not embedded domain knowledge (SM10).
+  - tag: structure
+    title: Semantic Model Structure
+    content: |
+      A semantic model is a YAML document with four sections:
+      data_sources (inputs), features (derived signals), algorithm
+      (reasoning), and output_format (outputs). Each section has
+      specific structural requirements defined in the articles.
+  - tag: evolution
+    title: Semantic Model Evolution
+    content: |
+      The semantic model is the primary target for agent evolution.
+      Version changes signal the scope of regeneration needed. PATCH
+      changes tune parameters. MINOR changes add features or modify
+      algorithms. MAJOR changes alter inputs or outputs and may
+      require PRD changes. Each semantic model evolves independently
+      of others in the same agent.

--- a/docs/specs/semantic-models/cobbler-prototype.yaml
+++ b/docs/specs/semantic-models/cobbler-prototype.yaml
@@ -1,0 +1,171 @@
+# Cobbler Semantic Model (Proposed)
+#
+# This file sketches what a semantic model layer for cobbler-scaffold
+# (https://github.com/petar-djukic/cobbler-scaffold) would look like.
+#
+# Cobbler currently has three YAML constitutions (design, planning, execution)
+# that constrain Claude's behavior per phase. These belong in the Architectural
+# Guidelines layer—they are prohibitive rules ("don't do X", "you must follow Y").
+#
+# What cobbler lacks is a declarative behavioral specification: what does the
+# agent observe, how does it reason, what does it produce? This file makes that
+# explicit for the two core phases: measure and stitch.
+
+measure:
+  semantic_model:
+    name: "cobbler-measure"
+    version: "1.0.0"
+
+    data_sources:
+      - id: specification_tree
+        connector: filesystem
+        queries:
+          - name: all_use_cases
+            source: "docs/specs/use-cases/rel*-uc*-*.yaml"
+            returns: list[UseCase]
+          - name: road_map
+            source: "docs/road-map.yaml"
+            returns: list[{release, use_cases, status}]
+      - id: project_state
+        connector: git + github
+        queries:
+          - name: implemented_use_cases
+            source: "road_map entries where status in [implemented, done]"
+            returns: list[use_case_id]
+          - name: open_issues
+            source: "gh issue list"
+            returns: list[Issue]
+
+    features:
+      - name: implementation_gap
+        source: specification_tree.all_use_cases - project_state.implemented_use_cases
+        extraction: "set difference of specified vs implemented"
+      - name: next_release
+        source: specification_tree.road_map
+        extraction: "earliest release with unimplemented use cases"
+      - name: dependency_order
+        source: implementation_gap
+        extraction: "topological sort by use case dependencies"
+
+    algorithm:
+      type: gap_ordered_task_generation
+      parameters:
+        task_size_lines: [250, 350]
+        max_files_per_task: 7
+        max_tasks_per_batch: 10
+      logic: |
+        Filter implementation_gap to next_release use cases
+        Sort by dependency_order
+        Decompose each use case into tasks:
+          1. Types and interfaces
+          2. Implementation
+          3. Tests
+        Each task targets task_size_lines of production code
+        Skip use cases with existing open_issues
+
+    output_format:
+      type: list[GitHubIssue]
+      fields: [title, body, labels, milestone]
+      body_schema: {deliverable_type, required_reading, files,
+                    requirements, acceptance_criteria}
+
+stitch:
+  semantic_model:
+    name: "cobbler-stitch"
+    version: "1.0.0"
+
+    data_sources:
+      - id: task
+        connector: github
+        queries:
+          - name: issue_description
+            source: "gh issue view {issue_id}"
+            returns: {deliverable_type, required_reading, files,
+                      requirements, design_decisions, acceptance_criteria}
+      - id: codebase
+        connector: filesystem
+        queries:
+          - name: existing_code
+            source: "files referenced in task.required_reading + task.files"
+            returns: list[SourceFile]
+          - name: specifications
+            source: "PRDs, architecture, use cases referenced in required_reading"
+            returns: list[SpecificationDocument]
+
+    features:
+      - name: context_assembly
+        source: codebase.specifications + codebase.existing_code
+        extraction: "token-budgeted context: 30% task spec, 40% code, 20% guidelines, 10% examples"
+      - name: interface_contracts
+        source: codebase.specifications
+        extraction: "exported types, function signatures, and patterns from referenced PRDs"
+      - name: test_expectations
+        source: task.issue_description.acceptance_criteria
+        extraction: "checkable outcomes mapped to test assertions"
+
+    algorithm:
+      type: specification_driven_generation
+      parameters:
+        max_agent_turns: 20
+        timeout_minutes: 10
+      logic: |
+        Read required_reading to understand contracts and context
+        For each file in task.files:
+          If action == create: generate from specifications
+          If action == modify: read existing, apply changes per requirements
+        Run quality gates (build, lint, test)
+        If tests fail: analyze failure, regenerate affected code
+        Iterate until acceptance_criteria satisfied or max_agent_turns reached
+
+    output_format:
+      type: list[ModifiedFile]
+      fields: [path, action, content]
+      postconditions:
+        - "all acceptance_criteria verified"
+        - "build passes"
+        - "lint passes"
+        - "tests pass"
+
+recovery:
+  semantic_model:
+    name: "cobbler-recovery"
+    version: "1.0.0"
+
+    data_sources:
+      - id: generation_state
+        connector: git + github
+        queries:
+          - name: generation_branch
+            source: "git branch --list 'gen-*'"
+            returns: {branch_name, last_commit, lifecycle_tags}
+          - name: stale_worktrees
+            source: "git worktree list"
+            returns: list[{path, branch, commit}]
+          - name: open_task_issues
+            source: "gh issue list --label generation"
+            returns: list[Issue]
+
+    features:
+      - name: interrupted_generation
+        source: generation_state.generation_branch
+        extraction: "branch with -start tag but no -finished tag"
+      - name: orphaned_worktrees
+        source: generation_state.stale_worktrees
+        extraction: "worktrees whose task branch has no open issue"
+      - name: resumable_backlog
+        source: generation_state.open_task_issues
+        extraction: "issues still open, ordered by dependency"
+
+    algorithm:
+      type: state_recovery
+      logic: |
+        If interrupted_generation exists:
+          Clean orphaned_worktrees
+          Resume from resumable_backlog
+        Else:
+          Start new generation from measure
+
+    output_format:
+      type: GenerationState
+      fields: [action, branch, next_issue]
+      actions: [resume, start_new, abort]

--- a/pkg/orchestrator/analyze.go
+++ b/pkg/orchestrator/analyze.go
@@ -31,13 +31,15 @@ type AnalyzeResult struct {
 	DependencyRuleViolations       []string // component_dependencies violating an allowed=false dependency_rule
 	BrokenStructRefs               []string // struct_refs pointing to non-existent PRD or requirement group
 	ComponentDepViolations         []string // depends_on entries not reflected in component_dependencies
+	SemanticModelErrors            []string // semantic model validation errors (SM1, SM3, SM7)
 }
 
 // analyzeCounts holds the artifact counts discovered during analysis.
 type analyzeCounts struct {
-	PRDs       int
-	UseCases   int
-	TestSuites int
+	PRDs           int
+	UseCases       int
+	TestSuites     int
+	SemanticModels int
 }
 
 // collectAnalyzeResult performs all cross-artifact consistency checks and
@@ -362,10 +364,17 @@ func (o *Orchestrator) collectAnalyzeResult() (AnalyzeResult, analyzeCounts, err
 	result.ConstitutionDrift = detectConstitutionDrift()
 	logf("analyze: constitution drift found %d file(s)", len(result.ConstitutionDrift))
 
+	// Check 14: Semantic model validation — validate standalone files,
+	// PRD shorthand models, and prompt-embedded full models.
+	smErrs, smCount := validateSemanticModels(prdFiles)
+	result.SemanticModelErrors = smErrs
+	logf("analyze: semantic model validation found %d error(s), %d standalone file(s)", len(smErrs), smCount)
+
 	counts := analyzeCounts{
-		PRDs:       len(prdIDs),
-		UseCases:   len(ucIDs),
-		TestSuites: len(testSuiteIDs),
+		PRDs:           len(prdIDs),
+		UseCases:       len(ucIDs),
+		TestSuites:     len(testSuiteIDs),
+		SemanticModels: smCount,
 	}
 	return result, counts, nil
 }
@@ -377,7 +386,7 @@ func (o *Orchestrator) Analyze() error {
 	if err != nil {
 		return err
 	}
-	return result.printReport(counts.PRDs, counts.UseCases, counts.TestSuites)
+	return result.printReport(counts.PRDs, counts.UseCases, counts.TestSuites, counts.SemanticModels)
 }
 
 // printSection prints a labeled list if items is non-empty, returning true.
@@ -394,7 +403,7 @@ func printSection(label string, items []string) bool {
 
 // printReport formats the analysis results to stdout. Returns nil when
 // all checks pass, or an error summarising that issues were found.
-func (r AnalyzeResult) printReport(prdCount, ucCount, tsCount int) error {
+func (r AnalyzeResult) printReport(prdCount, ucCount, tsCount, smCount int) error {
 	hasIssues := false
 	hasIssues = printSection("Orphaned PRDs (no use case references them)", r.OrphanedPRDs) || hasIssues
 	hasIssues = printSection("Releases without test suites (no docs/specs/test-suites/test-<release>.yaml)", r.ReleasesWithoutTestSuites) || hasIssues
@@ -410,12 +419,14 @@ func (r AnalyzeResult) printReport(prdCount, ucCount, tsCount int) error {
 	hasIssues = printSection("Dependency rule violations (component_dependency violates allowed=false rule)", r.DependencyRuleViolations) || hasIssues
 	hasIssues = printSection("Broken struct_refs (prd_id or requirement group not found)", r.BrokenStructRefs) || hasIssues
 	hasIssues = printSection("component_dependencies gaps (depends_on entries missing from component_dependencies)", r.ComponentDepViolations) || hasIssues
+	hasIssues = printSection("Semantic model errors (SM1 sections, SM3 traceability, SM7 naming)", r.SemanticModelErrors) || hasIssues
 
 	if !hasIssues {
 		fmt.Printf("\n✅ All consistency checks passed\n")
 		fmt.Printf("   - %d PRDs\n", prdCount)
 		fmt.Printf("   - %d use cases\n", ucCount)
 		fmt.Printf("   - %d test suites\n", tsCount)
+		fmt.Printf("   - %d semantic models\n", smCount)
 		return nil
 	}
 	return fmt.Errorf("found consistency issues (see above)")
@@ -614,6 +625,7 @@ func (o *Orchestrator) validateDocSchemas() []string {
 	errs = append(errs, validateYAMLStrict[ExecutionDoc]("docs/constitutions/execution.yaml")...)
 	errs = append(errs, validateYAMLStrict[GoStyleDoc]("docs/constitutions/go-style.yaml")...)
 	errs = append(errs, validateYAMLStrict[PlanningDoc]("docs/constitutions/planning.yaml")...)
+	errs = append(errs, validateYAMLStrict[SemanticModelDoc]("docs/constitutions/semantic-model.yaml")...)
 	errs = append(errs, validateYAMLStrict[TestingDoc]("docs/constitutions/testing.yaml")...)
 
 	// Embedded constitutions in pkg/orchestrator/constitutions/.
@@ -702,4 +714,213 @@ func detectConstitutionDrift() []string {
 		}
 	}
 	return drifted
+}
+
+// ---------------------------------------------------------------------------
+// Semantic model validation (R1–R7, SM1, SM3, SM7)
+// ---------------------------------------------------------------------------
+
+// smNameRe matches a valid semantic model name: lowercase words separated by hyphens, ≥2 parts.
+var smNameRe = regexp.MustCompile(`^[a-z][a-z0-9]*(-[a-z][a-z0-9]*)+$`)
+
+// smSemverRe matches a valid semver version string: MAJOR.MINOR.PATCH.
+var smSemverRe = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
+
+// smIdentRe extracts dot-separated identifier chains from a source expression.
+var smIdentRe = regexp.MustCompile(`[a-z_][a-z0-9_]*(?:\.[a-z_][a-z0-9_]*)*`)
+
+// validateSemanticModels runs all semantic model checks (R1–R6).
+// prdFiles is the already-globbed list of PRD paths. Returns errors and
+// the count of standalone semantic model files found.
+func validateSemanticModels(prdFiles []string) ([]string, int) {
+	var errs []string
+
+	// R1: Count standalone files in docs/specs/semantic-models/.
+	smFiles, _ := filepath.Glob("docs/specs/semantic-models/*.yaml")
+
+	// R4 + R5 + R6: Validate each standalone file.
+	for _, path := range smFiles {
+		errs = append(errs, validateStandaloneSemanticModel(path)...)
+	}
+
+	// R2: Scan PRDs for inline shorthand semantic_model:.
+	for _, path := range prdFiles {
+		errs = append(errs, validatePRDSemanticModel(path)...)
+	}
+
+	// R3: Scan docs/prompts/*.yaml for inline full semantic_model:.
+	promptFiles, _ := filepath.Glob("docs/prompts/*.yaml")
+	for _, path := range promptFiles {
+		errs = append(errs, validatePromptSemanticModel(path)...)
+	}
+
+	return errs, len(smFiles)
+}
+
+// validateStandaloneSemanticModel validates a standalone semantic model file
+// (docs/specs/semantic-models/*.yaml). Each top-level key names a behavior;
+// its value must have a semantic_model sub-key with all four sections.
+func validateStandaloneSemanticModel(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var raw map[string]struct {
+		SemanticModel map[string]interface{} `yaml:"semantic_model"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return []string{fmt.Sprintf("%s: invalid YAML: %v", path, err)}
+	}
+	var errs []string
+	for behavior, entry := range raw {
+		prefix := fmt.Sprintf("%s [%s].semantic_model", path, behavior)
+		sm := entry.SemanticModel
+		if sm == nil {
+			errs = append(errs, fmt.Sprintf("%s: behavior %q missing semantic_model sub-key", path, behavior))
+			continue
+		}
+		errs = append(errs, smValidateSections(prefix, sm)...)
+		errs = append(errs, smValidateSM7(prefix, sm)...)
+		errs = append(errs, smValidateSM3(prefix, sm)...)
+	}
+	return errs
+}
+
+// validatePRDSemanticModel checks a PRD file for an optional semantic_model:
+// field. When present, it must use the shorthand format (observe, reason, produce).
+func validatePRDSemanticModel(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var raw struct {
+		SemanticModel map[string]interface{} `yaml:"semantic_model"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil // YAML errors reported by schema validation
+	}
+	if raw.SemanticModel == nil {
+		return nil // no semantic model in this PRD
+	}
+	var errs []string
+	for _, key := range []string{"observe", "reason", "produce"} {
+		if _, ok := raw.SemanticModel[key]; !ok {
+			errs = append(errs, fmt.Sprintf("%s: semantic_model missing shorthand key %q (observe/reason/produce required)", path, key))
+		}
+	}
+	return errs
+}
+
+// validatePromptSemanticModel checks a prompt template file for an optional
+// semantic_model: field. When present, it must use the full format (SM1).
+func validatePromptSemanticModel(path string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var raw struct {
+		SemanticModel map[string]interface{} `yaml:"semantic_model"`
+	}
+	if err := yaml.Unmarshal(data, &raw); err != nil {
+		return nil
+	}
+	if raw.SemanticModel == nil {
+		return nil
+	}
+	prefix := path + ".semantic_model"
+	return smValidateSections(prefix, raw.SemanticModel)
+}
+
+// smValidateSections checks that a semantic model map has all four required
+// sections: data_sources, features, algorithm, output_format (SM1).
+func smValidateSections(prefix string, sm map[string]interface{}) []string {
+	var errs []string
+	for _, section := range []string{"data_sources", "features", "algorithm", "output_format"} {
+		if _, ok := sm[section]; !ok {
+			errs = append(errs, fmt.Sprintf("%s: missing required section %q (SM1)", prefix, section))
+		}
+	}
+	return errs
+}
+
+// smValidateSM7 checks that a semantic model's name matches the
+// {word}-{word}+ pattern and its version is valid semver (SM7).
+func smValidateSM7(prefix string, sm map[string]interface{}) []string {
+	var errs []string
+	if name, _ := sm["name"].(string); name != "" {
+		if !smNameRe.MatchString(name) {
+			errs = append(errs, fmt.Sprintf("%s: name %q does not match {word}-{word}+ pattern (SM7)", prefix, name))
+		}
+	}
+	if version, _ := sm["version"].(string); version != "" {
+		if !smSemverRe.MatchString(version) {
+			errs = append(errs, fmt.Sprintf("%s: version %q is not valid semver MAJOR.MINOR.PATCH (SM7)", prefix, version))
+		}
+	}
+	return errs
+}
+
+// smValidateSM3 checks that each feature's source references a declared
+// data_sources[*].id or another feature name (SM3).
+func smValidateSM3(prefix string, sm map[string]interface{}) []string {
+	// Collect declared data source IDs.
+	dataSourceIDs := make(map[string]bool)
+	if dsRaw, ok := sm["data_sources"]; ok {
+		if dsList, ok := dsRaw.([]interface{}); ok {
+			for _, ds := range dsList {
+				if dsMap, ok := ds.(map[string]interface{}); ok {
+					if id, ok := dsMap["id"].(string); ok && id != "" {
+						dataSourceIDs[id] = true
+					}
+				}
+			}
+		}
+	}
+
+	// Collect declared feature names.
+	featureNames := make(map[string]bool)
+	type featureEntry struct{ name, source string }
+	var features []featureEntry
+	if featRaw, ok := sm["features"]; ok {
+		if featList, ok := featRaw.([]interface{}); ok {
+			for _, f := range featList {
+				if fm, ok := f.(map[string]interface{}); ok {
+					name, _ := fm["name"].(string)
+					source, _ := fm["source"].(string)
+					if name != "" {
+						featureNames[name] = true
+					}
+					features = append(features, featureEntry{name, source})
+				}
+			}
+		}
+	}
+
+	// Check each feature's source references.
+	var errs []string
+	for _, feat := range features {
+		for _, ref := range smSourceRefs(feat.source) {
+			if !dataSourceIDs[ref] && !featureNames[ref] {
+				errs = append(errs, fmt.Sprintf("%s: feature %q source references undeclared id %q (SM3)", prefix, feat.name, ref))
+			}
+		}
+	}
+	return errs
+}
+
+// smSourceRefs extracts the base identifiers from a source expression.
+// "network_state.site_capacity - project_state.implemented" -> ["network_state", "project_state"]
+// "implementation_gap" -> ["implementation_gap"]
+func smSourceRefs(source string) []string {
+	tokens := smIdentRe.FindAllString(strings.ToLower(source), -1)
+	seen := make(map[string]bool)
+	var bases []string
+	for _, tok := range tokens {
+		base := strings.SplitN(tok, ".", 2)[0]
+		if !seen[base] {
+			seen[base] = true
+			bases = append(bases, base)
+		}
+	}
+	return bases
 }

--- a/pkg/orchestrator/analyze_test.go
+++ b/pkg/orchestrator/analyze_test.go
@@ -1009,7 +1009,7 @@ func TestPrintSection_WithItems(t *testing.T) {
 func TestPrintReport_AllClear(t *testing.T) {
 	r := AnalyzeResult{}
 	out := captureStdout(t, func() {
-		err := r.printReport(5, 10, 3)
+		err := r.printReport(5, 10, 3, 0)
 		if err != nil {
 			t.Errorf("expected nil error for clean report, got %v", err)
 		}
@@ -1026,6 +1026,9 @@ func TestPrintReport_AllClear(t *testing.T) {
 	if !strings.Contains(out, "3 test suites") {
 		t.Errorf("output missing test suite count, got %q", out)
 	}
+	if !strings.Contains(out, "0 semantic models") {
+		t.Errorf("output missing semantic model count, got %q", out)
+	}
 }
 
 func TestPrintReport_WithIssues(t *testing.T) {
@@ -1034,7 +1037,7 @@ func TestPrintReport_WithIssues(t *testing.T) {
 		BrokenCitations: []string{"uc001 T1: prd001 R99 not found"},
 	}
 	out := captureStdout(t, func() {
-		err := r.printReport(2, 3, 1)
+		err := r.printReport(2, 3, 1, 0)
 		if err == nil {
 			t.Error("expected error for report with issues")
 		}
@@ -1067,7 +1070,7 @@ func TestPrintReport_AllSections(t *testing.T) {
 		PRDsSpanningMultipleReleases: []string{"j"},
 	}
 	out := captureStdout(t, func() {
-		err := r.printReport(1, 1, 1)
+		err := r.printReport(1, 1, 1, 0)
 		if err == nil {
 			t.Error("expected error when all sections have issues")
 		}
@@ -1505,5 +1508,394 @@ overview:
 	}
 	if len(result.ComponentDepViolations) != 0 {
 		t.Errorf("expected no violations when no component_dependencies, got %v", result.ComponentDepViolations)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Semantic model validation tests (R1–R6, SM1, SM3, SM7)
+// ---------------------------------------------------------------------------
+
+func TestSmValidateSections_AllPresent(t *testing.T) {
+	t.Parallel()
+	sm := map[string]interface{}{
+		"data_sources": []interface{}{},
+		"features":     []interface{}{},
+		"algorithm":    map[string]interface{}{"type": "gap"},
+		"output_format": map[string]interface{}{"type": "list"},
+	}
+	errs := smValidateSections("test", sm)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for full model, got %v", errs)
+	}
+}
+
+func TestSmValidateSections_MissingSection(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		missing string
+	}{
+		{"data_sources"},
+		{"features"},
+		{"algorithm"},
+		{"output_format"},
+	}
+	for _, tt := range tests {
+		sm := map[string]interface{}{
+			"data_sources":  []interface{}{},
+			"features":      []interface{}{},
+			"algorithm":     map[string]interface{}{},
+			"output_format": map[string]interface{}{},
+		}
+		delete(sm, tt.missing)
+		errs := smValidateSections("prefix", sm)
+		if len(errs) != 1 {
+			t.Errorf("missing %q: expected 1 error, got %d: %v", tt.missing, len(errs), errs)
+			continue
+		}
+		if !strings.Contains(errs[0], tt.missing) {
+			t.Errorf("missing %q: error should mention section name, got %q", tt.missing, errs[0])
+		}
+		if !strings.Contains(errs[0], "SM1") {
+			t.Errorf("missing %q: error should mention SM1, got %q", tt.missing, errs[0])
+		}
+	}
+}
+
+func TestSmValidateSM7_ValidNameAndVersion(t *testing.T) {
+	t.Parallel()
+	sm := map[string]interface{}{
+		"name":    "cobbler-measure",
+		"version": "1.0.0",
+	}
+	errs := smValidateSM7("test", sm)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for valid name/version, got %v", errs)
+	}
+}
+
+func TestSmValidateSM7_InvalidName(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"cobbler", "Cobbler-Measure", "cobbler_measure", ""} {
+		sm := map[string]interface{}{"name": name, "version": "1.0.0"}
+		errs := smValidateSM7("test", sm)
+		if name == "" {
+			// empty name: no validation triggered
+			if len(errs) != 0 {
+				t.Errorf("empty name: expected no error, got %v", errs)
+			}
+			continue
+		}
+		if len(errs) != 1 {
+			t.Errorf("name %q: expected 1 error, got %d: %v", name, len(errs), errs)
+			continue
+		}
+		if !strings.Contains(errs[0], "SM7") {
+			t.Errorf("name %q: error should mention SM7, got %q", name, errs[0])
+		}
+	}
+}
+
+func TestSmValidateSM7_InvalidVersion(t *testing.T) {
+	t.Parallel()
+	for _, ver := range []string{"1.0", "v1.0.0", "1.0.0.0", "latest"} {
+		sm := map[string]interface{}{"name": "edge-compute", "version": ver}
+		errs := smValidateSM7("test", sm)
+		if len(errs) != 1 {
+			t.Errorf("version %q: expected 1 error, got %d: %v", ver, len(errs), errs)
+			continue
+		}
+		if !strings.Contains(errs[0], "SM7") {
+			t.Errorf("version %q: error should mention SM7, got %q", ver, errs[0])
+		}
+	}
+}
+
+func TestSmSourceRefs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		source string
+		want   []string
+	}{
+		{"specification_tree.all_use_cases - project_state.implemented", []string{"specification_tree", "project_state"}},
+		{"implementation_gap", []string{"implementation_gap"}},
+		{"codebase.specifications + codebase.existing_code", []string{"codebase"}},
+		{"task.issue_description.acceptance_criteria", []string{"task"}},
+		{"", nil},
+	}
+	for _, tt := range tests {
+		got := smSourceRefs(tt.source)
+		if len(got) != len(tt.want) {
+			t.Errorf("source %q: got %v, want %v", tt.source, got, tt.want)
+			continue
+		}
+		for i, w := range tt.want {
+			if got[i] != w {
+				t.Errorf("source %q: got[%d]=%q, want %q", tt.source, i, got[i], w)
+			}
+		}
+	}
+}
+
+func TestSmValidateSM3_ValidTraceability(t *testing.T) {
+	t.Parallel()
+	sm := map[string]interface{}{
+		"data_sources": []interface{}{
+			map[string]interface{}{"id": "network_state"},
+		},
+		"features": []interface{}{
+			map[string]interface{}{"name": "gap", "source": "network_state.capacity"},
+			map[string]interface{}{"name": "derived", "source": "gap"},
+		},
+	}
+	errs := smValidateSM3("test", sm)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for valid traceability, got %v", errs)
+	}
+}
+
+func TestSmValidateSM3_UntetheredFeature(t *testing.T) {
+	t.Parallel()
+	sm := map[string]interface{}{
+		"data_sources": []interface{}{
+			map[string]interface{}{"id": "network_state"},
+		},
+		"features": []interface{}{
+			map[string]interface{}{"name": "bad_feature", "source": "unknown_source.capacity"},
+		},
+	}
+	errs := smValidateSM3("test", sm)
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error for untethered feature, got %d: %v", len(errs), errs)
+	}
+	if len(errs) > 0 && !strings.Contains(errs[0], "SM3") {
+		t.Errorf("error should mention SM3, got %q", errs[0])
+	}
+}
+
+func TestValidateStandaloneSemanticModel_ValidFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := dir + "/model.yaml"
+	os.WriteFile(path, []byte(`measure:
+  semantic_model:
+    name: cobbler-measure
+    version: 1.0.0
+    data_sources:
+      - id: specification_tree
+        connector: filesystem
+    features:
+      - name: implementation_gap
+        source: specification_tree.all_use_cases
+        extraction: set difference
+    algorithm:
+      type: gap_ordered_task_generation
+    output_format:
+      type: list
+`), 0o644)
+	errs := validateStandaloneSemanticModel(path)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for valid standalone model, got %v", errs)
+	}
+}
+
+func TestValidateStandaloneSemanticModel_MissingAlgorithm(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := dir + "/model.yaml"
+	os.WriteFile(path, []byte(`analyze:
+  semantic_model:
+    name: cobbler-analyze
+    version: 1.0.0
+    data_sources:
+      - id: repo
+        connector: filesystem
+    features:
+      - name: counts
+        source: repo.files
+    output_format:
+      type: report
+`), 0o644)
+	errs := validateStandaloneSemanticModel(path)
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error for missing algorithm, got %d: %v", len(errs), errs)
+	}
+	if len(errs) > 0 && !strings.Contains(errs[0], "algorithm") {
+		t.Errorf("error should mention missing section, got %q", errs[0])
+	}
+}
+
+func TestValidatePRDSemanticModel_NoSemanticModel(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := dir + "/prd001.yaml"
+	os.WriteFile(path, []byte(`id: prd001
+title: Test PRD
+problem: test
+`), 0o644)
+	errs := validatePRDSemanticModel(path)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for PRD without semantic_model, got %v", errs)
+	}
+}
+
+func TestValidatePRDSemanticModel_ValidShorthand(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := dir + "/prd001.yaml"
+	os.WriteFile(path, []byte(`id: prd001
+title: Test PRD
+problem: test
+semantic_model:
+  observe: input data
+  reason: apply logic
+  produce: output result
+`), 0o644)
+	errs := validatePRDSemanticModel(path)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for valid shorthand model, got %v", errs)
+	}
+}
+
+func TestValidatePRDSemanticModel_MissingShorthandKey(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := dir + "/prd001.yaml"
+	// Missing "produce" key.
+	os.WriteFile(path, []byte(`id: prd001
+title: Test PRD
+semantic_model:
+  observe: input data
+  reason: apply logic
+`), 0o644)
+	errs := validatePRDSemanticModel(path)
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error for missing produce key, got %d: %v", len(errs), errs)
+	}
+	if len(errs) > 0 && !strings.Contains(errs[0], "produce") {
+		t.Errorf("error should mention missing key, got %q", errs[0])
+	}
+}
+
+func TestValidatePromptSemanticModel_NoSemanticModel(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := dir + "/measure.yaml"
+	os.WriteFile(path, []byte(`role: analyst
+task: analyze
+`), 0o644)
+	errs := validatePromptSemanticModel(path)
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for prompt without semantic_model, got %v", errs)
+	}
+}
+
+func TestValidatePromptSemanticModel_MissingSection(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := dir + "/measure.yaml"
+	// Full format but missing output_format.
+	os.WriteFile(path, []byte(`role: analyst
+semantic_model:
+  data_sources:
+    - id: repo
+  features:
+    - name: gap
+  algorithm:
+    type: gap_ordered
+`), 0o644)
+	errs := validatePromptSemanticModel(path)
+	if len(errs) != 1 {
+		t.Errorf("expected 1 error for missing output_format, got %d: %v", len(errs), errs)
+	}
+	if len(errs) > 0 && !strings.Contains(errs[0], "output_format") {
+		t.Errorf("error should mention missing section, got %q", errs[0])
+	}
+}
+
+func TestValidateSemanticModels_Count(t *testing.T) {
+	// Not parallel: uses os.Chdir.
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	os.MkdirAll("docs/specs/semantic-models", 0o755)
+	os.MkdirAll("docs/specs/product-requirements", 0o755)
+	os.MkdirAll("docs/prompts", 0o755)
+
+	// Write two valid standalone semantic model files.
+	writeValidSMFile := func(name, behavior string) {
+		os.WriteFile("docs/specs/semantic-models/"+name, []byte(behavior+`:
+  semantic_model:
+    name: test-`+behavior+`
+    version: 1.0.0
+    data_sources:
+      - id: src
+        connector: filesystem
+    features:
+      - name: feat
+        source: src.query
+    algorithm:
+      type: simple
+    output_format:
+      type: list
+`), 0o644)
+	}
+	writeValidSMFile("model-a.yaml", "behave")
+	writeValidSMFile("model-b.yaml", "analyze")
+
+	errs, count := validateSemanticModels(nil)
+	if count != 2 {
+		t.Errorf("expected count=2, got %d", count)
+	}
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for valid files, got %v", errs)
+	}
+}
+
+func TestCollectAnalyzeResult_SemanticModelErrors(t *testing.T) {
+	// Not parallel: uses os.Chdir.
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalOODDir(t)
+	os.MkdirAll("docs/specs/semantic-models", 0o755)
+	os.MkdirAll("docs/prompts", 0o755)
+
+	// Write a standalone file missing the algorithm section.
+	os.WriteFile("docs/specs/semantic-models/bad.yaml", []byte(`analyze:
+  semantic_model:
+    name: cobbler-analyze
+    version: 1.0.0
+    data_sources:
+      - id: repo
+    features:
+      - name: counts
+        source: repo.files
+    output_format:
+      type: report
+`), 0o644)
+
+	o := &Orchestrator{cfg: Config{}}
+	result, counts, err := o.collectAnalyzeResult()
+	if err != nil {
+		t.Fatalf("collectAnalyzeResult: %v", err)
+	}
+	if counts.SemanticModels != 1 {
+		t.Errorf("expected SemanticModels=1, got %d", counts.SemanticModels)
+	}
+	if len(result.SemanticModelErrors) == 0 {
+		t.Error("expected at least one semantic model error for missing algorithm")
+	}
+	found := false
+	for _, e := range result.SemanticModelErrors {
+		if strings.Contains(e, "algorithm") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected error mentioning algorithm, got %v", result.SemanticModelErrors)
 	}
 }

--- a/pkg/orchestrator/constitutions/planning.yaml
+++ b/pkg/orchestrator/constitutions/planning.yaml
@@ -13,6 +13,12 @@ articles:
       99.0 (unscheduled). Early preview of later use cases is allowed when they
       share functionality with the current release.
 
+      Use cases in road-map.yaml carry a status field. Use cases with
+      status "implemented" or "done" have existing code and are complete.
+      Do not propose any new tasks for them. Propose tasks only for use
+      cases with status "spec_complete", "pending", or any other value
+      that is not "implemented" or "done".
+
   - id: P2
     title: Task sizing
     rule: |

--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -384,6 +384,7 @@ type PRDDoc struct {
 	PackageContract    *PRDPackageContract            `yaml:"package_contract,omitempty"`
 	DependsOn          []PRDDependsOn                 `yaml:"depends_on,omitempty"`
 	StructRefs         []PRDStructRef                 `yaml:"struct_refs,omitempty"`
+	SemanticModel      *yaml.Node                     `yaml:"semantic_model,omitempty"`
 }
 
 // PRDRequirementGroup is a requirement section within a PRD.
@@ -773,6 +774,17 @@ type PlanningCodeIssues struct {
 
 // TestingDoc corresponds to docs/constitutions/testing.yaml.
 type TestingDoc struct {
+	Articles []ConstitutionArticle `yaml:"articles"`
+	Sections []ConstitutionSection `yaml:"sections,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Semantic model constitution (docs/constitutions/semantic-model.yaml)
+// ---------------------------------------------------------------------------
+
+// SemanticModelDoc corresponds to docs/constitutions/semantic-model.yaml.
+// The constitution only defines articles and sections — no additional sections.
+type SemanticModelDoc struct {
 	Articles []ConstitutionArticle `yaml:"articles"`
 	Sections []ConstitutionSection `yaml:"sections,omitempty"`
 }


### PR DESCRIPTION
## Summary

Adds semantic model validation to `mage analyze`. The check covers three artifact locations (standalone files, PRD inline shorthand, prompt full-format), validates SM1 (four required sections), SM7 (name/semver), and SM3 (feature source traceability). Also commits the two untracked semantic model files and syncs the planning constitution drift from GH-682.

## Changes

- `pkg/orchestrator/context.go`: Add `SemanticModelDoc` for constitution schema validation; add `SemanticModel *yaml.Node` to `PRDDoc` so PRDs with inline semantic models pass strict YAML validation
- `pkg/orchestrator/analyze.go`: `validateSemanticModels()` + helpers (`smValidateSections`, `smValidateSM7`, `smValidateSM3`, `smSourceRefs`, `validateStandaloneSemanticModel`, `validatePRDSemanticModel`, `validatePromptSemanticModel`); `SemanticModelErrors` field in `AnalyzeResult`; `SemanticModels` count in `analyzeCounts`; `printReport` updated with new section and count line
- `pkg/orchestrator/analyze_test.go`: 15 new tests covering all rules; 3 existing `printReport` calls updated for new signature
- `docs/constitutions/semantic-model.yaml`: New constitution (SM1–SM10)
- `docs/specs/semantic-models/cobbler-prototype.yaml`: Prototype behavioral specification for cobbler phases
- `pkg/orchestrator/constitutions/planning.yaml`: Sync embedded copy with docs/ (drift from GH-682)

## Stats

- 6 PRDs, 17 use cases, 3 test suites, 1 semantic model
- `mage analyze`: ✅ 0 errors

## Test plan

- [x] `mage analyze` passes with 0 errors
- [x] All 15 new tests pass
- [x] Full test suite passes

Closes #685