### PR TITLE
GH-1006: auto-advance releases when all use cases are complete

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -159,6 +159,11 @@ func (o *Orchestrator) RunCycles(label string) error {
 			consecutiveZeroLOC = 0
 		}
 
+		// Check if the current release is complete and auto-advance if so.
+		if advanced, ver := o.checkAutoAdvanceRelease(); advanced {
+			logf("generator %s: cycle %d — auto-advanced release %s", label, cycle, ver)
+		}
+
 		logf("generator %s: cycle %d — measure", label, cycle)
 		if err := o.RunMeasure(); err != nil {
 			return fmt.Errorf("cycle %d measure: %w", cycle, err)
@@ -177,6 +182,62 @@ func (o *Orchestrator) RunCycles(label string) error {
 
 	logf("generator %s: complete (total stitched=%d)", label, totalStitched)
 	return nil
+}
+
+// checkAutoAdvanceRelease detects when the current release's use cases are all
+// done and auto-advances by calling ReleaseUpdate (which marks UCs as
+// "implemented" in road-map.yaml and removes the release from
+// configuration.yaml). Changes are committed on the current branch. Returns
+// (true, version) if a release was advanced, (false, "") otherwise.
+func (o *Orchestrator) checkAutoAdvanceRelease() (bool, string) {
+	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
+	if rm == nil {
+		return false, ""
+	}
+
+	// Find the first release that is not yet done/implemented.
+	var target *RoadmapRelease
+	for i := range rm.Releases {
+		rel := &rm.Releases[i]
+		if !ucStatusDone(rel.Status) {
+			target = rel
+			break
+		}
+	}
+	if target == nil {
+		return false, ""
+	}
+
+	// Check if all use cases in this release are done.
+	if len(target.UseCases) == 0 {
+		return false, ""
+	}
+	for _, uc := range target.UseCases {
+		if !ucStatusDone(uc.Status) {
+			return false, ""
+		}
+	}
+
+	// All UCs done — auto-advance this release.
+	logf("checkAutoAdvanceRelease: release %s has all use cases done, advancing", target.Version)
+	if err := o.ReleaseUpdate(target.Version); err != nil {
+		logf("checkAutoAdvanceRelease: ReleaseUpdate(%s) failed: %v", target.Version, err)
+		return false, ""
+	}
+
+	// Commit the changes on the current branch.
+	_ = gitStageAll(".")
+	msg := fmt.Sprintf("Auto-advance release %s: all use cases complete\n\nMarked use cases as implemented in road-map.yaml.\nRemoved %s from project.releases in configuration.yaml.", target.Version, target.Version)
+	if err := gitCommit(msg, "."); err != nil {
+		logf("checkAutoAdvanceRelease: commit failed: %v", err)
+	}
+
+	// Reload config so subsequent measure sees updated releases.
+	if cfg, err := LoadConfig(DefaultConfigFile); err == nil {
+		o.cfg = cfg
+	}
+
+	return true, target.Version
 }
 
 // GeneratorStart begins a new generation trail.

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -1389,3 +1389,114 @@ func TestResolveStopTarget_CallerOnCustomBase_UsesCustomBase(t *testing.T) {
 		t.Errorf("resolveStopTarget = %q, want %q", got, "develop")
 	}
 }
