### PR TITLE
GH-892: measure termination, multi-cycle feedback, and SDK message type tests

### DIFF
--- a/pkg/orchestrator/cobbler_test.go
+++ b/pkg/orchestrator/cobbler_test.go
@@ -1751,6 +1751,72 @@ func TestRunClaudeSDK_ConcurrentCalls_Race(t *testing.T) {
 	}
 }
 
+// TestRunClaudeSDK_NonContentMessagesIgnored verifies that message types the
+// claude binary can emit — SystemMessage, UserMessage, StreamEvent — flow
+// through the runClaudeSDK message loop without error or panic. These types
+// are silently ignored in the switch statement (only AssistantMessage and
+// ResultMessage are acted upon), which is the correct behaviour. The test
+// also documents all known SDK message types so that a future regression
+// (e.g. a type causing a panic or an unexpected [SDK WARNING] parse failure)
+// is caught at unit-test level rather than in production generation runs.
+func TestRunClaudeSDK_NonContentMessagesIgnored(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		msgs []claudetypes.Message
+	}{
+		{
+			name: "SystemMessage",
+			msgs: []claudetypes.Message{
+				&claudetypes.SystemMessage{Type: "system", Subtype: "init"},
+				resultMsg(1, 1, 0),
+			},
+		},
+		{
+			name: "UserMessage",
+			msgs: []claudetypes.Message{
+				&claudetypes.UserMessage{Type: "user"},
+				resultMsg(1, 1, 0),
+			},
+		},
+		{
+			name: "StreamEvent",
+			msgs: []claudetypes.Message{
+				&claudetypes.StreamEvent{Type: "stream_event"},
+				resultMsg(1, 1, 0),
+			},
+		},
+		{
+			name: "MixedNonContent",
+			msgs: []claudetypes.Message{
+				&claudetypes.SystemMessage{Type: "system", Subtype: "init"},
+				&claudetypes.UserMessage{Type: "user"},
+				&claudetypes.StreamEvent{Type: "stream_event"},
+				resultMsg(5, 10, 0.001),
+			},
+		},
+	}
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			msgs := tc.msgs
+			o := newSDKOrchestrator(func(_ context.Context, _ string, _ *claudetypes.ClaudeAgentOptions) (<-chan claudetypes.Message, error) {
+				ch := make(chan claudetypes.Message, len(msgs))
+				for _, m := range msgs {
+					ch <- m
+				}
+				close(ch)
+				return ch, nil
+			})
+			_, err := o.runClaudeSDK(context.Background(), "prompt", t.TempDir(), true)
+			if err != nil {
+				t.Errorf("runClaudeSDK returned unexpected error for %s: %v", tc.name, err)
+			}
+		})
+	}
+}
+
 // --- filterSDKStderr ---
 
 func TestFilterSDKStderr_RateLimitWarningReplaced(t *testing.T) {

--- a/tests/rel01.0/uc003/measure_claude_test.go
+++ b/tests/rel01.0/uc003/measure_claude_test.go
@@ -45,6 +45,39 @@ func TestRel01_UC003_MeasureCreatesIssues(t *testing.T) {
 	t.Logf("cobbler:measure created %d issue(s)", n)
 }
 
+// MeasureReturnsZeroForImplementedSpec runs cobbler:measure against the
+// snapshot codebase without resetting Go sources. The snapshot is fully
+// implemented relative to its spec, so the measure agent should return an
+// empty task list and create zero issues. This validates the spec-complete
+// detection introduced in GH-889: the measure prompt now explicitly permits
+// returning [] when no meaningful work remains.
+// Requires Claude: invokes cobbler:measure which calls Claude via podman.
+func TestRel01_UC003_MeasureReturnsZeroForImplementedSpec(t *testing.T) {
+	dir := testutil.SetupRepo(t, snapshotDir)
+	testutil.SetupClaude(t, dir)
+
+	// Allow up to 3 issues so that if measure incorrectly proposes work it
+	// shows up in the assertion, rather than being artificially limited to 0.
+	testutil.WriteConfigOverride(t, dir, func(cfg *orchestrator.Config) {
+		cfg.Cobbler.MaxMeasureIssues = 3
+	})
+
+	// init is a no-op but follows the test convention; do NOT reset so the
+	// full codebase is visible to the measure agent.
+	if err := testutil.RunMage(t, dir, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	if err := testutil.RunMage(t, dir, "cobbler:measure"); err != nil {
+		t.Fatalf("cobbler:measure: %v", err)
+	}
+
+	n := testutil.CountReadyIssues(t, dir)
+	if n != 0 {
+		t.Errorf("expected 0 ready issues after measure on fully-implemented codebase, got %d", n)
+	}
+	t.Logf("cobbler:measure created %d issue(s) (want 0)", n)
+}
+
 // MeasureRecordsInvocation runs measure and verifies that an InvocationRecord
 // is saved in the history stats file with token data.
 // Requires Claude: invokes cobbler:measure which calls Claude via podman.

--- a/tests/rel01.0/uc004/stitch_claude_test.go
+++ b/tests/rel01.0/uc004/stitch_claude_test.go
@@ -109,3 +109,52 @@ func TestRel01_UC004_StitchRecordsInvocation(t *testing.T) {
 		t.Fatal("expected at least one stitch report file in .cobbler/history/, got none")
 	}
 }
+
+// SecondMeasureProducesNoNewTasks runs a measure → stitch → measure cycle
+// and asserts the second measure creates zero new tasks. After stitch
+// implements the single proposed task and closes its issue, the second
+// measure should detect that the implementation satisfies the requirement
+// and return an empty task list rather than spinning with follow-up tasks.
+// This validates the multi-cycle termination behaviour introduced in GH-889.
+// Requires Claude: invokes cobbler:measure and cobbler:stitch which call Claude via podman.
+func TestRel01_UC004_SecondMeasureProducesNoNewTasks(t *testing.T) {
+	dir := testutil.SetupRepo(t, snapshotDir)
+	testutil.SetupClaude(t, dir)
+
+	testutil.WriteConfigOverride(t, dir, func(cfg *orchestrator.Config) {
+		cfg.Cobbler.MaxMeasureIssues = 1
+		cfg.Cobbler.MaxStitchIssuesPerCycle = 1
+	})
+
+	if err := testutil.RunMage(t, dir, "reset"); err != nil {
+		t.Fatalf("reset: %v", err)
+	}
+	if err := testutil.RunMage(t, dir, "generator:start"); err != nil {
+		t.Fatalf("generator:start: %v", err)
+	}
+
+	// First measure: propose one task.
+	if err := testutil.RunMage(t, dir, "cobbler:measure"); err != nil {
+		t.Fatalf("first cobbler:measure: %v", err)
+	}
+	if n := testutil.WaitForReadyIssues(t, dir, 1, 30*time.Second); n == 0 {
+		t.Fatal("expected at least 1 ready issue after first measure, got 0")
+	}
+
+	// Stitch: implement the proposed task and close its issue.
+	if err := testutil.RunMage(t, dir, "cobbler:stitch"); err != nil {
+		t.Fatalf("cobbler:stitch: %v", err)
+	}
+
+	// Second measure: with the task implemented and its issue closed, measure
+	// should recognise the spec is satisfied and return an empty task list.
+	if err := testutil.RunMage(t, dir, "cobbler:measure"); err != nil {
+		t.Fatalf("second cobbler:measure: %v", err)
+	}
+
+	n := testutil.CountReadyIssues(t, dir)
+	if n != 0 {
+		t.Errorf("expected 0 ready issues after second measure (stitch already implemented the task), got %d", n)
+	}
+	t.Logf("second cobbler:measure created %d issue(s) (want 0)", n)
+}


### PR DESCRIPTION
## Summary

Adds three tests that cover the gaps identified in generation run 18 (GH-380): measure spec-complete detection (AC1), multi-cycle measure→stitch→measure termination (AC2), and SDK message type handling (AC3).

## Changes

- `tests/rel01.0/uc003/measure_claude_test.go`: `TestRel01_UC003_MeasureReturnsZeroForImplementedSpec` — run measure on fully-implemented snapshot, assert 0 issues created (validates GH-889 prompt fix)
- `tests/rel01.0/uc004/stitch_claude_test.go`: `TestRel01_UC004_SecondMeasureProducesNoNewTasks` — measure→stitch→measure cycle, assert second measure creates 0 new tasks (validates GH-889 zero-LOC guard)
- `pkg/orchestrator/cobbler_test.go`: `TestRunClaudeSDK_NonContentMessagesIgnored` — table-driven unit test for SystemMessage, UserMessage, StreamEvent, and mixed non-content types through `runClaudeSDK`

## Stats

go_loc_test: 18845 (+148 from 18697)

## Test plan

- [x] `go test ./pkg/orchestrator/ -count=1` passes (AC3 unit test verified)
- [x] `go build -tags=usecase,claude ./tests/...` compiles (AC1, AC2 verified)
- [x] `mage analyze` passes

Closes #892