### PR TITLE
GH-989: show requirements progress in stats:generator

### DIFF
--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -6,6 +6,7 @@ package orchestrator
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -164,6 +165,22 @@ func (o *Orchestrator) GeneratorStats() error {
 		}
 	}
 
+	// Requirements progress.
+	total, byPRD := countTotalPRDRequirements()
+	if total > 0 {
+		addressed := 0
+		for prd, status := range prdStatus {
+			if status == "done" || status == "in-progress" {
+				addressed += byPRD[prd]
+			}
+		}
+		pct := 0
+		if total > 0 {
+			pct = addressed * 100 / total
+		}
+		fmt.Printf("\nRequirements: %d/%d addressed by this generation (%d%%)\n", addressed, total, pct)
+	}
+
 	return nil
 }
 
@@ -209,6 +226,40 @@ func parseStitchComment(body string) stitchCommentData {
 	}
 
 	return d
+}
+
+// countTotalPRDRequirements loads all PRD files and counts the total number of
+// requirement items across all groups. Returns the total count and a map from
+// PRD short name (e.g. "prd-003") to its item count for cross-referencing with
+// generation task PRD references.
+func countTotalPRDRequirements() (int, map[string]int) {
+	paths, _ := filepath.Glob("docs/specs/product-requirements/prd*.yaml")
+	byPRD := make(map[string]int, len(paths))
+	total := 0
+	for _, path := range paths {
+		prd := loadYAML[PRDDoc](path)
+		if prd == nil {
+			continue
+		}
+		count := 0
+		for _, group := range prd.Requirements {
+			count += len(group.Items)
+		}
+		total += count
+		// Store under the short prd-NNN name that extractPRDRefs produces.
+		stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		if idx := strings.IndexByte(stem, '-'); idx > 0 {
+			// "prd003-cobbler-workflows" → "prd-003-cobbler-workflows" matches
+			// extractPRDRefs output like "prd-003". Store both forms.
+			byPRD[stem] = count
+		}
+		// extractPRDRefs produces "prd-NNN" form, so convert "prd003" → "prd-003".
+		if len(stem) >= 6 && stem[:3] == "prd" {
+			short := "prd-" + stem[3:6]
+			byPRD[short] = count
+		}
+	}
+	return total, byPRD
 }
 
 // extractPRDRefs returns deduplicated prd-* tokens found in text.

--- a/pkg/orchestrator/generator_stats_test.go
+++ b/pkg/orchestrator/generator_stats_test.go
@@ -3,7 +3,11 @@
 
 package orchestrator
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 // --- parseStitchComment (GH-571) ---
 
@@ -137,5 +141,63 @@ func TestParseCobblerIssuesJSON_State(t *testing.T) {
 	}
 	if issues[1].State != "closed" {
 		t.Errorf("issues[1].State = %q, want \"closed\"", issues[1].State)
+	}
+}
+
+// --- countTotalPRDRequirements (GH-989) ---
+
+func TestCountTotalPRDRequirements(t *testing.T) {
+	// Uses os.Chdir — do NOT use t.Parallel()
+	dir := t.TempDir()
+
+	prdDir := filepath.Join(dir, "docs", "specs", "product-requirements")
+	if err := os.MkdirAll(prdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	prdContent := `name: test-prd
+requirements:
+  group-a:
+    description: Group A
+    items:
+      - id: REQ-001
+        text: First requirement
+      - id: REQ-002
+        text: Second requirement
+  group-b:
+    description: Group B
+    items:
+      - id: REQ-003
+        text: Third requirement
+`
+	if err := os.WriteFile(filepath.Join(prdDir, "prd001-test.yaml"), []byte(prdContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	total, byPRD := countTotalPRDRequirements()
+	if total != 3 {
+		t.Errorf("total = %d, want 3", total)
+	}
+	if byPRD["prd-001"] != 3 {
+		t.Errorf("byPRD[prd-001] = %d, want 3", byPRD["prd-001"])
+	}
+}
+
+func TestCountTotalPRDRequirements_NoPRDs(t *testing.T) {
+	// Uses os.Chdir — do NOT use t.Parallel()
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	total, byPRD := countTotalPRDRequirements()
+	if total != 0 {
+		t.Errorf("total = %d, want 0", total)
+	}
+	if len(byPRD) != 0 {
+		t.Errorf("byPRD = %v, want empty", byPRD)
 	}
 }


### PR DESCRIPTION
## Summary

Adds requirements implementation progress tracking to `stats:generator`. After the PRD coverage table, the command now shows how many total PRD requirements are addressed by the current generation run, with a percentage.

## Changes

- Added `countTotalPRDRequirements()` function that loads all PRD YAML files and counts requirement items per PRD
- Added requirements progress line to `GeneratorStats()` output: `Requirements: X/Y addressed by this generation (Z%)`
- Added 2 tests: `TestCountTotalPRDRequirements` and `TestCountTotalPRDRequirements_NoPRDs`

## Stats

- Prod LOC: 13,657 (delta from 13,751 baseline reflects other branch changes)
- Test LOC: 19,206 (+62 from 19,144 baseline)

## Test plan

- [x] `mage analyze` passes
- [x] All stats tests pass
- [x] New tests cover both PRD-present and no-PRD scenarios

Closes #989