### PR TITLE
GH-1025: extract release version directly from task title

### DIFF
--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -109,7 +110,8 @@ func (o *Orchestrator) GeneratorStats() error {
 		s.numReqs = countDescriptionReqs(iss.Description)
 		totalReqs += s.numReqs
 
-		// Extract PRD references, resolve release, and track coverage.
+		// Extract release directly from title; fall back to PRD mapping.
+		s.release = extractRelease(iss.Title)
 		s.prds = extractPRDRefs(iss.Title + " " + iss.Description)
 		for _, prd := range s.prds {
 			if s.release == "" {
@@ -433,6 +435,19 @@ func countDescriptionReqs(description string) int {
 		return 0
 	}
 	return len(parsed.Requirements)
+}
+
+// reRelease matches release patterns like "rel01.0" or "rel02.1" in text.
+var reRelease = regexp.MustCompile(`rel(\d{2}\.\d)`)
+
+// extractRelease returns the first release version (e.g. "01.0") found in
+// text by matching relNN.N patterns. Returns "" if no match.
+func extractRelease(text string) string {
+	m := reRelease.FindStringSubmatch(text)
+	if m == nil {
+		return ""
+	}
+	return m[1]
 }
 
 // extractPRDRefs returns deduplicated prd-* tokens found in text.

--- a/pkg/orchestrator/generator_stats_test.go
+++ b/pkg/orchestrator/generator_stats_test.go
@@ -91,6 +91,33 @@ func TestParseStitchComment_NoMatch(t *testing.T) {
 	}
 }
 
+// --- extractRelease (GH-1025) ---
+
+func TestExtractRelease(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		text string
+		want string
+	}{
+		{"title with rel", "cmd/tee implementation (rel02.1-uc001-tee)", "02.1"},
+		{"rel01.0", "[stitch] prd001: Implement Foo (rel01.0-uc003)", "01.0"},
+		{"no release", "prd001: Implement Foo", ""},
+		{"plain text", "no release info here", ""},
+		{"multiple releases", "rel01.0 and rel02.1", "01.0"},
+		{"embedded in word", "xrel03.0y", "03.0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractRelease(tc.text)
+			if got != tc.want {
+				t.Errorf("extractRelease(%q) = %q, want %q", tc.text, got, tc.want)
+			}
+		})
+	}
+}
+
 // --- extractPRDRefs (GH-571) ---
 
 func TestExtractPRDRefs(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds direct release version extraction from task titles in stats:generator, replacing the indirect PRD→use case touchpoint mapping that always produced `-`. Titles like `cmd/tee implementation (rel02.1-uc001-tee)` now populate the `Rel` column correctly.

## Changes

- Added `extractRelease` function with `rel(\d{2}\.\d)` regex
- Wired into `GeneratorStats` loop before PRD-based fallback
- Added 6 test cases for `extractRelease`

## Stats

- Delta: +43 lines (14 prod, 29 test)

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] `TestExtractRelease` covers match/no-match/multiple/embedded cases

Closes #1025