### PR TITLE
GH-886: filter SDK rate_limit_event warnings and log structured entry

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -4,6 +4,7 @@
 package orchestrator
 
 import (
+	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -50,6 +51,36 @@ type LocSnapshot struct {
 // unset CLAUDECODE at the process level before calling Query. The mutex
 // prevents concurrent calls from interleaving the unset/restore sequence.
 var sdkEnvMu sync.Mutex
+
+// sdkStderrMu serialises os.Stderr replacement in runClaudeSDK.
+// The SDK transport writes rate-limit warnings directly to os.Stderr via its
+// internal logger. We redirect os.Stderr through a filter pipe for the full
+// duration of each SDK call so those warnings can be replaced with a clean
+// operator-facing log entry. The mutex prevents concurrent redirects from
+// interfering with each other.
+var sdkStderrMu sync.Mutex
+
+// filterSDKStderr reads lines from r and forwards them to dst, except that
+// lines matching the SDK's rate-limit parse warning are replaced with a
+// structured log entry. It closes r and signals done when r reaches EOF.
+// Write directly to dst (not via logf) to avoid writing back into the pipe.
+func filterSDKStderr(r *os.File, dst *os.File, done chan<- struct{}) {
+	defer func() {
+		_ = r.Close()
+		close(done)
+	}()
+	sc := bufio.NewScanner(r)
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.Contains(line, "Failed to parse message from CLI") &&
+			strings.Contains(line, "rate_limit_event") {
+			ts := time.Now().Format(time.RFC3339)
+			fmt.Fprintf(dst, "[%s] claude: rate_limit\n", ts)
+			continue
+		}
+		fmt.Fprintln(dst, line)
+	}
+}
 
 // captureLOC returns the current Go LOC counts. Errors are swallowed
 // because stats collection is best-effort.
@@ -799,9 +830,39 @@ func (o *Orchestrator) runClaudeSDK(ctx context.Context, prompt, workDir string,
 		}
 	}
 
+	start := time.Now()
+
+	// Redirect os.Stderr through a filter pipe for the full duration of this
+	// call. The SDK transport writes rate_limit_event warnings directly to
+	// os.Stderr via its internal logger (not surfaced through the message
+	// channel). filterSDKStderr replaces those warnings with a structured log
+	// entry and forwards all other lines to the original stderr unchanged.
+	// sdkStderrMu serialises concurrent calls so redirects do not interleave.
+	// The lock must be acquired before any logf call to prevent a data race on
+	// os.Stderr between the redirect write and logf's read.
+	sdkStderrMu.Lock()
+	origStderr := os.Stderr
+	pr, pw, pipeErr := os.Pipe()
+	if pipeErr == nil {
+		os.Stderr = pw
+	}
+	stderrDone := make(chan struct{})
+	if pipeErr == nil {
+		go filterSDKStderr(pr, origStderr, stderrDone)
+	}
+	// Log after os.Stderr is redirected so the message flows through the filter.
 	logf("runClaude: SDK query workDir=%q (timeout=%s)", workDir, o.cfg.ClaudeTimeout())
 
-	start := time.Now()
+	// Cleanup: restore stderr and drain the filter goroutine after the call.
+	// Defined here so all return paths below trigger it via the defer.
+	defer func() {
+		if pipeErr == nil {
+			pw.Close()
+			<-stderrDone
+			os.Stderr = origStderr
+		}
+		sdkStderrMu.Unlock()
+	}()
 
 	// The SDK calls os.Environ() when constructing the subprocess env, so
 	// opts.Env["CLAUDECODE"]="" would merely append after CLAUDECODE=1 already

--- a/pkg/orchestrator/cobbler_test.go
+++ b/pkg/orchestrator/cobbler_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1747,6 +1748,80 @@ func TestRunClaudeSDK_ConcurrentCalls_Race(t *testing.T) {
 		if err != nil {
 			t.Errorf("goroutine %d: %v", i, err)
 		}
+	}
+}
+
+// --- filterSDKStderr ---
+
+func TestFilterSDKStderr_RateLimitWarningReplaced(t *testing.T) {
+	t.Parallel()
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+
+	// Write the SDK rate-limit warning and a normal line to the input pipe.
+	input := "[SDK WARNING] Failed to parse message from CLI: unknown message type (type: rate_limit_event)\n" +
+		"[cobbler] some other log line\n"
+	if _, err := inW.WriteString(input); err != nil {
+		t.Fatal(err)
+	}
+	inW.Close()
+
+	go filterSDKStderr(inR, outW, done)
+	<-done
+	outW.Close()
+
+	out, err := io.ReadAll(outR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	outStr := string(out)
+	if strings.Contains(outStr, "[SDK WARNING]") {
+		t.Errorf("filterSDKStderr: SDK WARNING should be suppressed, got: %q", outStr)
+	}
+	if !strings.Contains(outStr, "claude: rate_limit") {
+		t.Errorf("filterSDKStderr: expected 'claude: rate_limit' in output, got: %q", outStr)
+	}
+	if !strings.Contains(outStr, "some other log line") {
+		t.Errorf("filterSDKStderr: other log lines should pass through, got: %q", outStr)
+	}
+}
+
+func TestFilterSDKStderr_OtherWarningsPassThrough(t *testing.T) {
+	t.Parallel()
+	inR, inW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	outR, outW, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	done := make(chan struct{})
+
+	// A different SDK warning (not rate_limit_event) must not be suppressed.
+	input := "[SDK WARNING] Failed to parse message from CLI: unknown message type (type: some_other_event)\n"
+	if _, err := inW.WriteString(input); err != nil {
+		t.Fatal(err)
+	}
+	inW.Close()
+
+	go filterSDKStderr(inR, outW, done)
+	<-done
+	outW.Close()
+
+	out, err := io.ReadAll(outR)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(out), "[SDK WARNING]") {
+		t.Errorf("filterSDKStderr: non-rate-limit warnings should pass through, got: %q", string(out))
 	}
 }
 


### PR DESCRIPTION
## Summary

The `claude-agent-sdk-go` transport emits `[SDK WARNING] Failed to parse message from CLI: unknown message type (type: rate_limit_event)` because `rate_limit_event` is not registered in the SDK's type switch. This is alarming and misleading. This PR intercepts those warnings via a stderr filter pipe and replaces them with a clean structured log entry.

## Changes

- `cobbler.go`: `filterSDKStderr` function reads lines from a pipe, suppresses the SDK rate-limit parse warning, and writes a clean `claude: rate_limit` entry to the original stderr; `runClaudeSDK` redirects `os.Stderr` through this filter for the full call duration using `sdkStderrMu` to prevent data races
- `cobbler_test.go`: `TestFilterSDKStderr_RateLimitWarningReplaced` and `TestFilterSDKStderr_OtherWarningsPassThrough`

## Stats

go_loc_prod: 13543 (+61) | go_loc_test: 18697 (+75)

## Test plan

- [x] `go test ./pkg/orchestrator/ -count=1` passes
- [x] `go test ./pkg/orchestrator/ -count=1 -race -run TestRunClaudeSDK_ConcurrentCalls_Race` passes (no race)
- [x] `mage analyze` passes

Closes #886