### PR TITLE
GH-847: Skip implemented releases in selectNextPendingUseCase

### DIFF
--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -1459,6 +1459,17 @@ func ucStatusDone(status string) bool {
 // use case whose status is neither "done" nor "implemented". When a release
 // filter is configured in cfg (via Releases or Release), only releases in
 // scope are considered.
+//
+// Release-level status is checked in addition to per-use-case status: a
+// release with status "implemented" or "done" is skipped entirely, even if
+// individual use cases within it are not explicitly marked done. This prevents
+// stale releases config values from causing re-implementation proposals.
+//
+// When a filter is active and all matching releases are already implemented,
+// the function falls back to scanning all releases without the filter and
+// returns the first pending use case found. The caller can detect this
+// auto-advance by comparing the returned UC's release to the configured scope.
+//
 // Returns (nil, nil) when all use cases are done or the road-map is absent.
 func selectNextPendingUseCase(cfg ProjectConfig) (*UseCaseDoc, error) {
 	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
@@ -1468,32 +1479,82 @@ func selectNextPendingUseCase(cfg ProjectConfig) (*UseCaseDoc, error) {
 	}
 
 	rf := newReleaseFilter(cfg.Releases, cfg.Release)
-	for i := range rm.Releases {
-		rel := &rm.Releases[i]
-		// Skip releases outside the configured scope.
-		if rf.active() {
+
+	// firstPendingUC scans releases (optionally restricted by rf) and returns
+	// the first use case not yet done. Release-level implemented status is
+	// always respected regardless of filter.
+	firstPendingUC := func(filter releaseFilter) (*UseCaseDoc, error) {
+		for i := range rm.Releases {
+			rel := &rm.Releases[i]
+			if filter.active() {
+				if filter.ReleaseSet != nil && !filter.ReleaseSet[rel.Version] {
+					continue
+				}
+				if filter.ReleaseSet == nil && rel.Version > filter.MaxRelease {
+					continue
+				}
+			}
+			// Skip entire releases already marked as implemented at release level.
+			if ucStatusDone(rel.Status) {
+				logf("selectNextPendingUseCase: skipping release %s (status=%s)", rel.Version, rel.Status)
+				continue
+			}
+			for _, uc := range rel.UseCases {
+				if ucStatusDone(uc.Status) {
+					continue
+				}
+				path := filepath.Join("docs", "specs", "use-cases", uc.ID+".yaml")
+				doc := loadYAML[UseCaseDoc](path)
+				if doc == nil {
+					logf("selectNextPendingUseCase: use case file not found: %s", path)
+					return nil, nil
+				}
+				doc.File = path
+				logf("selectNextPendingUseCase: next pending UC=%s status=%s", uc.ID, uc.Status)
+				return doc, nil
+			}
+		}
+		return nil, nil
+	}
+
+	doc, err := firstPendingUC(rf)
+	if err != nil || doc != nil {
+		return doc, err
+	}
+
+	// When a filter was active but yielded nothing, check whether all
+	// filtered releases carry status "implemented". If so, the config is
+	// stale: auto-advance past the configured scope to find the next pending
+	// UC from any release. We use the strict "implemented" check (not the
+	// broader ucStatusDone that also matches "done") so that a release
+	// filtered to a "done"-but-not-yet-implemented release does not trigger
+	// unintended auto-advance (GH-847).
+	if rf.active() {
+		allImplemented := true
+		filteredAny := false
+		for i := range rm.Releases {
+			rel := &rm.Releases[i]
 			if rf.ReleaseSet != nil && !rf.ReleaseSet[rel.Version] {
 				continue
 			}
 			if rf.ReleaseSet == nil && rel.Version > rf.MaxRelease {
 				continue
 			}
+			filteredAny = true
+			if !strings.EqualFold(rel.Status, "implemented") {
+				allImplemented = false
+				break
+			}
 		}
-		for _, uc := range rel.UseCases {
-			if ucStatusDone(uc.Status) {
-				continue
+		if filteredAny && allImplemented {
+			logf("selectNextPendingUseCase: all configured releases implemented; scanning all releases for next pending UC")
+			doc, err = firstPendingUC(releaseFilter{})
+			if err != nil || doc != nil {
+				return doc, err
 			}
-			path := filepath.Join("docs", "specs", "use-cases", uc.ID+".yaml")
-			doc := loadYAML[UseCaseDoc](path)
-			if doc == nil {
-				logf("selectNextPendingUseCase: use case file not found: %s", path)
-				return nil, nil
-			}
-			doc.File = path
-			logf("selectNextPendingUseCase: next pending UC=%s status=%s", uc.ID, uc.Status)
-			return doc, nil
 		}
 	}
+
 	logf("selectNextPendingUseCase: all use cases done")
 	return nil, nil
 }

--- a/pkg/orchestrator/context_test.go
+++ b/pkg/orchestrator/context_test.go
@@ -2028,3 +2028,143 @@ func TestSelectNextPendingUseCase_MissingRoadmap(t *testing.T) {
 		t.Errorf("expected nil for missing road-map, got %+v", uc)
 	}
 }
+
+// GH-847: release-level status checks -------------------------------------
+
+// TestSelectNextPendingUseCase_ReleaseLevelImplemented verifies that a release
+// with status "implemented" is skipped even when its individual use cases do
+// not carry a done status, and the next non-implemented release is returned.
+func TestSelectNextPendingUseCase_ReleaseLevelImplemented(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	roadmap := `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    name: Release 1
+    status: implemented
+    use_cases:
+      - id: rel01.0-uc001-init
+        status: not started
+  - version: "02.0"
+    name: Release 2
+    status: in_progress
+    use_cases:
+      - id: rel02.0-uc001-ext
+        status: not started
+`
+	ucContent := `id: rel02.0-uc001-ext
+title: Extension
+touchpoints: []
+`
+	if err := os.WriteFile("docs/road-map.yaml", []byte(roadmap), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("docs/specs/use-cases/rel02.0-uc001-ext.yaml", []byte(ucContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	uc, err := selectNextPendingUseCase(ProjectConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uc == nil {
+		t.Fatal("expected non-nil UC (rel01.0 is implemented, rel02.0 is pending)")
+	}
+	if uc.ID != "rel02.0-uc001-ext" {
+		t.Errorf("expected rel02.0-uc001-ext, got %s", uc.ID)
+	}
+}
+
+// TestSelectNextPendingUseCase_StaleFilterAutoAdvance verifies that when the
+// configured releases list points at a release that is already "implemented"
+// in road-map.yaml, the function auto-advances past it and returns the first
+// pending UC from any release (GH-847).
+func TestSelectNextPendingUseCase_StaleFilterAutoAdvance(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	roadmap := `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    name: Release 1
+    status: implemented
+    use_cases:
+      - id: rel01.0-uc001-init
+        status: implemented
+  - version: "02.0"
+    name: Release 2
+    status: spec_complete
+    use_cases:
+      - id: rel02.0-uc001-ext
+        status: not started
+`
+	ucContent := `id: rel02.0-uc001-ext
+title: Extension
+touchpoints: []
+`
+	if err := os.WriteFile("docs/road-map.yaml", []byte(roadmap), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("docs/specs/use-cases/rel02.0-uc001-ext.yaml", []byte(ucContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure the stale release: releases: ["01.0"] even though it's implemented.
+	uc, err := selectNextPendingUseCase(ProjectConfig{Releases: []string{"01.0"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uc == nil {
+		t.Fatal("expected auto-advance to rel02.0-uc001-ext when filter is stale-implemented")
+	}
+	if uc.ID != "rel02.0-uc001-ext" {
+		t.Errorf("expected rel02.0-uc001-ext after auto-advance, got %s", uc.ID)
+	}
+}
+
+// TestSelectNextPendingUseCase_FilterNotImplementedNotAutoAdvanced verifies
+// that the auto-advance does NOT trigger when the configured release is not
+// yet fully implemented (i.e. the filter is valid, just no pending UCs).
+func TestSelectNextPendingUseCase_FilterNotImplementedNotAutoAdvanced(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	roadmap := `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    name: Release 1
+    status: in_progress
+    use_cases:
+      - id: rel01.0-uc001-init
+        status: done
+  - version: "02.0"
+    name: Release 2
+    status: spec_complete
+    use_cases:
+      - id: rel02.0-uc001-ext
+        status: not started
+`
+	ucContent := `id: rel02.0-uc001-ext
+title: Extension
+touchpoints: []
+`
+	if err := os.WriteFile("docs/road-map.yaml", []byte(roadmap), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile("docs/specs/use-cases/rel02.0-uc001-ext.yaml", []byte(ucContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Filter to rel01.0 which is in_progress (not implemented) — no auto-advance.
+	uc, err := selectNextPendingUseCase(ProjectConfig{Releases: []string{"01.0"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if uc != nil {
+		t.Errorf("expected nil (rel01.0 in_progress but all UCs done, no auto-advance), got %s", uc.ID)
+	}
+}

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -464,7 +464,12 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 	// Enforce releases scope: the roadmap is not filtered by release, so
 	// without an explicit constraint the agent may propose tasks from adjacent
 	// releases after exhausting the configured ones.
-	doc.Constraints += measureReleasesConstraint(o.cfg.Project.Releases, o.cfg.Project.Release)
+	// Filter out releases already marked as implemented in road-map.yaml so a
+	// stale releases config value does not direct Claude to re-implement work
+	// that is already done (GH-847).
+	activeReleases := filterImplementedReleases(o.cfg.Project.Releases)
+	activeRelease := filterImplementedRelease(o.cfg.Project.Release)
+	doc.Constraints += measureReleasesConstraint(activeReleases, activeRelease)
 
 	out, err := yaml.Marshal(&doc)
 	if err != nil {
@@ -493,6 +498,53 @@ func measureReleasesConstraint(releases []string, release string) string {
 		)
 	}
 	return ""
+}
+
+// filterImplementedReleases returns a copy of releases with any entry whose
+// road-map status is "implemented" or "done" removed. Releases not found in
+// road-map.yaml are kept (unknown status is not treated as implemented).
+// Returns nil when all releases are filtered out.
+func filterImplementedReleases(releases []string) []string {
+	if len(releases) == 0 {
+		return releases
+	}
+	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
+	if rm == nil {
+		return releases
+	}
+	status := make(map[string]string, len(rm.Releases))
+	for _, rel := range rm.Releases {
+		status[rel.Version] = rel.Status
+	}
+	var out []string
+	for _, r := range releases {
+		if ucStatusDone(status[r]) {
+			logf("filterImplementedReleases: dropping implemented release %s from constraint", r)
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// filterImplementedRelease returns the release string unchanged unless the
+// road-map marks that release as implemented/done, in which case "" is
+// returned so no legacy single-release constraint is emitted.
+func filterImplementedRelease(release string) string {
+	if release == "" {
+		return ""
+	}
+	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
+	if rm == nil {
+		return release
+	}
+	for _, rel := range rm.Releases {
+		if rel.Version == release && ucStatusDone(rel.Status) {
+			logf("filterImplementedRelease: dropping implemented release %s from constraint", release)
+			return ""
+		}
+	}
+	return release
 }
 
 type proposedIssue struct {

--- a/pkg/orchestrator/measure_test.go
+++ b/pkg/orchestrator/measure_test.go
@@ -767,6 +767,92 @@ design_decisions:
 	}
 }
 
+// GH-847: filterImplementedReleases / filterImplementedRelease ----------------
+
+func TestFilterImplementedReleases_DropsImplemented(t *testing.T) {
+	_, cleanup := setupMeasureRoadmapDir(t, `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    status: implemented
+    use_cases: []
+  - version: "02.0"
+    status: spec_complete
+    use_cases: []
+`, "", "")
+	defer cleanup()
+
+	got := filterImplementedReleases([]string{"01.0", "02.0"})
+	if len(got) != 1 || got[0] != "02.0" {
+		t.Errorf("filterImplementedReleases = %v; want [02.0]", got)
+	}
+}
+
+func TestFilterImplementedReleases_AllImplemented_ReturnsNil(t *testing.T) {
+	_, cleanup := setupMeasureRoadmapDir(t, `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    status: implemented
+    use_cases: []
+`, "", "")
+	defer cleanup()
+
+	got := filterImplementedReleases([]string{"01.0"})
+	if len(got) != 0 {
+		t.Errorf("filterImplementedReleases all implemented = %v; want nil/empty", got)
+	}
+}
+
+func TestFilterImplementedReleases_UnknownReleaseKept(t *testing.T) {
+	_, cleanup := setupMeasureRoadmapDir(t, `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    status: implemented
+    use_cases: []
+`, "", "")
+	defer cleanup()
+
+	// "99.0" not in road-map → unknown status → kept.
+	got := filterImplementedReleases([]string{"99.0"})
+	if len(got) != 1 || got[0] != "99.0" {
+		t.Errorf("filterImplementedReleases unknown = %v; want [99.0]", got)
+	}
+}
+
+func TestFilterImplementedRelease_ImplementedReturnsEmpty(t *testing.T) {
+	_, cleanup := setupMeasureRoadmapDir(t, `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    status: implemented
+    use_cases: []
+`, "", "")
+	defer cleanup()
+
+	got := filterImplementedRelease("01.0")
+	if got != "" {
+		t.Errorf("filterImplementedRelease implemented = %q; want empty", got)
+	}
+}
+
+func TestFilterImplementedRelease_NotImplementedKept(t *testing.T) {
+	_, cleanup := setupMeasureRoadmapDir(t, `id: rm1
+title: Roadmap
+releases:
+  - version: "01.0"
+    status: spec_complete
+    use_cases: []
+`, "", "")
+	defer cleanup()
+
+	got := filterImplementedRelease("01.0")
+	if got != "01.0" {
+		t.Errorf("filterImplementedRelease spec_complete = %q; want 01.0", got)
+	}
+}
+
 func TestMeasureReleasesConstraint_WithReleases(t *testing.T) {
 	t.Parallel()
 	got := measureReleasesConstraint([]string{"01.0", "02.0"}, "")


### PR DESCRIPTION
## Summary

Fixes a bug where a stale `releases` config value pointing at an already-implemented release caused `measureReleasesConstraint` to direct Claude to re-propose work for that release. The fix adds release-level `status: implemented` skipping in `selectNextPendingUseCase` and filters implemented releases out of the prompt constraint.

## Changes

- `pkg/orchestrator/context.go`: `selectNextPendingUseCase` now skips releases with release-level `ucStatusDone(rel.Status)`; auto-advances past the stale filter scope when all configured releases are `status: implemented`
- `pkg/orchestrator/measure.go`: `filterImplementedReleases` and `filterImplementedRelease` helpers strip implemented releases from the prompt constraint; `buildMeasurePrompt` uses them instead of passing raw config values
- `pkg/orchestrator/context_test.go`: 3 new tests for release-level skip, stale-filter auto-advance, and no-auto-advance guard
- `pkg/orchestrator/measure_test.go`: 5 new tests for `filterImplementedReleases` and `filterImplementedRelease`

## Stats

go_loc_prod: 13402 (was 13289, +113)
go_loc_test: 18504 (was 18278, +226)

## Test plan

- [x] `mage analyze` passes
- [x] Full unit test suite passes (`go test ./pkg/orchestrator/`)
- [x] `TestSelectNextPendingUseCase_ReleaseFilter` (existing) still passes — auto-advance does not trigger for `status: done`
- [x] `TestSelectNextPendingUseCase_StaleFilterAutoAdvance` passes — auto-advance triggers for `status: implemented`

Closes #847