### PR TITLE
GH-686: Add direct CLI execution mode (bypass podman)

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -451,9 +451,16 @@ func parseClaudeTokens(output []byte) ClaudeResult {
 	return ClaudeResult{}
 }
 
-// checkClaude verifies that Claude can be invoked: podman is available,
-// the container image exists, and credentials are present.
+// checkClaude verifies that Claude can be invoked. In podman mode it
+// confirms podman is available and the container image exists. In CLI mode
+// it confirms the claude binary is on PATH. Both modes verify credentials.
 func (o *Orchestrator) checkClaude() error {
+	if o.cfg.Cobbler.effectiveMode() == ExecutionModeCLI {
+		if _, err := exec.LookPath(binClaude); err != nil {
+			return fmt.Errorf("claude not found on PATH; install the Claude CLI or set mode: podman")
+		}
+		return o.ensureCredentials()
+	}
 	if err := o.checkPodman(); err != nil {
 		return err
 	}
@@ -583,7 +590,12 @@ func (o *Orchestrator) runClaude(prompt, dir string, silence bool, extraClaudeAr
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := o.buildPodmanCmd(ctx, workDir, extraClaudeArgs...)
+	var cmd *exec.Cmd
+	if o.cfg.Cobbler.effectiveMode() == ExecutionModeCLI {
+		cmd = o.buildDirectCmd(ctx, workDir, extraClaudeArgs...)
+	} else {
+		cmd = o.buildPodmanCmd(ctx, workDir, extraClaudeArgs...)
+	}
 
 	cmd.Stdin = strings.NewReader(prompt)
 
@@ -678,6 +690,19 @@ func (o *Orchestrator) buildPodmanCmd(ctx context.Context, workDir string, extra
 
 	logf("runClaude: exec %s %v (timeout=%s)", binPodman, args, o.cfg.ClaudeTimeout())
 	return exec.CommandContext(ctx, binPodman, args...)
+}
+
+// buildDirectCmd constructs the exec.Cmd for running the claude binary
+// directly on the host, without a podman container. The working directory
+// is set on the command so Claude Code operates within the correct project
+// root. No volume mounts or image selection are involved.
+func (o *Orchestrator) buildDirectCmd(ctx context.Context, workDir string, extraClaudeArgs ...string) *exec.Cmd {
+	args := append([]string{}, o.cfg.Claude.Args...)
+	args = append(args, extraClaudeArgs...)
+	logf("runClaude: exec %s %v (mode=cli timeout=%s)", binClaude, args, o.cfg.ClaudeTimeout())
+	cmd := exec.CommandContext(ctx, binClaude, args...)
+	cmd.Dir = workDir
+	return cmd
 }
 
 // logConfig prints the resolved configuration for debugging.

--- a/pkg/orchestrator/cobbler_test.go
+++ b/pkg/orchestrator/cobbler_test.go
@@ -682,6 +682,88 @@ func TestBuildPodmanCmd_ExtraArgsAppended(t *testing.T) {
 	}
 }
 
+// --- buildDirectCmd ---
+
+func TestBuildDirectCmd_UsesClaudeBinary(t *testing.T) {
+	t.Parallel()
+	o := New(Config{})
+	cmd := o.buildDirectCmd(context.TODO(), "/work/mydir")
+
+	if cmd.Path == "" {
+		t.Fatal("buildDirectCmd returned cmd with empty Path")
+	}
+	// The command base name must be "claude" (exact binary lookup may vary).
+	if !strings.HasSuffix(cmd.Path, binClaude) && cmd.Args[0] != binClaude {
+		t.Errorf("buildDirectCmd should invoke %q; got Path=%q Args=%v", binClaude, cmd.Path, cmd.Args)
+	}
+}
+
+func TestBuildDirectCmd_SetsWorkDir(t *testing.T) {
+	t.Parallel()
+	o := New(Config{})
+	cmd := o.buildDirectCmd(context.TODO(), "/work/mydir")
+
+	if cmd.Dir != "/work/mydir" {
+		t.Errorf("buildDirectCmd cmd.Dir = %q; want /work/mydir", cmd.Dir)
+	}
+}
+
+func TestBuildDirectCmd_ExtraArgsAppended(t *testing.T) {
+	t.Parallel()
+	o := New(Config{})
+	cmd := o.buildDirectCmd(context.TODO(), "/work", "--max-turns", "5")
+
+	joined := strings.Join(cmd.Args, " ")
+	if !strings.Contains(joined, "--max-turns") {
+		t.Errorf("buildDirectCmd missing extra arg --max-turns; args=%v", cmd.Args)
+	}
+	if !strings.Contains(joined, "5") {
+		t.Errorf("buildDirectCmd missing extra arg 5; args=%v", cmd.Args)
+	}
+}
+
+func TestBuildDirectCmd_NoVolumeMount(t *testing.T) {
+	t.Parallel()
+	o := New(Config{})
+	cmd := o.buildDirectCmd(context.TODO(), "/work/mydir")
+
+	joined := strings.Join(cmd.Args, " ")
+	// Check for the podman-style volume mount pattern ("-v /path:/path"),
+	// not just "-v" which would match "--verbose".
+	if strings.Contains(joined, " -v /") {
+		t.Errorf("buildDirectCmd should not contain volume mount flags; args=%v", cmd.Args)
+	}
+	if strings.Contains(joined, binPodman) {
+		t.Errorf("buildDirectCmd should not invoke podman; args=%v", cmd.Args)
+	}
+}
+
+// --- effectiveMode ---
+
+func TestEffectiveMode_DefaultIsPodman(t *testing.T) {
+	t.Parallel()
+	cfg := CobblerConfig{}
+	if got := cfg.effectiveMode(); got != ExecutionModePodman {
+		t.Errorf("effectiveMode() = %q; want %q", got, ExecutionModePodman)
+	}
+}
+
+func TestEffectiveMode_CLIMode(t *testing.T) {
+	t.Parallel()
+	cfg := CobblerConfig{Mode: ExecutionModeCLI}
+	if got := cfg.effectiveMode(); got != ExecutionModeCLI {
+		t.Errorf("effectiveMode() = %q; want %q", got, ExecutionModeCLI)
+	}
+}
+
+func TestEffectiveMode_UnknownFallsToPodman(t *testing.T) {
+	t.Parallel()
+	cfg := CobblerConfig{Mode: "docker"}
+	if got := cfg.effectiveMode(); got != ExecutionModePodman {
+		t.Errorf("effectiveMode() with unknown mode = %q; want %q", got, ExecutionModePodman)
+	}
+}
+
 // --- saveHistory* best-effort behavior ---
 
 func TestSaveHistoryReport_EmptyHistoryDir_NoOp(t *testing.T) {

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -278,6 +278,33 @@ type CobblerConfig struct {
 	// the last argument. stdout replaces the file content in the prompt.
 	// On non-zero exit or empty output, the full file content is used.
 	MeasureSummarizeCommand string `yaml:"measure_summarize_command"`
+
+	// Mode selects the Claude execution backend. Valid values are
+	// ExecutionModePodman (default, run Claude inside a podman container)
+	// and ExecutionModeCLI (run the claude binary directly on the host,
+	// bypassing podman). Use ExecutionModeCLI in environments where podman
+	// is unavailable or when the host already provides an isolated claude
+	// installation. See prd001 R11.
+	Mode string `yaml:"mode"`
+}
+
+// Execution mode constants for CobblerConfig.Mode.
+const (
+	// ExecutionModePodman runs Claude inside a podman container (default).
+	ExecutionModePodman = "podman"
+
+	// ExecutionModeCLI runs the claude binary directly on the host,
+	// bypassing podman volume mounts and image management.
+	ExecutionModeCLI = "cli"
+)
+
+// effectiveMode returns the execution mode, defaulting to ExecutionModePodman
+// when Mode is empty or unrecognised.
+func (c *CobblerConfig) effectiveMode() string {
+	if c.Mode == ExecutionModeCLI {
+		return ExecutionModeCLI
+	}
+	return ExecutionModePodman
 }
 
 // PodmanConfig holds settings for the podman container runtime.


### PR DESCRIPTION
## Summary

Adds `ExecutionModeCLI` as an alternative to the default podman-based execution. Setting `cobbler.mode: cli` in `configuration.yaml` runs the `claude` binary directly on the host — no podman, no volume mounts, no image management — making cobbler usable in environments where podman is unavailable or undesired.

## Changes

- `config.go`: `Mode string` field on `CobblerConfig`, `effectiveMode()` helper defaulting to `"podman"`, `ExecutionModePodman`/`ExecutionModeCLI` constants
- `cobbler.go`: `buildDirectCmd()` sets `cmd.Dir` instead of constructing podman flags; `runClaude()` branches on `effectiveMode()`; `checkClaude()` skips podman and image checks in CLI mode, verifies only that `claude` is on PATH
- `cobbler_test.go`: 7 new tests — `TestBuildDirectCmd_*` (4) and `TestEffectiveMode_*` (3)

## Stats

All 60+ tests pass. `mage analyze` clean.

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] `TestBuildDirectCmd_*` and `TestEffectiveMode_*` cover new paths

Closes #686