### PR TITLE
GH-990: per-stitch LOC and cumulative LOC in stats:generator

### DIFF
--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -16,12 +16,14 @@ import (
 // generatorIssueStats holds per-issue stats derived from labels and comments.
 type generatorIssueStats struct {
 	cobblerIssue
-	status    string  // "done", "failed", "in-progress", "pending"
-	costUSD   float64
-	durationS int
-	numTurns  int
-	prds      []string
-	release   string // roadmap release version, e.g. "01.0"
+	status       string  // "done", "failed", "in-progress", "pending"
+	costUSD      float64
+	durationS    int
+	numTurns     int
+	locDeltaProd int
+	locDeltaTest int
+	prds         []string
+	release      string // roadmap release version, e.g. "01.0"
 }
 
 // GeneratorStats prints a status report for the current generation run.
@@ -57,7 +59,7 @@ func (o *Orchestrator) GeneratorStats() error {
 	// Collect per-issue stats.
 	rows := make([]generatorIssueStats, 0, len(issues))
 	var totalCost float64
-	var totalTurns int
+	var totalTurns, totalLocProd, totalLocTest int
 	var nDone, nFailed, nInProgress, nPending int
 	prdStatus := make(map[string]string) // prd name → highest-priority status
 	prdReleaseMap := buildPRDReleaseMap()
@@ -93,9 +95,13 @@ func (o *Orchestrator) GeneratorStats() error {
 			if p.numTurns > 0 {
 				s.numTurns += p.numTurns
 			}
+			s.locDeltaProd += p.locDeltaProd
+			s.locDeltaTest += p.locDeltaTest
 		}
 		totalCost += s.costUSD
 		totalTurns += s.numTurns
+		totalLocProd += s.locDeltaProd
+		totalLocTest += s.locDeltaTest
 
 		// Extract PRD references, resolve release, and track coverage.
 		s.prds = extractPRDRefs(iss.Title + " " + iss.Description)
@@ -136,6 +142,7 @@ func (o *Orchestrator) GeneratorStats() error {
 	}
 	fmt.Println()
 	fmt.Printf("Total cost: $%.2f, %d turns\n", totalCost, totalTurns)
+	fmt.Printf("LOC created: %+d prod, %+d test\n", totalLocProd, totalLocTest)
 
 	// Per-release breakdown.
 	type relCounts struct{ done, inProgress, pending, failed int }
@@ -180,7 +187,7 @@ func (o *Orchestrator) GeneratorStats() error {
 
 	// Issue table.
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "#\tIdx\tStatus\tRel\tCost\tDuration\tTurns\tTitle")
+	fmt.Fprintln(w, "#\tIdx\tStatus\tRel\tCost\tDuration\tTurns\tProd\tTest\tTitle")
 	for _, r := range rows {
 		cost := "-"
 		if r.costUSD > 0 {
@@ -194,6 +201,14 @@ func (o *Orchestrator) GeneratorStats() error {
 		if r.numTurns > 0 {
 			turns = strconv.Itoa(r.numTurns)
 		}
+		prod := "-"
+		if r.locDeltaProd != 0 {
+			prod = fmt.Sprintf("%+d", r.locDeltaProd)
+		}
+		test := "-"
+		if r.locDeltaTest != 0 {
+			test = fmt.Sprintf("%+d", r.locDeltaTest)
+		}
 		rel := r.release
 		if rel == "" {
 			rel = "-"
@@ -202,8 +217,8 @@ func (o *Orchestrator) GeneratorStats() error {
 		if len(title) > 48 {
 			title = title[:45] + "..."
 		}
-		fmt.Fprintf(w, "%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			r.Number, r.Index, r.status, rel, cost, dur, turns, title)
+		fmt.Fprintf(w, "%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.Number, r.Index, r.status, rel, cost, dur, turns, prod, test, title)
 	}
 	if err := w.Flush(); err != nil {
 		return err
@@ -249,9 +264,11 @@ func (o *Orchestrator) GeneratorStats() error {
 
 // stitchCommentData holds metrics extracted from a stitch progress comment.
 type stitchCommentData struct {
-	costUSD   float64
-	durationS int
-	numTurns  int
+	costUSD      float64
+	durationS    int
+	numTurns     int
+	locDeltaProd int
+	locDeltaTest int
 }
 
 // parseStitchComment extracts cost and duration from a stitch progress comment
@@ -270,6 +287,16 @@ func parseStitchComment(body string) stitchCommentData {
 		costStr = strings.TrimRight(costStr, ".,;")
 		if v, err := strconv.ParseFloat(costStr, 64); err == nil {
 			d.costUSD = v
+		}
+	}
+
+	// Parse "LOC delta: +N prod, +N test"
+	if i := strings.Index(body, "LOC delta: "); i >= 0 {
+		rest := body[i+11:]
+		var prod, test int
+		if n, _ := fmt.Sscanf(rest, "%d prod, %d test", &prod, &test); n == 2 {
+			d.locDeltaProd = prod
+			d.locDeltaTest = test
 		}
 	}
 

--- a/pkg/orchestrator/generator_stats_test.go
+++ b/pkg/orchestrator/generator_stats_test.go
@@ -21,6 +21,12 @@ func TestParseStitchComment_Completed(t *testing.T) {
 	if d.durationS != 5*60+32 {
 		t.Errorf("durationS = %d, want %d", d.durationS, 5*60+32)
 	}
+	if d.locDeltaProd != 45 {
+		t.Errorf("locDeltaProd = %d, want 45", d.locDeltaProd)
+	}
+	if d.locDeltaTest != 17 {
+		t.Errorf("locDeltaTest = %d, want 17", d.locDeltaTest)
+	}
 }
 
 func TestParseStitchComment_Failed(t *testing.T) {
@@ -56,6 +62,24 @@ func TestParseStitchComment_WithTurns(t *testing.T) {
 	}
 	if d.costUSD != 0.55 {
 		t.Errorf("costUSD = %v, want 0.55", d.costUSD)
+	}
+	if d.locDeltaProd != 20 {
+		t.Errorf("locDeltaProd = %d, want 20", d.locDeltaProd)
+	}
+	if d.locDeltaTest != 10 {
+		t.Errorf("locDeltaTest = %d, want 10", d.locDeltaTest)
+	}
+}
+
+func TestParseStitchComment_NegativeLOC(t *testing.T) {
+	t.Parallel()
+	body := "Stitch completed in 1m 5s. LOC delta: -12 prod, +30 test. Cost: $0.20. Turns: 5."
+	d := parseStitchComment(body)
+	if d.locDeltaProd != -12 {
+		t.Errorf("locDeltaProd = %d, want -12", d.locDeltaProd)
+	}
+	if d.locDeltaTest != 30 {
+		t.Errorf("locDeltaTest = %d, want 30", d.locDeltaTest)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds per-stitch LOC delta columns (Prod/Test) to the `stats:generator` issue table and a cumulative LOC summary line. LOC deltas are parsed from stitch completion comments which already include `LOC delta: +N prod, +N test`.

## Changes

- Added `locDeltaProd`, `locDeltaTest` fields to `stitchCommentData` and `generatorIssueStats`
- Added `LOC delta:` parsing to `parseStitchComment`
- Added "Prod" and "Test" columns to the issue table
- Added "LOC created: +N prod, +N test" to the aggregate summary
- Added `TestParseStitchComment_NegativeLOC` test, extended existing tests to verify LOC fields

## Test plan

- [x] `mage analyze` passes
- [x] All stats tests pass (12 tests)
- [x] Negative LOC deltas handled correctly

Closes #990