### PR TITLE
GH-833: Remove hard-coded ExecutionModeSDK from snapshot test setup

### DIFF
--- a/tests/rel01.0/internal/testutil/snapshot.go
+++ b/tests/rel01.0/internal/testutil/snapshot.go
@@ -80,7 +80,9 @@ func PrepareSnapshot(orchRoot string) (string, func(), error) {
 
 // overrideSnapshotIssuesRepo writes cobbler.issues_repo into the snapshot's
 // configuration.yaml so that all test repos created from it point to the
-// correct GitHub repo for issue tracking.
+// correct GitHub repo for issue tracking. All other fields, including
+// cobbler.mode, are preserved from the snapshot's configuration.yaml so
+// that the execution mode is controlled by sdd-hello-world's config (GH-833).
 func overrideSnapshotIssuesRepo(snapDir, issuesRepo string) error {
 	cfgPath := filepath.Join(snapDir, orchestrator.DefaultConfigFile)
 	data, err := os.ReadFile(cfgPath)
@@ -92,7 +94,6 @@ func overrideSnapshotIssuesRepo(snapDir, issuesRepo string) error {
 		return err
 	}
 	cfg.Cobbler.IssuesRepo = issuesRepo
-	cfg.Cobbler.Mode = orchestrator.ExecutionModeSDK
 	newData, err := yaml.Marshal(&cfg)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

`overrideSnapshotIssuesRepo` in `tests/rel01.0/internal/testutil/snapshot.go` was unconditionally setting `cfg.Cobbler.Mode = ExecutionModeSDK`, overriding whatever execution mode `sdd-hello-world`'s `configuration.yaml` carries. This made it impossible to test CLI mode without changing Go source. The fix removes that one line so the mode is controlled entirely by the snapshot's config.

## Changes

- `tests/rel01.0/internal/testutil/snapshot.go`: remove `cfg.Cobbler.Mode = orchestrator.ExecutionModeSDK`; add comment explaining the intent

## Test plan

- [x] `go vet -tags usecase ./tests/rel01.0/...` passes
- [x] `mage analyze` passes
- [ ] `mage test:usecase` passes after sdd-hello-world sets `cobbler.mode: cli` (or `sdk`) in its `configuration.yaml` (tracked in #385)

Closes #833