### PR TITLE
GH-965: Preserve Claude Code system prompt in SDK mode

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -820,6 +820,15 @@ func (o *Orchestrator) runClaudeSDK(ctx context.Context, prompt, workDir string,
 	opts.DangerouslySkipPermissions = true
 	opts.AllowDangerouslySkipPermissions = true
 
+	// Preserve Claude Code's built-in system prompt (tool discipline, read-before-write,
+	// etc.) by using a preset instead of leaving SystemPrompt nil. When nil, the SDK
+	// passes --system-prompt "" which strips the defaults, causing stitch to hallucinate
+	// file reads from package_contracts (GH-965).
+	opts = opts.WithSystemPromptPreset(claudetypes.SystemPromptPreset{
+		Type:   "preset",
+		Preset: "claude_code",
+	})
+
 	// Map --max-turns from extraClaudeArgs into the options struct.
 	for i := 0; i+1 < len(extraClaudeArgs); i++ {
 		if extraClaudeArgs[i] == "--max-turns" {


### PR DESCRIPTION
## Summary

Fixed SDK mode stripping Claude Code's built-in system prompt. The Go Agent SDK passes `--system-prompt ""` when `SystemPrompt` is nil, removing tool discipline instructions and causing stitch to hallucinate file reads. Setting a `claude_code` preset makes the SDK use `--append-system-prompt` instead, preserving the defaults.

## Changes

- `pkg/orchestrator/cobbler.go`: set `SystemPrompt` to `SystemPromptPreset{Type: "preset", Preset: "claude_code"}` in `runClaudeSDK`

## Stats

13,751 prod LOC (+9 lines), 19,144 test LOC (no delta)

## Test plan

- [x] `go build ./pkg/orchestrator/` compiles
- [x] All unit tests pass
- [ ] SDK mode stitch produces non-zero LOC on packages with `package_contracts`

Closes #965