### PR TITLE
GH-1005: dynamically scope go_source_dirs per stitch task

### DIFF
--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -330,6 +331,59 @@ func parseRequiredReading(description string) []string {
 	return parsed.RequiredReading
 }
 
+// scopeSourceDirs narrows GoSourceDirs based on the task description's files
+// field (GH-1005). For each configured dir, if the task's files reference a
+// sub-directory two levels deep (e.g. "cmd/cat/main.go" under "cmd/"), only
+// that sub-directory is included instead of the whole tree. Directories where
+// all task files sit directly inside (e.g. "pkg/orchestrator/foo.go" under
+// "pkg/") are kept as-is. Returns nil when no scoping is possible.
+func scopeSourceDirs(configDirs []string, description string) []string {
+	if description == "" || len(configDirs) == 0 {
+		return nil
+	}
+	var parsed struct {
+		Files []string `yaml:"files"`
+	}
+	if err := yaml.Unmarshal([]byte(description), &parsed); err != nil || len(parsed.Files) == 0 {
+		return nil
+	}
+
+	// Extract two-level prefixes from task files: "cmd/cat/main.go" → "cmd/cat".
+	subDirs := make(map[string]bool)
+	for _, f := range parsed.Files {
+		f = strings.TrimPrefix(f, "./")
+		parts := strings.SplitN(f, "/", 3)
+		if len(parts) == 3 {
+			subDirs[parts[0]+"/"+parts[1]] = true
+		}
+	}
+
+	changed := false
+	scoped := make([]string, 0, len(configDirs))
+	for _, dir := range configDirs {
+		clean := strings.TrimRight(strings.TrimPrefix(dir, "./"), "/")
+		// Collect sub-directories of this config dir referenced by the task.
+		var matches []string
+		for sd := range subDirs {
+			if strings.HasPrefix(sd, clean+"/") {
+				matches = append(matches, sd)
+			}
+		}
+		if len(matches) > 0 {
+			sort.Strings(matches)
+			scoped = append(scoped, matches...)
+			changed = true
+		} else {
+			scoped = append(scoped, dir)
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+	return scoped
+}
+
 // validateIssueDescription checks that a description parses as valid YAML
 // and contains the required top-level keys defined by the issue-format
 // constitution. Returns an error describing what is missing; callers
@@ -619,6 +673,7 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 
 	// Build project context from the worktree directory so source code
 	// reflects the latest state after prior stitches have been merged.
+	// Scope GoSourceDirs to only directories relevant to this task (GH-1005).
 	var projectCtx *ProjectContext
 	if task.worktreeDir != "" {
 		orig, err := os.Getwd()
@@ -629,7 +684,12 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 			logf("buildStitchPrompt: chdir to worktree error: %v", err)
 		} else {
 			defer os.Chdir(orig)
-			ctx, ctxErr := buildProjectContext("", o.cfg.Project, phaseCtx)
+			scopedProject := o.cfg.Project
+			if scoped := scopeSourceDirs(o.cfg.Project.GoSourceDirs, task.description); len(scoped) > 0 {
+				logf("buildStitchPrompt: scoped go_source_dirs %v -> %v", o.cfg.Project.GoSourceDirs, scoped)
+				scopedProject.GoSourceDirs = scoped
+			}
+			ctx, ctxErr := buildProjectContext("", scopedProject, phaseCtx)
 			if ctxErr != nil {
 				logf("buildStitchPrompt: buildProjectContext error: %v", ctxErr)
 			} else {

--- a/pkg/orchestrator/stitch_test.go
+++ b/pkg/orchestrator/stitch_test.go
@@ -956,6 +956,109 @@ func TestGitBranchExists_ChecksLocalBranches(t *testing.T) {
 	}
 }
 
+// --- scopeSourceDirs (GH-1005) ---
+
+func TestScopeSourceDirs_EmptyDescription(t *testing.T) {
+	t.Parallel()
+	got := scopeSourceDirs([]string{"cmd/", "pkg/"}, "")
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestScopeSourceDirs_NoDirs(t *testing.T) {
+	t.Parallel()
+	desc := "files:\n  - cmd/cat/main.go\n"
+	got := scopeSourceDirs(nil, desc)
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestScopeSourceDirs_NoFilesField(t *testing.T) {
+	t.Parallel()
+	desc := "requirements:\n  - do something\n"
+	got := scopeSourceDirs([]string{"cmd/", "pkg/"}, desc)
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestScopeSourceDirs_InvalidYAML(t *testing.T) {
+	t.Parallel()
+	got := scopeSourceDirs([]string{"cmd/"}, "{{not yaml")
+	if got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestScopeSourceDirs_NarrowsCmd(t *testing.T) {
+	t.Parallel()
+	desc := "files:\n  - cmd/cat/main.go\n  - cmd/cat/cat_test.go\n  - pkg/orchestrator/stitch.go\n"
+	got := scopeSourceDirs([]string{"cmd/", "pkg/"}, desc)
+	// cmd/ narrows to cmd/cat; pkg/ narrows to pkg/orchestrator.
+	want := []string{"cmd/cat", "pkg/orchestrator"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d]=%q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestScopeSourceDirs_MultipleCmdSubdirs(t *testing.T) {
+	t.Parallel()
+	desc := "files:\n  - cmd/cat/main.go\n  - cmd/grep/main.go\n"
+	got := scopeSourceDirs([]string{"cmd/"}, desc)
+	want := []string{"cmd/cat", "cmd/grep"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("got[%d]=%q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestScopeSourceDirs_NoChangeReturnsNil(t *testing.T) {
+	t.Parallel()
+	// Files only at root level can't narrow any directory.
+	desc := "files:\n  - main.go\n  - go.mod\n"
+	got := scopeSourceDirs([]string{"cmd/", "pkg/"}, desc)
+	if got != nil {
+		t.Errorf("expected nil for shallow files, got %v", got)
+	}
+}
+
+func TestScopeSourceDirs_DotSlashPrefix(t *testing.T) {
+	t.Parallel()
+	desc := "files:\n  - ./cmd/cat/main.go\n"
+	got := scopeSourceDirs([]string{"./cmd/"}, desc)
+	want := []string{"cmd/cat"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if got[0] != want[0] {
+		t.Errorf("got %q, want %q", got[0], want[0])
+	}
+}
+
+func TestScopeSourceDirs_PkgNarrows(t *testing.T) {
+	t.Parallel()
+	desc := "files:\n  - pkg/orchestrator/stitch.go\n"
+	got := scopeSourceDirs([]string{"pkg/"}, desc)
+	want := []string{"pkg/orchestrator"}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	if got[0] != want[0] {
+		t.Errorf("got %q, want %q", got[0], want[0])
+	}
+}
+
 // --- commitWorktreeChanges (error path) ---
 
 func TestCommitWorktreeChanges_InvalidDir(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds `scopeSourceDirs()` to narrow `GoSourceDirs` before loading source files in `buildStitchPrompt`. When a task's `files` field references specific sub-directories (e.g. `cmd/cat/`), only those sub-directories are loaded instead of the entire `cmd/` tree, reducing context window usage.

## Changes

- Added `scopeSourceDirs` function to `stitch.go` (parses task YAML `files` field, extracts two-level directory prefixes, narrows config dirs)
- Modified `buildStitchPrompt` to call `scopeSourceDirs` before `buildProjectContext`
- Added 9 unit tests covering: empty inputs, invalid YAML, single/multiple sub-dir narrowing, dot-slash prefixes, no-change returns nil

## Stats

- +61 prod LOC, +103 test LOC

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] 9 new `TestScopeSourceDirs_*` tests all pass

Closes #1005