### PR TITLE
GH-700: Set CLI execution mode for use-case test snapshots

### DIFF
--- a/tests/rel01.0/internal/testutil/snapshot.go
+++ b/tests/rel01.0/internal/testutil/snapshot.go
@@ -92,6 +92,7 @@ func overrideSnapshotIssuesRepo(snapDir, issuesRepo string) error {
 		return err
 	}
 	cfg.Cobbler.IssuesRepo = issuesRepo
+	cfg.Cobbler.Mode = orchestrator.ExecutionModeCLI
 	newData, err := yaml.Marshal(&cfg)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

`PrepareSnapshot` now writes `cobbler.mode: cli` into each snapshot's `configuration.yaml` alongside `cobbler.issues_repo`. All `PrepareSnapshot`-based use-case tests invoke `claude` directly on the host instead of routing through podman.

## Changes

- `tests/rel01.0/internal/testutil/snapshot.go`: one line — `cfg.Cobbler.Mode = orchestrator.ExecutionModeCLI` in `overrideSnapshotIssuesRepo`

## Test plan

- [x] `mage analyze` passes
- [x] `go build ./...` passes

Closes #700