### PR TITLE
GH-747: Close orphaned [measuring] placeholders on Claude failure

### DIFF
--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -246,6 +246,20 @@ func closeMeasuringPlaceholder(repo string, number int) {
 	logf("closeMeasuringPlaceholder: closed #%d", number)
 }
 
+// closeMeasuringPlaceholderWithComment closes the placeholder issue and adds a
+// comment explaining why it was closed. Used on error paths to avoid orphans
+// (GH-747). Best-effort: logs and ignores errors.
+func closeMeasuringPlaceholderWithComment(repo string, number int, comment string) {
+	if err := exec.Command(binGh, "issue", "comment",
+		"--repo", repo,
+		fmt.Sprintf("%d", number),
+		"--body", comment,
+	).Run(); err != nil {
+		logf("closeMeasuringPlaceholderWithComment: comment on #%d warning: %v", number, err)
+	}
+	closeMeasuringPlaceholder(repo, number)
+}
+
 // upgradeMeasuringPlaceholder converts the transient measuring placeholder
 // into the task issue in-place. It edits the placeholder's title and body
 // to match the proposed issue, adds the cobbler-gen label so stitch can

--- a/pkg/orchestrator/issues_gh_test.go
+++ b/pkg/orchestrator/issues_gh_test.go
@@ -668,6 +668,58 @@ func TestCloseMeasuringPlaceholder_FakeRepo_NoOp(t *testing.T) {
 	closeMeasuringPlaceholder("fake/repo-that-does-not-exist", 99999) // must not panic
 }
 
+// TestCloseMeasuringPlaceholderWithComment_FakeRepo_NoOp verifies
+// closeMeasuringPlaceholderWithComment does not panic when the GitHub CLI
+// fails on a fake repo (GH-747).
+func TestCloseMeasuringPlaceholderWithComment_FakeRepo_NoOp(t *testing.T) {
+	t.Parallel()
+	closeMeasuringPlaceholderWithComment("fake/repo-that-does-not-exist", 99999,
+		"Measure did not complete; closed automatically.") // must not panic
+}
+
+// TestPlaceholderResolved_DeferIsNoOpOnSuccess verifies that when
+// placeholderResolved is set to true before a defer fires, the defer body
+// does not call closeMeasuringPlaceholderWithComment (GH-747).
+// We validate the flag contract directly: if resolved==true, defer is skipped;
+// if resolved==false, defer fires with the comment function.
+func TestPlaceholderResolved_DeferIsNoOpOnSuccess(t *testing.T) {
+	t.Parallel()
+	called := false
+	closeFunc := func() { called = true }
+
+	resolved := true
+	func() {
+		defer func() {
+			if !resolved {
+				closeFunc()
+			}
+		}()
+	}()
+	if called {
+		t.Error("closeFunc must not be called when placeholderResolved=true")
+	}
+}
+
+// TestPlaceholderResolved_DeferFiresOnFailure verifies that when
+// placeholderResolved remains false, the defer calls the close function (GH-747).
+func TestPlaceholderResolved_DeferFiresOnFailure(t *testing.T) {
+	t.Parallel()
+	called := false
+	closeFunc := func() { called = true }
+
+	resolved := false
+	func() {
+		defer func() {
+			if !resolved {
+				closeFunc()
+			}
+		}()
+	}()
+	if !called {
+		t.Error("closeFunc must be called when placeholderResolved=false")
+	}
+}
+
 // --- progress comments (GH-567) ---
 
 // TestCommentCobblerIssue_FakeRepo_NoOp verifies commentCobblerIssue does not

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -179,10 +179,19 @@ func (o *Orchestrator) RunMeasure() error {
 		// Create a placeholder issue so users can see measure is running Claude.
 		// The placeholder has no cobbler labels and is invisible to stitch and to
 		// the measure context prompt. It is closed after the iteration regardless
-		// of outcome (GH-568).
+		// of outcome (GH-568). The defer below closes it on any early-return path
+		// (e.g. Claude failure) so it never stays open as an orphan (GH-747).
 		placeholderNum, placeholderErr := createMeasuringPlaceholder(repo, generation, i+1)
 		if placeholderErr != nil {
 			logf("measure: warning: createMeasuringPlaceholder: %v", placeholderErr)
+		}
+		placeholderResolved := false
+		if placeholderNum > 0 {
+			defer func(num int) {
+				if !placeholderResolved {
+					closeMeasuringPlaceholderWithComment(repo, num, "Measure did not complete; closed automatically.")
+				}
+			}(placeholderNum)
 		}
 
 		var createdIDs []string
@@ -307,6 +316,8 @@ func (o *Orchestrator) RunMeasure() error {
 
 		// Close the placeholder only when it was not upgraded in-place (GH-578).
 		// An upgraded placeholder became the task issue; closing it destroys the task.
+		// Mark placeholderResolved so the defer registered above is a no-op (GH-747).
+		placeholderResolved = true
 		if placeholderNum > 0 && !placeholderUpgraded {
 			closeMeasuringPlaceholder(repo, placeholderNum)
 		}


### PR DESCRIPTION
## Summary

When measure's Claude call fails (rate-limit kill, watchdog timeout, network stall), the `[measuring]` placeholder issue was never closed, leaving it permanently open as an orphan. This PR registers a `defer` immediately after `createMeasuringPlaceholder` succeeds that calls `closeMeasuringPlaceholderWithComment` unless `placeholderResolved` is set to `true` by a normal completion path.

## Changes

- `pkg/orchestrator/measure.go`: add `placeholderResolved` flag and `defer` to close placeholder on any early-return error path; set `placeholderResolved = true` before the existing normal-path `closeMeasuringPlaceholder` call
- `pkg/orchestrator/issues_gh.go`: add `closeMeasuringPlaceholderWithComment` — closes the issue and adds an explanatory comment before closing
- `pkg/orchestrator/issues_gh_test.go`: add `TestCloseMeasuringPlaceholderWithComment_FakeRepo_NoOp`, `TestPlaceholderResolved_DeferIsNoOpOnSuccess`, `TestPlaceholderResolved_DeferFiresOnFailure`

## Stats

go_loc_prod: 13407 → 13421 (+14)
go_loc_test: 18024 → 18067 (+43)

## Test plan

- [x] `mage analyze` passes
- [x] All unit tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] 3 new tests covering the new function and the flag contract

Closes #747