### PR TITLE
GH-687: Add Agent SDK execution mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,3 +3,5 @@ module github.com/mesh-intelligence/cobbler-scaffold
 go 1.25.7
 
 require gopkg.in/yaml.v3 v3.0.1
+
+require github.com/schlunsen/claude-agent-sdk-go v0.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
+github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/magefiles/go.mod
+++ b/magefiles/go.mod
@@ -7,6 +7,9 @@ require (
 	github.com/mesh-intelligence/cobbler-scaffold v0.20260222.1
 )
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require (
+	github.com/schlunsen/claude-agent-sdk-go v0.5.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)
 
 replace github.com/mesh-intelligence/cobbler-scaffold => ../

--- a/magefiles/go.sum
+++ b/magefiles/go.sum
@@ -1,7 +1,7 @@
 github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
 github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260222.1 h1:vtKyGacBygYXgY5tWmBUL1caCOkpC31pa77oVXwLi1k=
-github.com/mesh-intelligence/cobbler-scaffold v0.20260222.1/go.mod h1:9w4n94XEc6kmBFv+YNwofyopXKBoGnayNB6Xd+2h9EU=
+github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
+github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -12,10 +12,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"time"
 
+	claudesdk "github.com/schlunsen/claude-agent-sdk-go"
+	claudetypes "github.com/schlunsen/claude-agent-sdk-go/types"
 	"gopkg.in/yaml.v3"
 )
 
@@ -452,10 +455,12 @@ func parseClaudeTokens(output []byte) ClaudeResult {
 }
 
 // checkClaude verifies that Claude can be invoked. In podman mode it
