### PR TITLE
GH-1021: reset releases to spec_complete on generator:stop

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -464,6 +464,12 @@ func (o *Orchestrator) GeneratorStop() error {
 		}
 	}
 
+	// Reset all implemented releases back to spec_complete so the repo is
+	// ready for the next generation run (GH-1021).
+	if err := o.resetImplementedReleases(); err != nil {
+		logf("generator:stop: reset releases warning: %v", err)
+	}
+
 	o.cleanupDirs()
 
 	logf("generator:stop: done, work is on %s", baseBranch)
@@ -534,6 +540,36 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 
 	logf("generator:stop: deleting branch")
 	_ = gitDeleteBranch(branch, ".") // best-effort; branch may already be deleted
+	return nil
+}
+
+// resetImplementedReleases loads road-map.yaml, finds all releases with
+// status "implemented", and calls ReleaseClear for each to reset them to
+// "spec_complete" and repopulate configuration.yaml (GH-1021).
+func (o *Orchestrator) resetImplementedReleases() error {
+	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
+	if rm == nil {
+		return nil
+	}
+	var cleared []string
+	for _, rel := range rm.Releases {
+		if strings.EqualFold(rel.Status, "implemented") {
+			if err := o.ReleaseClear(rel.Version); err != nil {
+				logf("resetImplementedReleases: ReleaseClear(%s) failed: %v", rel.Version, err)
+				continue
+			}
+			cleared = append(cleared, rel.Version)
+		}
+	}
+	if len(cleared) == 0 {
+		return nil
+	}
+	_ = gitStageAll(".")
+	msg := fmt.Sprintf("Reset releases to spec_complete after generator:stop\n\nCleared: %s", strings.Join(cleared, ", "))
+	if err := gitCommit(msg, "."); err != nil {
+		return fmt.Errorf("commit release reset: %w", err)
+	}
+	logf("resetImplementedReleases: cleared %d release(s): %s", len(cleared), strings.Join(cleared, ", "))
 	return nil
 }
 

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -1500,3 +1500,115 @@ releases:
 		t.Error("should not advance when all releases already done")
 	}
 }
+
+// --- resetImplementedReleases (GH-1021) ---
+
+func TestResetImplementedReleases(t *testing.T) {
+	dir := initTestGitRepo(t)
+
+	roadmapContent := `id: rm1
+title: Test Roadmap
+releases:
+  - version: "00.0"
+    name: Release 0
+    status: implemented
+    use_cases:
+      - id: rel00.0-uc001-format
+        status: implemented
+        summary: Format output
+  - version: "01.0"
+    name: Release 1
+    status: implemented
+    use_cases:
+      - id: rel01.0-uc001-ext
+        status: implemented
+        summary: Extension
+  - version: "02.0"
+    name: Release 2
+    status: spec_complete
+    use_cases:
+      - id: rel02.0-uc001-tee
+        status: spec_complete
+        summary: Tee
+`
+	writeRoadmapFile(t, dir, roadmapContent)
+	cfgPath := filepath.Join(dir, DefaultConfigFile)
+	writeConfigFile(t, cfgPath, []string{"02.0"})
+
+	o := &Orchestrator{cfg: Config{}}
+	if err := o.resetImplementedReleases(); err != nil {
+		t.Fatalf("resetImplementedReleases error: %v", err)
+	}
+
+	// Verify 00.0 and 01.0 are reset to spec_complete.
+	for _, ver := range []string{"00.0", "01.0"} {
+		statuses, err := roadmapUCStatuses(filepath.Join(dir, "docs", "road-map.yaml"), ver)
+		if err != nil {
+			t.Fatalf("read statuses for %s: %v", ver, err)
+		}
+		for id, status := range statuses {
+			if status != "spec_complete" {
+				t.Errorf("UC %s (rel %s): want spec_complete, got %q", id, ver, status)
+			}
+		}
+	}
+
+	// Verify 02.0 is unchanged.
+	statuses, err := roadmapUCStatuses(filepath.Join(dir, "docs", "road-map.yaml"), "02.0")
+	if err != nil {
+		t.Fatalf("read statuses for 02.0: %v", err)
+	}
+	for id, status := range statuses {
+		if status != "spec_complete" {
+			t.Errorf("UC %s (rel 02.0): want spec_complete, got %q", id, status)
+		}
+	}
+
+	// Verify configuration.yaml has 00.0 and 01.0 added to releases.
+	versions, err := releaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	found := map[string]bool{}
+	for _, v := range versions {
+		found[v] = true
+	}
+	if !found["00.0"] {
+		t.Error("00.0 should be in config releases after reset")
+	}
+	if !found["01.0"] {
+		t.Error("01.0 should be in config releases after reset")
+	}
+}
+
+func TestResetImplementedReleases_NoneImplemented(t *testing.T) {
+	dir := initTestGitRepo(t)
+
+	roadmapContent := `id: rm1
+title: Test Roadmap
+releases:
+  - version: "00.0"
+    name: Release 0
+    status: spec_complete
+    use_cases:
+      - id: rel00.0-uc001-format
+        status: spec_complete
+        summary: Format
+`
+	writeRoadmapFile(t, dir, roadmapContent)
+
+	o := &Orchestrator{cfg: Config{}}
+	if err := o.resetImplementedReleases(); err != nil {
+		t.Fatalf("resetImplementedReleases error: %v", err)
+	}
+	// No error, no commit — just a no-op.
+}
+
+func TestResetImplementedReleases_NoRoadmap(t *testing.T) {
+	initTestGitRepo(t)
+
+	o := &Orchestrator{cfg: Config{}}
+	if err := o.resetImplementedReleases(); err != nil {
+		t.Fatalf("resetImplementedReleases error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

After `generator:stop` completes the merge and cleanup, all `implemented` releases in road-map.yaml are now automatically reset to `spec_complete` and their versions are added back to configuration.yaml's releases list. This eliminates the manual reset step before starting the next generation run.

## Changes

- Added `resetImplementedReleases` method called from `GeneratorStop`
- Loads road-map.yaml, finds `implemented` releases, calls `ReleaseClear` for each
- Commits the reset changes automatically
- 3 tests: multi-release reset, no-op when none implemented, no-op when no roadmap

## Stats

- Delta: +148 lines (35 prod, 113 test)

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass

Closes #1021