### PR TITLE
GH-385: Upgrade sdd-hello-world to v0.20260306.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,7 @@ go 1.25.7
 
 require gopkg.in/yaml.v3 v3.0.1
 
-require github.com/schlunsen/claude-agent-sdk-go v0.5.1 // indirect
+require (
+	github.com/petar-djukic/sdd-hello-world v0.20260306.1 // indirect
+	github.com/schlunsen/claude-agent-sdk-go v0.5.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/petar-djukic/sdd-hello-world v0.20260306.1 h1:GWukg6r/MLmKbJ7asF92zBtkiH9A08XSorAS3XpDW+E=
+github.com/petar-djukic/sdd-hello-world v0.20260306.1/go.mod h1:oC+U33XqVDEwP+E5L3AdPIYqVE3xda+/4rfwSrdw9XM=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1 h1:8hho5wd5XU87q91ssEFeJmgS0whm6JTroqtwnaUQxcA=
 github.com/schlunsen/claude-agent-sdk-go v0.5.1/go.mod h1:bH59LsKvDqUtYzW+6MNoaFEjcpMtfdvRNjQDCyfBJ+o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=


### PR DESCRIPTION
## Summary

Upgrades the sdd-hello-world test target from v0.20260301.1 to v0.20260306.1. The new version adds `cobbler.mode: cli` to its `configuration.yaml`, which pairs with the GH-833 fix (removed hard-coded `ExecutionModeSDK` from `snapshot.go`) to run all use-case tests in CLI mode end-to-end.

## Changes

- `go.mod`: bump `github.com/petar-djukic/sdd-hello-world` indirect dependency to `v0.20260306.1`
- `go.sum`: add checksums for `v0.20260306.1`

## Stats

go_loc_prod: 13434 (no change)
go_loc_test: 18076 (no change)

## Test plan

- [x] `mage analyze` passes
- [x] All 53 use-case tests pass (`mage test:usecase`)
- [x] Tests run in CLI mode (cobbler.mode: cli from sdd-hello-world configuration.yaml)

Closes #385