+
+// --- checkAutoAdvanceRelease (GH-1006) ---
+
+func TestCheckAutoAdvanceRelease_AllUCsDone(t *testing.T) {
+	dir := initTestGitRepo(t)
+
+	// Write a roadmap where release 00.0 has all UCs done.
+	roadmapContent := `id: rm1
+title: Test Roadmap
+releases:
+  - version: "00.0"
+    name: Release 0
+    status: in_progress
+    use_cases:
+      - id: rel00.0-uc001-format
+        status: done
+        summary: Format output
+      - id: rel00.0-uc002-build
+        status: done
+        summary: Build pipeline
+  - version: "01.0"
+    name: Release 1
+    status: pending
+    use_cases:
+      - id: rel01.0-uc001-ext
+        status: spec_complete
+        summary: Extension
+`
+	writeRoadmapFile(t, dir, roadmapContent)
+	cfgPath := filepath.Join(dir, DefaultConfigFile)
+	writeConfigFile(t, cfgPath, []string{"00.0", "01.0"})
+
+	o := &Orchestrator{cfg: Config{}}
+	advanced, ver := o.checkAutoAdvanceRelease()
+	if !advanced {
+		t.Fatal("expected auto-advance, got false")
+	}
+	if ver != "00.0" {
+		t.Errorf("advanced version = %q, want %q", ver, "00.0")
+	}
+
+	// Verify road-map.yaml: release 00.0 UCs should be "implemented".
+	statuses, err := roadmapUCStatuses(filepath.Join(dir, "docs", "road-map.yaml"), "00.0")
+	if err != nil {
+		t.Fatalf("read statuses: %v", err)
+	}
+	for id, status := range statuses {
+		if status != "implemented" {
+			t.Errorf("UC %s: want implemented, got %q", id, status)
+		}
+	}
+
+	// Verify configuration.yaml: "00.0" should be removed.
+	versions, err := releaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	for _, v := range versions {
+		if v == "00.0" {
+			t.Error("00.0 should have been removed from config releases")
+		}
+	}
+}
+
+func TestCheckAutoAdvanceRelease_NotAllDone(t *testing.T) {
+	dir := initTestGitRepo(t)
+
+	// Release 00.0 has one pending UC.
+	writeRoadmapFile(t, dir, sampleRoadmap)
+	cfgPath := filepath.Join(dir, DefaultConfigFile)
+	writeConfigFile(t, cfgPath, []string{"00.0"})
+
+	o := &Orchestrator{cfg: Config{}}
+	advanced, ver := o.checkAutoAdvanceRelease()
+	if advanced {
+		t.Errorf("should not advance when UCs are pending, got version=%q", ver)
+	}
+}
+
+func TestCheckAutoAdvanceRelease_NoRoadmap(t *testing.T) {
+	_ = chdirTemp(t)
+
+	o := &Orchestrator{cfg: Config{}}
+	advanced, _ := o.checkAutoAdvanceRelease()
+	if advanced {
+		t.Error("should not advance when no road-map.yaml exists")
+	}
+}
+
+func TestCheckAutoAdvanceRelease_AllReleasesAlreadyDone(t *testing.T) {
+	dir := initTestGitRepo(t)
+
+	roadmapContent := `id: rm1
+title: Test Roadmap
+releases:
+  - version: "00.0"
+    name: Release 0
+    status: done
+    use_cases:
+      - id: rel00.0-uc001-format
+        status: done
+        summary: Format output
+`
+	writeRoadmapFile(t, dir, roadmapContent)
+
+	o := &Orchestrator{cfg: Config{}}
+	advanced, _ := o.checkAutoAdvanceRelease()
+	if advanced {
+		t.Error("should not advance when all releases already done")
+	}
+}


### PR DESCRIPTION
## Summary

Adds automatic release advancement to the generator loop. After each stitch cycle, `checkAutoAdvanceRelease` detects when the current release's use cases are all done, calls `ReleaseUpdate` to mark them as implemented in road-map.yaml and remove the release from configuration.yaml, commits the changes, and reloads config so the next measure cycle targets the following release.

## Changes

- Added `checkAutoAdvanceRelease()` method to `Orchestrator` in `generator.go`
- Called in `RunCycles` after stitch, before measure
- Added 4 unit tests: all-UCs-done (verifies roadmap + config mutation), not-all-done, no-roadmap, all-releases-already-done

## Stats

- +61 prod LOC, +111 test LOC

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] 4 new `TestCheckAutoAdvanceRelease_*` tests all pass

Closes #1006