### PR TITLE
GH-697: Run mage test:usecase — 53/53 pass, fix CLI mode CLAUDECODE regression

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -696,12 +696,25 @@ func (o *Orchestrator) buildPodmanCmd(ctx context.Context, workDir string, extra
 // directly on the host, without a podman container. The working directory
 // is set on the command so Claude Code operates within the correct project
 // root. No volume mounts or image selection are involved.
+//
+// CLAUDECODE is stripped from the environment so that claude can start even
+// when the caller is itself running inside a Claude Code session. Without this,
+// claude detects the nested session and exits with status 1.
 func (o *Orchestrator) buildDirectCmd(ctx context.Context, workDir string, extraClaudeArgs ...string) *exec.Cmd {
 	args := append([]string{}, o.cfg.Claude.Args...)
 	args = append(args, extraClaudeArgs...)
 	logf("runClaude: exec %s %v (mode=cli timeout=%s)", binClaude, args, o.cfg.ClaudeTimeout())
 	cmd := exec.CommandContext(ctx, binClaude, args...)
 	cmd.Dir = workDir
+	// Inherit the full environment but remove CLAUDECODE so that the claude
+	// subprocess does not see itself as nested inside another Claude session.
+	filtered := make([]string, 0, len(os.Environ()))
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, "CLAUDECODE=") {
+			filtered = append(filtered, e)
+		}
+	}
+	cmd.Env = filtered
 	return cmd
 }
 

--- a/pkg/orchestrator/cobbler_test.go
+++ b/pkg/orchestrator/cobbler_test.go
@@ -738,6 +738,21 @@ func TestBuildDirectCmd_NoVolumeMount(t *testing.T) {
 	}
 }
 
+func TestBuildDirectCmd_StripsCLAUDECODE(t *testing.T) {
+	t.Setenv("CLAUDECODE", "1")
+	o := New(Config{})
+	cmd := o.buildDirectCmd(context.TODO(), "/work")
+
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "CLAUDECODE=") {
+			t.Errorf("buildDirectCmd should strip CLAUDECODE from env; found %q", e)
+		}
+	}
+	if cmd.Env == nil {
+		t.Error("buildDirectCmd should set cmd.Env (not nil) when stripping CLAUDECODE")
+	}
+}
+
 // --- effectiveMode ---
 
 func TestEffectiveMode_DefaultIsPodman(t *testing.T) {


### PR DESCRIPTION
## Summary

All 53 use-case tests pass across 8 packages. One regression was found and fixed: CLI mode (`buildDirectCmd`, added in GH-686) inherited `CLAUDECODE` from the host environment, causing Claude to refuse to start with "nested sessions" error. The fix filters `CLAUDECODE` from the subprocess environment.

## Changes

- `pkg/orchestrator/cobbler.go`: filter `CLAUDECODE` from `cmd.Env` in `buildDirectCmd` so Claude can start when the caller is itself inside a Claude Code session
- `pkg/orchestrator/cobbler_test.go`: `TestBuildDirectCmd_StripsCLAUDECODE`

## Stats

```
go_loc: 31053
prd: 8441 words | use_case: 7163 words | test_suite: 3676 words
```

## Test plan

- [x] `mage analyze` passes
- [x] All 53 use-case tests pass (8 packages, 0 failures, 0 skips)
- [x] Unit tests pass

Closes #697