### PR TITLE
GH-859: Add stats:generator to orchestrator.go.tmpl

### DIFF
--- a/orchestrator.go.tmpl
+++ b/orchestrator.go.tmpl
@@ -144,6 +144,9 @@ func (Stats) Loc() error { return newOrch().Stats() }
 // Tokens enumerates prompt-attached files and counts tokens via the Anthropic API.
 func (Stats) Tokens() error { return newOrch().TokenStats() }
 
+// Generator prints a status report for the current generation run.
+func (Stats) Generator() error { return newOrch().GeneratorStats() }
+
 // --- Prompt targets ---
 
 // Measure prints the assembled measure prompt to stdout.


### PR DESCRIPTION
## Summary

`stats:generator` was implemented in GH-571 and registered in cobbler-scaffold's own `magefile.go`, but was never propagated to `orchestrator.go.tmpl`. Scaffolded projects (e.g. go-unix-utils) therefore had no `stats:generator` target. This PR adds the missing one-line registration.

## Changes

- `orchestrator.go.tmpl`: added `func (Stats) Generator() error { return newOrch().GeneratorStats() }`

## Stats

Lines of code (Go, production): 13580 (+0)
Lines of code (Go, tests):      18559 (+0)
Words (documentation):          19280 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] All unit tests pass

Closes #859