### PR TITLE
GH-1022: rename [measure] to [stitch] in issue title when stitch picks up a task

### DIFF
--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -590,8 +590,26 @@ func pickReadyIssue(repo, generation string) (cobblerIssue, error) {
 	if err := removeIssueLabel(repo, picked.Number, cobblerLabelReady); err != nil {
 		logf("pickReadyIssue: remove ready label from #%d: %v", picked.Number, err)
 	}
+
+	// Rename [measure] → [stitch] so stats:generator shows which phase executed the task.
+	if strings.HasPrefix(picked.Title, "[measure] ") {
+		picked.Title = "[stitch] " + strings.TrimPrefix(picked.Title, "[measure] ")
+		if err := editIssueTitle(repo, picked.Number, picked.Title); err != nil {
+			logf("pickReadyIssue: rename title warning for #%d: %v", picked.Number, err)
+		}
+	}
+
 	logf("pickReadyIssue: picked #%d %q gen=%s", picked.Number, picked.Title, generation)
 	return picked, nil
+}
+
+// editIssueTitle updates the title of a GitHub issue.
+func editIssueTitle(repo string, number int, title string) error {
+	return exec.Command(binGh, "issue", "edit",
+		"--repo", repo,
+		fmt.Sprintf("%d", number),
+		"--title", title,
+	).Run()
 }
 
 // closeCobblerIssue closes a GitHub issue and re-runs promoteReadyIssues so

--- a/pkg/orchestrator/issues_gh_test.go
+++ b/pkg/orchestrator/issues_gh_test.go
@@ -771,3 +771,31 @@ func TestLinkSubIssue_FakeRepo_Error(t *testing.T) {
 		t.Error("linkSubIssue with fake repo must return an error")
 	}
 }
+
+// --- measure→stitch title rename (GH-1022) ---
+
+func TestMeasureToStitchTitleRename(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		title string
+		want  string
+	}{
+		{"with prefix", "[measure] Implement cat utility", "[stitch] Implement cat utility"},
+		{"without prefix", "Implement cat utility", "Implement cat utility"},
+		{"empty", "", ""},
+		{"prefix only", "[measure] ", "[stitch] "},
+		{"nested prefix", "[measure] [measure] double", "[stitch] [measure] double"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.title
+			if strings.HasPrefix(got, "[measure] ") {
+				got = "[stitch] " + strings.TrimPrefix(got, "[measure] ")
+			}
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When stitch picks up a task via `pickReadyIssue`, the `[measure]` prefix in the issue title is renamed to `[stitch]`. This makes `stats:generator` output clearly show which phase executed each task.

## Changes

- `pickReadyIssue` in `issues_gh.go`: renames `[measure]` → `[stitch]` after claiming the issue
- Added `editIssueTitle` helper function
- Added `TestMeasureToStitchTitleRename` with 5 test cases

## Stats

- +17 prod LOC, +29 test LOC

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] 5 new title rename test cases pass

Closes #1022