### PR TITLE
GH-1028: add requirements column to stats:generator

### DIFF
--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -11,6 +11,8 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+
+	"gopkg.in/yaml.v3"
 )
 
 // generatorIssueStats holds per-issue stats derived from labels and comments.
@@ -22,6 +24,7 @@ type generatorIssueStats struct {
 	numTurns     int
 	locDeltaProd int
 	locDeltaTest int
+	numReqs      int // number of requirements in the task description
 	prds         []string
 	release      string // roadmap release version, e.g. "01.0"
 }
@@ -59,7 +62,7 @@ func (o *Orchestrator) GeneratorStats() error {
 	// Collect per-issue stats.
 	rows := make([]generatorIssueStats, 0, len(issues))
 	var totalCost float64
-	var totalTurns, totalLocProd, totalLocTest int
+	var totalTurns, totalLocProd, totalLocTest, totalReqs int
 	var nDone, nFailed, nInProgress, nPending int
 	prdStatus := make(map[string]string) // prd name → highest-priority status
 	prdReleaseMap := buildPRDReleaseMap()
@@ -103,6 +106,9 @@ func (o *Orchestrator) GeneratorStats() error {
 		totalLocProd += s.locDeltaProd
 		totalLocTest += s.locDeltaTest
 
+		s.numReqs = countDescriptionReqs(iss.Description)
+		totalReqs += s.numReqs
+
 		// Extract PRD references, resolve release, and track coverage.
 		s.prds = extractPRDRefs(iss.Title + " " + iss.Description)
 		for _, prd := range s.prds {
@@ -143,6 +149,7 @@ func (o *Orchestrator) GeneratorStats() error {
 	fmt.Println()
 	fmt.Printf("Total cost: $%.2f, %d turns\n", totalCost, totalTurns)
 	fmt.Printf("LOC created: %+d prod, %+d test\n", totalLocProd, totalLocTest)
+	fmt.Printf("Requirements: %d total in tasks\n", totalReqs)
 
 	// Per-release breakdown.
 	type relCounts struct{ done, inProgress, pending, failed int }
@@ -187,7 +194,7 @@ func (o *Orchestrator) GeneratorStats() error {
 
 	// Issue table.
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "#\tIdx\tStatus\tRel\tCost\tDuration\tTurns\tProd\tTest\tTitle")
+	fmt.Fprintln(w, "#\tIdx\tStatus\tRel\tReqs\tCost\tDuration\tTurns\tProd\tTest\tTitle")
 	for _, r := range rows {
 		cost := "-"
 		if r.costUSD > 0 {
@@ -209,6 +216,10 @@ func (o *Orchestrator) GeneratorStats() error {
 		if r.locDeltaTest != 0 {
 			test = fmt.Sprintf("%+d", r.locDeltaTest)
 		}
+		reqs := "-"
+		if r.numReqs > 0 {
+			reqs = strconv.Itoa(r.numReqs)
+		}
 		rel := r.release
 		if rel == "" {
 			rel = "-"
@@ -217,8 +228,8 @@ func (o *Orchestrator) GeneratorStats() error {
 		if len(title) > 48 {
 			title = title[:45] + "..."
 		}
-		fmt.Fprintf(w, "%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			r.Number, r.Index, r.status, rel, cost, dur, turns, prod, test, title)
+		fmt.Fprintf(w, "%d\t%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.Number, r.Index, r.status, rel, reqs, cost, dur, turns, prod, test, title)
 	}
 	if err := w.Flush(); err != nil {
 		return err
@@ -407,6 +418,21 @@ func buildPRDReleaseMap() map[string]string {
 		}
 	}
 	return prdRelease
+}
+
+// countDescriptionReqs counts the number of requirements in a task description
+// by parsing the YAML requirements list. Each item with an "id" field (e.g.
+// "R1", "R2") counts as one requirement.
+func countDescriptionReqs(description string) int {
+	var parsed struct {
+		Requirements []struct {
+			ID string `yaml:"id"`
+		} `yaml:"requirements"`
+	}
+	if err := yaml.Unmarshal([]byte(description), &parsed); err != nil {
+		return 0
+	}
+	return len(parsed.Requirements)
 }
 
 // extractPRDRefs returns deduplicated prd-* tokens found in text.

--- a/pkg/orchestrator/generator_stats_test.go
+++ b/pkg/orchestrator/generator_stats_test.go
@@ -238,6 +238,52 @@ func TestCountTotalPRDRequirements_NoPRDs(t *testing.T) {
 	}
 }
 
+// --- countDescriptionReqs (GH-1028) ---
+
+func TestCountDescriptionReqs(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		desc string
+		want int
+	}{
+		{
+			name: "three requirements",
+			desc: "title: some task\nrequirements:\n  - id: R1\n    text: first\n  - id: R2\n    text: second\n  - id: R3\n    text: third\n",
+			want: 3,
+		},
+		{
+			name: "no requirements key",
+			desc: "title: some task\ndescription: no reqs here\n",
+			want: 0,
+		},
+		{
+			name: "empty requirements list",
+			desc: "title: some task\nrequirements: []\n",
+			want: 0,
+		},
+		{
+			name: "invalid yaml",
+			desc: "{{not yaml at all",
+			want: 0,
+		},
+		{
+			name: "plain text",
+			desc: "Just a plain text description with no YAML structure.",
+			want: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := countDescriptionReqs(tc.desc)
+			if got != tc.want {
+				t.Errorf("countDescriptionReqs() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 // --- buildPRDReleaseMap (GH-992) ---
 
 func TestBuildPRDReleaseMap(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a Reqs column to the stats:generator issue table showing how many requirements each task addresses, parsed from the YAML requirements list in task descriptions. Also displays an aggregate total in the header.

## Changes

- Added `countDescriptionReqs` function to parse YAML requirements from task descriptions
- Wired requirement counting into the issue stats loop
- Added `Reqs` column to table header and row output
- Added aggregate requirements total to header summary
- Added 5 test cases for `countDescriptionReqs`

## Stats

- go_loc_prod: 14120
- go_loc_test: 20087
- Delta: +76 lines (30 prod, 46 test)

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (including 5 new `TestCountDescriptionReqs` subtests)

Closes #1028