### PR TITLE
GH-827: Document cobbler.mode (podman, cli, sdk) in eng03

### DIFF
--- a/docs/engineering/eng03-project-initialization.yaml
+++ b/docs/engineering/eng03-project-initialization.yaml
@@ -8,8 +8,8 @@ introduction: |
   A consuming project integrates the orchestrator by running the scaffold command,
   which detects the project structure and generates the files needed to run
   measure-stitch cycles. This document covers prerequisites, the scaffold procedure,
-  the files it creates, podman configuration, the configuration reference, and
-  the available Mage targets.
+  the files it creates, Claude execution modes, podman configuration, the
+  configuration reference, and the available Mage targets.
 
 sections:
   - title: Prerequisites
@@ -69,12 +69,42 @@ sections:
       The magefiles/ directory keeps build tooling dependencies separate from
       the project's own go.mod.
 
+  - title: Claude Execution Modes
+    content: |
+      The orchestrator supports three Claude execution modes, selected by the
+      cobbler.mode field in configuration.yaml. No environment variable controls
+      the mode; configuration.yaml is the single source of truth.
+
+      | Mode | Value | Description |
+      |------|-------|-------------|
+      | Podman (default) | podman | Run Claude inside a podman container |
+      | CLI | cli | Run the claude binary directly on the host |
+      | SDK | sdk | Use the Go Agent SDK for structured streaming |
+
+      Set the mode in configuration.yaml:
+
+        cobbler:
+          mode: podman   # or cli, or sdk
+
+      When cobbler.mode is empty, the orchestrator defaults to podman. The
+      podman: section of configuration.yaml is required only when mode is
+      podman. For cli and sdk, the orchestrator invokes claude directly from
+      PATH, so no container image or podman installation is needed.
+
+      Use cli or sdk on hosts where podman is unavailable (CI runners, macOS
+      without a VM backend, development laptops). Use podman for production
+      generation runs that benefit from container isolation.
+
+      The execution mode is governed by prd001-orchestrator-core.yaml (R1 —
+      Config struct and CobblerConfig).
+
   - title: Podman Configuration
     content: |
-      Claude runs inside a podman container. The orchestrator wraps every
-      Claude invocation in podman run, mounting the repository directory at
-      the same absolute path inside the container. Same-path mounting ensures
-      that absolute file references in prompts resolve correctly.
+      This section applies when cobbler.mode is podman (the default). Claude
+      runs inside a podman container. The orchestrator wraps every Claude
+      invocation in podman run, mounting the repository directory at the same
+      absolute path inside the container. Same-path mounting ensures that
+      absolute file references in prompts resolve correctly.
 
       Install podman on macOS:
 
@@ -135,6 +165,7 @@ sections:
         cleanup_dirs       Directories to remove after generator:stop or generator:reset
 
       cobbler:
+        mode                       default: podman — execution mode; one of podman, cli, sdk
         dir                        default: .cobbler/ — scratch directory
         max_stitch_issues          default: 0 (unlimited) — total stitch cap for a run
         max_stitch_issues_per_cycle default: 10 — tasks per cycle before re-measuring
@@ -190,3 +221,4 @@ references:
   - docs/VISION.yaml
   - docs/engineering/eng01-generation-workflow.yaml
   - docs/engineering/eng02-prompt-templates.yaml
+  - docs/specs/product-requirements/prd001-orchestrator-core.yaml


### PR DESCRIPTION
## Summary

The `cobbler.mode` field controlling Claude execution mode (podman/cli/sdk) was documented only in Go source code. This PR adds a dedicated \"Claude Execution Modes\" section to `eng03-project-initialization.yaml` and wires it into the Configuration Reference.

## Changes

- New section \"Claude Execution Modes\" with a mode comparison table, example configuration snippet, guidance on when to use each mode, and a note that environment variables do not control the mode
- \"Podman Configuration\" section updated to clarify it applies only when `mode: podman`
- `cobbler.mode` added to the Configuration Reference `cobbler:` block
- `prd001-orchestrator-core.yaml` added to the references list
- Introduction updated to mention the new section

## Stats

docs only — no Go LOC change

## Test plan

- [x] `mage analyze` passes
- [x] Documentation reviewed for consistency with config.go constants

Closes #827