### PR TITLE
GH-849: Fix Loc-Prod-After always 0 in stitch commit trailers

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -58,6 +58,26 @@ func (o *Orchestrator) captureLOC() LocSnapshot {
 	return LocSnapshot{Production: rec.GoProdLOC, Test: rec.GoTestLOC}
 }
 
+// captureLOCAt returns Go LOC counts measured in dir. It temporarily changes
+// the working directory so CollectStats walks the correct tree. Errors are
+// swallowed because stats collection is best-effort.
+func (o *Orchestrator) captureLOCAt(dir string) LocSnapshot {
+	if dir == "" {
+		return o.captureLOC()
+	}
+	orig, err := os.Getwd()
+	if err != nil {
+		logf("captureLOCAt: getwd: %v", err)
+		return LocSnapshot{}
+	}
+	if err := os.Chdir(dir); err != nil {
+		logf("captureLOCAt: chdir to %s: %v", dir, err)
+		return LocSnapshot{}
+	}
+	defer func() { os.Chdir(orig) }() //nolint:errcheck
+	return o.captureLOC()
+}
+
 // InvocationRecord is the JSON blob recorded as a GitHub issue comment after
 // every Claude invocation.
 type InvocationRecord struct {

--- a/pkg/orchestrator/cobbler_test.go
+++ b/pkg/orchestrator/cobbler_test.go
@@ -946,6 +946,61 @@ func TestCaptureLOC_EmptyDir_ReturnsZero(t *testing.T) {
 	}
 }
 
+// --- captureLOCAt ---
+
+func TestCaptureLOCAt_CountsInTargetDir(t *testing.T) {
+	// Not parallel: uses os.Chdir to verify cwd is restored.
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "prod.go"), []byte("line 1\nline 2\nline 3\n"), 0644)
+	os.WriteFile(filepath.Join(dir, "suite_test.go"), []byte("test 1\ntest 2\n"), 0644)
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	o := New(Config{})
+	snap := o.captureLOCAt(dir)
+
+	if snap.Production != 3 {
+		t.Errorf("Production = %d, want 3", snap.Production)
+	}
+	if snap.Test != 2 {
+		t.Errorf("Test = %d, want 2", snap.Test)
+	}
+
+	// cwd must be restored after the call.
+	after, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if after != origDir {
+		t.Errorf("cwd after captureLOCAt = %q, want %q", after, origDir)
+	}
+}
+
+func TestCaptureLOCAt_EmptyDirString_FallsBackToCwd(t *testing.T) {
+	// Not parallel: uses os.Chdir.
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "x.go"), []byte("a\nb\n"), 0644)
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	o := New(Config{})
+	snap := o.captureLOCAt("") // empty dir → fallback to captureLOC (cwd)
+	if snap.Production != 2 {
+		t.Errorf("Production = %d, want 2", snap.Production)
+	}
+}
+
 // --- InvocationRecord JSON serialization (covers recordInvocation marshaling) ---
 
 func TestInvocationRecord_JSONShape(t *testing.T) {

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -441,10 +441,15 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 		return errTaskReset
 	}
 
+	// Capture locAfter from the worktree before merging. The worktree starts
+	// from the current generation branch state and includes Claude's additions,
+	// so this gives the correct post-task LOC without waiting for the merge.
+	locAfter := o.captureLOCAt(task.worktreeDir)
+	logf("doOneTask: locAfter prod=%d test=%d", locAfter.Production, locAfter.Test)
+
 	// Append outcome trailers to the worktree commit before merging.
 	// Trailers must be on the pre-merge commit so they travel into the
-	// generation branch history. LOCAfter and Diff are not yet available
-	// at this point; the full record is saved in HistoryStats YAML files.
+	// generation branch history.
 	trailerRec := InvocationRecord{
 		Caller:    "stitch",
 		StartedAt: claudeStart.UTC().Format(time.RFC3339),
@@ -457,6 +462,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 			CostUSD:       tokens.CostUSD,
 		},
 		LOCBefore: locBefore,
+		LOCAfter:  locAfter,
 	}
 	if err := appendOutcomeTrailers(task.worktreeDir, trailerRec); err != nil {
 		logf("doOneTask: outcome trailer warning for %s: %v", task.id, err)
@@ -491,7 +497,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	}
 	logf("doOneTask: merge completed in %s", time.Since(mergeStart).Round(time.Second))
 
-	// Capture LOC diff, per-file diff, and post-merge LOC.
+	// Capture per-file diff stats.
 	diff, diffErr := gitDiffShortstat(preMergeRef, ".")
 	if diffErr != nil {
 		logf("doOneTask: warning getting diff shortstat: %v", diffErr)
@@ -502,8 +508,6 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 		logf("doOneTask: warning getting file changes: %v", fcErr)
 	}
 	logf("doOneTask: fileChanges=%d entries", len(fileChanges))
-	locAfter := o.captureLOC()
-	logf("doOneTask: locAfter prod=%d test=%d", locAfter.Production, locAfter.Test)
 
 	// Cleanup worktree.
 	logf("doOneTask: cleaning up worktree for %s", task.id)


### PR DESCRIPTION
## Summary

`appendOutcomeTrailers` was called with an `InvocationRecord` that had no `LOCAfter` because `locAfter` was only captured after the merge, but the trailers are written to the pre-merge worktree commit. This caused `Loc-Prod-After: 0` and `Loc-Test-After: 0` in every stitch commit message.

## Changes

- Added `captureLOCAt(dir string) LocSnapshot` to `cobbler.go` — measures LOC in an explicit directory instead of relying on the process cwd
- Moved `locAfter` capture to BEFORE `appendOutcomeTrailers`, measuring from `task.worktreeDir` (which has the generation branch baseline + Claude's additions)
- Included `LOCAfter: locAfter` in `trailerRec` so commit trailers carry correct values
- Added 2 unit tests for `captureLOCAt`

## Stats

Lines of code (Go, production): 13426 (+24)
Lines of code (Go, tests):      18559 (+55)
Words (documentation):          19280 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] All unit tests pass (`go test ./pkg/orchestrator/`)
- [x] `TestCaptureLOCAt_CountsInTargetDir` verifies the fix and cwd restoration
- [x] `TestCaptureLOCAt_EmptyDirString_FallsBackToCwd` verifies empty-dir fallback

Closes #849