### PR TITLE
GH-887: Enforce P9 measure validation by default (hard block)

### DIFF
--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -198,14 +198,15 @@ type CobblerConfig struct {
 	MaxContextBytes int `yaml:"max_context_bytes"`
 
 	// EnforceMeasureValidation enables strict validation of measure output.
-	// When true, issues that violate P9 granularity ranges or P7 file naming
-	// are rejected and measure retries. When false (default), violations are
-	// logged as advisory warnings and import proceeds.
-	EnforceMeasureValidation bool `yaml:"enforce_measure_validation"`
+	// When true (default), issues that violate P9 granularity ranges or P7
+	// file naming are rejected and measure retries up to MaxMeasureRetries
+	// times. Set to false to revert to advisory-only behavior where violations
+	// are logged but import proceeds.
+	EnforceMeasureValidation *bool `yaml:"enforce_measure_validation"`
 
 	// MaxMeasureRetries is the maximum number of retry attempts per iteration
-	// when EnforceMeasureValidation rejects the output. When 0 (default),
-	// no retries are attempted. A value of 2-3 is recommended.
+	// when EnforceMeasureValidation rejects the output. Defaults to 2.
+	// Set to 0 to disable retries (enforcement still applies on the first try).
 	MaxMeasureRetries int `yaml:"max_measure_retries"`
 
 	// MaxRequirementsPerTask is the maximum number of requirements a single
@@ -392,6 +393,16 @@ func (c *CobblerConfig) effectiveMeasureExcludeTests() bool {
 	return *c.MeasureExcludeTests
 }
 
+// EffectiveEnforceMeasureValidation returns whether P9/P7 measure validation
+// is enforced. Nil (field absent in YAML) defaults to true; an explicit false
+// reverts to advisory-only behavior.
+func (c *CobblerConfig) EffectiveEnforceMeasureValidation() bool {
+	if c.EnforceMeasureValidation == nil {
+		return true
+	}
+	return *c.EnforceMeasureValidation
+}
+
 // DefaultConfig returns a Config populated with all default values.
 // Project-specific fields (ModulePath, BinaryName, etc.) are left empty;
 // the caller fills them in or the user edits the generated file.
@@ -399,7 +410,7 @@ func DefaultConfig() Config {
 	t := true
 	cfg := Config{
 		Claude:  ClaudeConfig{SilenceAgent: &t},
-		Cobbler: CobblerConfig{MeasureExcludeTests: &t},
+		Cobbler: CobblerConfig{MeasureExcludeTests: &t, EnforceMeasureValidation: &t},
 	}
 	cfg.applyDefaults()
 	return cfg
@@ -510,6 +521,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Cobbler.IdleTimeoutSeconds == 0 {
 		c.Cobbler.IdleTimeoutSeconds = 60
+	}
+	if c.Cobbler.MaxMeasureRetries == 0 {
+		c.Cobbler.MaxMeasureRetries = 2
 	}
 	if c.Claude.MaxTimeSec == 0 {
 		c.Claude.MaxTimeSec = 300

--- a/pkg/orchestrator/config_test.go
+++ b/pkg/orchestrator/config_test.go
@@ -243,7 +243,7 @@ func TestLoadConfig_EnforceMeasureValidationFromYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if !cfg.Cobbler.EnforceMeasureValidation {
+	if !cfg.Cobbler.EffectiveEnforceMeasureValidation() {
 		t.Error("EnforceMeasureValidation: got false, want true")
 	}
 	if cfg.Cobbler.MaxMeasureRetries != 3 {
@@ -251,17 +251,31 @@ func TestLoadConfig_EnforceMeasureValidationFromYAML(t *testing.T) {
 	}
 }
 
-func TestLoadConfig_EnforceMeasureValidationDefaultsFalse(t *testing.T) {
+func TestLoadConfig_EnforceMeasureValidationDefaultsTrue(t *testing.T) {
 	f := writeTemp(t, "project:\n  module_path: example.com/x\n")
 	cfg, err := LoadConfig(f)
 	if err != nil {
 		t.Fatalf("LoadConfig: %v", err)
 	}
-	if cfg.Cobbler.EnforceMeasureValidation {
-		t.Error("EnforceMeasureValidation default: got true, want false")
+	if !cfg.Cobbler.EffectiveEnforceMeasureValidation() {
+		t.Error("EnforceMeasureValidation default: got false, want true")
 	}
-	if cfg.Cobbler.MaxMeasureRetries != 0 {
-		t.Errorf("MaxMeasureRetries default: got %d, want 0", cfg.Cobbler.MaxMeasureRetries)
+	if cfg.Cobbler.MaxMeasureRetries != 2 {
+		t.Errorf("MaxMeasureRetries default: got %d, want 2", cfg.Cobbler.MaxMeasureRetries)
+	}
+}
+
+func TestLoadConfig_EnforceMeasureValidationExplicitFalse(t *testing.T) {
+	yaml := `cobbler:
+  enforce_measure_validation: false
+`
+	f := writeTemp(t, yaml)
+	cfg, err := LoadConfig(f)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Cobbler.EffectiveEnforceMeasureValidation() {
+		t.Error("EnforceMeasureValidation explicit false: got true, want false")
 	}
 }
 

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -603,7 +603,7 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 	if len(vr.Warnings) > 0 {
 		logf("importIssues: %d warning(s)", len(vr.Warnings))
 	}
-	if vr.HasErrors() && o.cfg.Cobbler.EnforceMeasureValidation && !skipEnforcement {
+	if vr.HasErrors() && o.cfg.Cobbler.EffectiveEnforceMeasureValidation() && !skipEnforcement {
 		return nil, vr.Errors, fmt.Errorf("measure validation failed (%d error(s)): %s",
 			len(vr.Errors), strings.Join(vr.Errors, "; "))
 	}

--- a/pkg/orchestrator/measure_test.go
+++ b/pkg/orchestrator/measure_test.go
@@ -1255,7 +1255,6 @@ acceptance_criteria:
 
 	cfg := Config{}
 	cfg.Cobbler.Dir = dir
-	cfg.Cobbler.EnforceMeasureValidation = true
 	o := New(cfg)
 
 	_, validationErrs, err := o.importIssuesImpl(yamlFile, "owner/repo", "gen", false, 0)
@@ -1293,7 +1292,6 @@ acceptance_criteria:
 
 	cfg := Config{}
 	cfg.Cobbler.Dir = dir
-	cfg.Cobbler.EnforceMeasureValidation = true
 	o := New(cfg)
 
 	// skipEnforcement=true should bypass validation errors.


### PR DESCRIPTION
## Summary

Converts `EnforceMeasureValidation` from `bool` (default `false`, advisory-only) to `*bool` (default `true`, hard block). P9 granularity and P7 file-naming violations now reject task creation by default. The measure agent automatically retries up to `MaxMeasureRetries` times (now defaulting to 2) before the cycle fails. Users who want the old advisory behavior can set `enforce_measure_validation: false` in their `configuration.yaml`.

## Changes

- `config.go`: `EnforceMeasureValidation *bool` with `EffectiveEnforceMeasureValidation()` accessor; `MaxMeasureRetries` defaults to 2; `DefaultConfig` initialises both
- `measure.go`: uses `EffectiveEnforceMeasureValidation()` accessor
- `config_test.go`: renamed `DefaultsFalse` → `DefaultsTrue`; added `ExplicitFalse` test
- `measure_test.go`: removed now-redundant `EnforceMeasureValidation = true` assignments

## Stats

go_loc: 32208 → ~32250 (+42 lines)

## Test plan

- [x] `mage analyze` passes
- [x] All unit tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] `TestImportIssuesImpl_ValidationRejectsInEnforcingMode` still passes (now tests default behavior)
- [x] `TestImportIssuesImpl_ValidationPassesWhenSkipped` still passes

Closes #887