### PR TITLE
GH-1024: propagate CLI turn count to ClaudeResult

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -27,14 +27,15 @@ import (
 // InputTokens is the total input (non-cached + cache creation + cache read).
 // CacheCreationTokens and CacheReadTokens break down how the input was served.
 // RawOutput contains the full stream-json output from Claude for history.
-// NumTurns, DurationAPIMs, and SessionID are populated only in SDK mode.
+// NumTurns is populated from progressWriter in CLI/Podman mode and from the
+// SDK ResultMessage in SDK mode. DurationAPIMs and SessionID are SDK-only.
 type ClaudeResult struct {
 	InputTokens         int
 	OutputTokens        int
 	CacheCreationTokens int
 	CacheReadTokens     int
 	CostUSD             float64
-	NumTurns            int    // SDK mode only; 0 in CLI/Podman
+	NumTurns            int    // CLI: from progressWriter; SDK: from ResultMessage
 	DurationAPIMs       int    // SDK mode only; API-side latency in milliseconds
 	SessionID           string // SDK mode only; Claude session identifier
 	RawOutput           []byte
@@ -692,8 +693,10 @@ func (o *Orchestrator) runClaude(prompt, dir string, silence bool, extraClaudeAr
 
 	var stdoutBuf bytes.Buffer
 	var outputWriter io.Writer
+	var pw *progressWriter
 	if silence {
-		outputWriter = newProgressWriter(&stdoutBuf, time.Now())
+		pw = newProgressWriter(&stdoutBuf, time.Now())
+		outputWriter = pw
 	} else {
 		outputWriter = io.MultiWriter(os.Stdout, &stdoutBuf)
 		cmd.Stderr = os.Stderr
@@ -741,6 +744,9 @@ func (o *Orchestrator) runClaude(prompt, dir string, silence bool, extraClaudeAr
 
 	rawOutput := stdoutBuf.Bytes()
 	result := parseClaudeTokens(rawOutput)
+	if pw != nil {
+		result.NumTurns = pw.turn
+	}
 	result.RawOutput = make([]byte, len(rawOutput))
 	copy(result.RawOutput, rawOutput)
 	logf("runClaude: finished in %s in=%d (cache_create=%d cache_read=%d) out=%d cost=$%.4f (err=%v)",

--- a/pkg/orchestrator/cobbler_test.go
+++ b/pkg/orchestrator/cobbler_test.go
@@ -1415,6 +1415,38 @@ func TestProgressWriter_LogLine_LongSnippetTruncated(t *testing.T) {
 	}
 }
 
+// --- progressWriter turn propagation (GH-1024) ---
+
+func TestProgressWriter_TurnCount_MultipleAssistantEvents(t *testing.T) {
+	t.Parallel()
+	var buf bytes.Buffer
+	pw := newProgressWriter(&buf, time.Now())
+
+	// Simulate 3 assistant turns followed by a result.
+	assistant := `{"type":"assistant","message":{"content":[{"type":"text","text":"turn"}]}}`
+	result := `{"type":"result","total_cost_usd":0.50,"usage":{"input_tokens":100,"output_tokens":50,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}`
+	stream := assistant + "\n" + assistant + "\n" + assistant + "\n" + result + "\n"
+
+	// Write the stream through progressWriter (simulating cmd.Stdout).
+	pw.Write([]byte(stream))
+
+	if pw.turn != 3 {
+		t.Errorf("pw.turn = %d, want 3", pw.turn)
+	}
+
+	// Verify parseClaudeTokens gets cost from the same buffer.
+	cr := parseClaudeTokens(buf.Bytes())
+	if cr.CostUSD != 0.50 {
+		t.Errorf("CostUSD = %v, want 0.50", cr.CostUSD)
+	}
+
+	// Simulate the propagation that runClaude does.
+	cr.NumTurns = pw.turn
+	if cr.NumTurns != 3 {
+		t.Errorf("NumTurns = %d, want 3", cr.NumTurns)
+	}
+}
+
 // --- logConfig ---
 
 func TestLogConfig(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the always-zero Turns column in stats:generator for CLI/Podman tasks by propagating the turn count from `progressWriter` (which already counts assistant events during streaming) to `ClaudeResult.NumTurns`.

## Changes

- Kept `progressWriter` reference accessible in `runClaude` after the output writer setup
- Set `result.NumTurns = pw.turn` after `parseClaudeTokens` when `pw` is available
- Updated `NumTurns` field comments to reflect both CLI and SDK sources
- Added integration test: `TestProgressWriter_TurnCount_MultipleAssistantEvents`

## Stats

- Delta: +41/-3 lines

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] New test verifies 3 assistant events → turn=3 propagated to NumTurns

Closes #1024