### PR TITLE
GH-1026: deduplicate measure proposals against closed issues

### DIFF
--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -612,6 +612,16 @@ func editIssueTitle(repo string, number int, title string) error {
 	).Run()
 }
 
+// normalizeIssueTitle strips [measure]/[stitch] prefixes and trims whitespace
+// so that proposed titles can be compared against existing issues (GH-1026).
+func normalizeIssueTitle(title string) string {
+	t := strings.TrimSpace(title)
+	for _, prefix := range []string{"[measure] ", "[stitch] "} {
+		t = strings.TrimPrefix(t, prefix)
+	}
+	return strings.TrimSpace(t)
+}
+
 // closeCobblerIssue closes a GitHub issue and re-runs promoteReadyIssues so
 // any unblocked issues become ready.
 func closeCobblerIssue(repo string, number int, generation string) error {

--- a/pkg/orchestrator/issues_gh_test.go
+++ b/pkg/orchestrator/issues_gh_test.go
@@ -799,3 +799,30 @@ func TestMeasureToStitchTitleRename(t *testing.T) {
 		})
 	}
 }
+
+// --- normalizeIssueTitle (GH-1026) ---
+
+func TestNormalizeIssueTitle(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"measure prefix", "[measure] prd001: Implement Foo", "prd001: Implement Foo"},
+		{"stitch prefix", "[stitch] prd001: Implement Foo", "prd001: Implement Foo"},
+		{"no prefix", "prd001: Implement Foo", "prd001: Implement Foo"},
+		{"extra whitespace", "  [measure]  prd001: Implement Foo  ", "prd001: Implement Foo"},
+		{"empty string", "", ""},
+		{"prefix only", "[measure] ", "[measure]"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := normalizeIssueTitle(tc.input)
+			if got != tc.want {
+				t.Errorf("normalizeIssueTitle(%q) = %q, want %q", tc.input, got, tc.want)
+			}
+		})
+	}
+}

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -608,6 +608,27 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 			len(vr.Errors), strings.Join(vr.Errors, "; "))
 	}
 
+	// Deduplicate: fetch existing issues for this generation and skip any
+	// proposed issue whose normalized title matches a closed one (GH-1026).
+	closedTitles := make(map[string]int) // normalized title → issue number
+	if existing, err := listAllCobblerIssues(repo, generation); err == nil {
+		for _, ex := range existing {
+			if ex.State == "closed" {
+				closedTitles[normalizeIssueTitle(ex.Title)] = ex.Number
+			}
+		}
+	}
+	var filtered []proposedIssue
+	for _, issue := range issues {
+		norm := normalizeIssueTitle(issue.Title)
+		if dup, ok := closedTitles[norm]; ok {
+			logf("importIssues: skipping duplicate %q — already completed as #%d", issue.Title, dup)
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+	issues = filtered
+
 	// Create all issues on GitHub. When a placeholder number is given and exactly
 	// one issue is proposed, upgrade the placeholder in-place instead of creating
 	// a new issue, eliminating the two-issue dance (GH-578).


### PR DESCRIPTION
## Summary

Prevents measure from proposing duplicate tasks that were already completed in the same generation. Before creating GitHub issues, `importIssuesImpl` fetches closed issues and skips any proposal whose normalized title matches, saving wasted stitch cycles.

## Changes

- Added `normalizeIssueTitle` to `issues_gh.go` — strips `[measure]`/`[stitch]` prefixes for comparison
- Added dedup logic in `importIssuesImpl` — fetches closed issues, builds title set, filters proposals
- Added 6 test cases for `normalizeIssueTitle`

## Stats

- go_loc_prod: +20 lines
- go_loc_test: +38 lines

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] `TestNormalizeIssueTitle` covers measure/stitch prefixes, no prefix, whitespace, empty

Closes #1026