-// confirms podman is available and the container image exists. In CLI mode
-// it confirms the claude binary is on PATH. Both modes verify credentials.
+// confirms podman is available and the container image exists. In CLI and
+// SDK modes it confirms the claude binary is on PATH. All modes verify
+// credentials.
 func (o *Orchestrator) checkClaude() error {
-	if o.cfg.Cobbler.effectiveMode() == ExecutionModeCLI {
+	switch o.cfg.Cobbler.effectiveMode() {
+	case ExecutionModeCLI, ExecutionModeSDK:
 		if _, err := exec.LookPath(binClaude); err != nil {
 			return fmt.Errorf("claude not found on PATH; install the Claude CLI or set mode: podman")
 		}
@@ -590,6 +595,10 @@ func (o *Orchestrator) runClaude(prompt, dir string, silence bool, extraClaudeAr
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	if o.cfg.Cobbler.effectiveMode() == ExecutionModeSDK {
+		return o.runClaudeSDK(ctx, prompt, workDir, silence, extraClaudeArgs...)
+	}
+
 	var cmd *exec.Cmd
 	if o.cfg.Cobbler.effectiveMode() == ExecutionModeCLI {
 		cmd = o.buildDirectCmd(ctx, workDir, extraClaudeArgs...)
@@ -716,6 +725,103 @@ func (o *Orchestrator) buildDirectCmd(ctx context.Context, workDir string, extra
 	}
 	cmd.Env = filtered
 	return cmd
+}
+
+// runClaudeSDK executes Claude via the Go Agent SDK and returns token usage.
+// It is called by runClaude when the execution mode is ExecutionModeSDK.
+//
+// The SDK communicates with the claude binary via the --stdio JSONL protocol,
+// returning typed message events (AssistantMessage, ResultMessage, etc.).
+// This provides structured streaming and native token reporting without the
+// need for raw stream-json parsing.
+//
+// CLAUDECODE is zeroed in the SDK environment so the claude subprocess can
+// start even when the caller is inside a Claude Code session.
+func (o *Orchestrator) runClaudeSDK(ctx context.Context, prompt, workDir string, silence bool, extraClaudeArgs ...string) (ClaudeResult, error) {
+	opts := claudetypes.NewClaudeAgentOptions()
+	opts.CWD = &workDir
+	opts.DangerouslySkipPermissions = true
+	opts.AllowDangerouslySkipPermissions = true
+
+	// Zero CLAUDECODE so the SDK's claude subprocess starts even when the
+	// caller is running inside a Claude Code session (nested-session guard).
+	opts.Env["CLAUDECODE"] = ""
+
+	// Map --max-turns from extraClaudeArgs into the options struct.
+	for i := 0; i+1 < len(extraClaudeArgs); i++ {
+		if extraClaudeArgs[i] == "--max-turns" {
+			if n, err := strconv.Atoi(extraClaudeArgs[i+1]); err == nil {
+				opts = opts.WithMaxTurns(n)
+			}
+			i++ // skip the value token
+		}
+	}
+
+	logf("runClaude: SDK query workDir=%q (timeout=%s)", workDir, o.cfg.ClaudeTimeout())
+
+	start := time.Now()
+	msgChan, err := claudesdk.Query(ctx, prompt, opts)
+	if err != nil {
+		return ClaudeResult{}, fmt.Errorf("claude SDK query: %w", err)
+	}
+
+	var result ClaudeResult
+	var textBuf strings.Builder
+
+	for msg := range msgChan {
+		switch m := msg.(type) {
+		case *claudetypes.AssistantMessage:
+			for _, block := range m.Content {
+				if tb, ok := block.(*claudetypes.TextBlock); ok {
+					if !silence {
+						fmt.Print(tb.Text)
+					}
+					textBuf.WriteString(tb.Text)
+				}
+			}
+		case *claudetypes.ResultMessage:
+			if m.TotalCostUSD != nil {
+				result.CostUSD = *m.TotalCostUSD
+			}
+			result.InputTokens = intFromUsage(m.Usage, "input_tokens")
+			result.OutputTokens = intFromUsage(m.Usage, "output_tokens")
+			result.CacheCreationTokens = intFromUsage(m.Usage, "cache_creation_input_tokens")
+			result.CacheReadTokens = intFromUsage(m.Usage, "cache_read_input_tokens")
+			if m.IsError {
+				return result, fmt.Errorf("claude SDK session returned error result")
+			}
+		}
+	}
+
+	// Store the collected text as RawOutput for history compatibility.
+	result.RawOutput = []byte(textBuf.String())
+	logf("runClaude: SDK finished in %s in=%d (cache_create=%d cache_read=%d) out=%d cost=$%.4f",
+		time.Since(start).Round(time.Second),
+		result.InputTokens, result.CacheCreationTokens, result.CacheReadTokens,
+		result.OutputTokens, result.CostUSD)
+	return result, nil
+}
+
+// intFromUsage extracts an integer from the ResultMessage usage map,
+// which uses map[string]interface{} because Anthropic API usage fields
+// are JSON numbers (float64 after decode).
+func intFromUsage(usage map[string]interface{}, key string) int {
+	if usage == nil {
+		return 0
+	}
+	v, ok := usage[key]
+	if !ok {
+		return 0
+	}
+	switch n := v.(type) {
+	case float64:
+		return int(n)
+	case int:
+		return n
+	case int64:
+		return int(n)
+	}
+	return 0
 }
 
 // logConfig prints the resolved configuration for debugging.

--- a/pkg/orchestrator/cobbler_test.go
+++ b/pkg/orchestrator/cobbler_test.go
@@ -779,6 +779,63 @@ func TestEffectiveMode_UnknownFallsToPodman(t *testing.T) {
 	}
 }
 
+func TestEffectiveMode_SDKMode(t *testing.T) {
+	t.Parallel()
+	cfg := CobblerConfig{Mode: ExecutionModeSDK}
+	if got := cfg.effectiveMode(); got != ExecutionModeSDK {
+		t.Errorf("effectiveMode() = %q; want %q", got, ExecutionModeSDK)
+	}
+}
+
+// --- intFromUsage ---
+
+func TestIntFromUsage_NilMap(t *testing.T) {
+	t.Parallel()
+	if got := intFromUsage(nil, "input_tokens"); got != 0 {
+		t.Errorf("intFromUsage(nil) = %d; want 0", got)
+	}
+}
+
+func TestIntFromUsage_MissingKey(t *testing.T) {
+	t.Parallel()
+	m := map[string]interface{}{"output_tokens": float64(100)}
+	if got := intFromUsage(m, "input_tokens"); got != 0 {
+		t.Errorf("intFromUsage missing key = %d; want 0", got)
+	}
+}
+
+func TestIntFromUsage_Float64(t *testing.T) {
+	t.Parallel()
+	m := map[string]interface{}{"input_tokens": float64(512)}
+	if got := intFromUsage(m, "input_tokens"); got != 512 {
+		t.Errorf("intFromUsage float64 = %d; want 512", got)
+	}
+}
+
+func TestIntFromUsage_Int(t *testing.T) {
+	t.Parallel()
+	m := map[string]interface{}{"input_tokens": int(256)}
+	if got := intFromUsage(m, "input_tokens"); got != 256 {
+		t.Errorf("intFromUsage int = %d; want 256", got)
+	}
+}
+
+func TestIntFromUsage_Int64(t *testing.T) {
+	t.Parallel()
+	m := map[string]interface{}{"input_tokens": int64(1024)}
+	if got := intFromUsage(m, "input_tokens"); got != 1024 {
+		t.Errorf("intFromUsage int64 = %d; want 1024", got)
+	}
+}
+
+func TestIntFromUsage_UnknownType(t *testing.T) {
+	t.Parallel()
+	m := map[string]interface{}{"input_tokens": "not-a-number"}
+	if got := intFromUsage(m, "input_tokens"); got != 0 {
+		t.Errorf("intFromUsage unknown type = %d; want 0", got)
+	}
+}
+
 // --- saveHistory* best-effort behavior ---
 
 func TestSaveHistoryReport_EmptyHistoryDir_NoOp(t *testing.T) {

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -280,11 +280,11 @@ type CobblerConfig struct {
 	MeasureSummarizeCommand string `yaml:"measure_summarize_command"`
 
 	// Mode selects the Claude execution backend. Valid values are
-	// ExecutionModePodman (default, run Claude inside a podman container)
-	// and ExecutionModeCLI (run the claude binary directly on the host,
-	// bypassing podman). Use ExecutionModeCLI in environments where podman
-	// is unavailable or when the host already provides an isolated claude
-	// installation. See prd001 R11.
+	// ExecutionModePodman (default, run Claude inside a podman container),
+	// ExecutionModeCLI (run the claude binary directly on the host), and
+	// ExecutionModeSDK (use the Go Agent SDK for structured streaming).
+	// Use ExecutionModeCLI or ExecutionModeSDK in environments where podman
+	// is unavailable. See prd001 R11.
 	Mode string `yaml:"mode"`
 }
 
@@ -296,15 +296,26 @@ const (
 	// ExecutionModeCLI runs the claude binary directly on the host,
 	// bypassing podman volume mounts and image management.
 	ExecutionModeCLI = "cli"
+
+	// ExecutionModeSDK uses the Go Agent SDK (github.com/schlunsen/claude-agent-sdk-go)
+	// to run Claude programmatically. The SDK communicates with the claude binary
+	// via the --stdio JSONL protocol and returns typed message events, providing
+	// native streaming, structured token reporting, and cwd isolation without
+	// the need for podman volume mounts.
+	ExecutionModeSDK = "sdk"
 )
 
 // effectiveMode returns the execution mode, defaulting to ExecutionModePodman
 // when Mode is empty or unrecognised.
 func (c *CobblerConfig) effectiveMode() string {
-	if c.Mode == ExecutionModeCLI {
+	switch c.Mode {
+	case ExecutionModeCLI:
 		return ExecutionModeCLI
+	case ExecutionModeSDK:
+		return ExecutionModeSDK
+	default:
+		return ExecutionModePodman
 	}
-	return ExecutionModePodman
 }
 
 // PodmanConfig holds settings for the podman container runtime.


### PR DESCRIPTION
## Summary

Adds a third execution mode (`sdk`) that invokes the Claude CLI via the `github.com/schlunsen/claude-agent-sdk-go` Go SDK instead of a subprocess. SDK mode streams typed `AssistantMessage` and `ResultMessage` events, capturing output and token-usage metrics without spawning a shell process.

## Changes

- `config.go`: Added `ExecutionModeSDK = "sdk"` constant; updated `effectiveMode()` to a switch statement covering all three modes
- `cobbler.go`: Added `runClaudeSDK()` for SDK-based execution; added `intFromUsage()` helper to parse token counts from `map[string]interface{}`; updated `checkClaude()` and `runClaude()` to branch on SDK mode
- `cobbler_test.go`: Added `TestEffectiveMode_SDKMode` and six `TestIntFromUsage_*` tests
- `go.mod` / `go.sum`: Added `github.com/schlunsen/claude-agent-sdk-go v0.5.1`
- `magefiles/go.mod` / `go.sum`: Updated for transitive dependency

## Stats

go_loc_prod: 13213 (+~80 vs v0.20260305.3)
go_loc_test: 18014 (+~50)

## Test plan

- [x] `go test ./pkg/orchestrator/ -count=1` — all pass
- [x] `mage analyze` — 0 errors
- [x] New tests: `TestEffectiveMode_SDKMode`, `TestIntFromUsage_*` (6 cases)

Closes #687