### PR TITLE
GH-1020: Recurring test:usecase run

### DIFF
--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -610,11 +610,22 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 
 	// Deduplicate: fetch existing issues for this generation and skip any
 	// proposed issue whose normalized title matches a closed one (GH-1026).
+	// Only dedup when the generation has open issues — indicates an active run.
+	// If all issues are closed, this is likely a fresh start on the same branch.
 	closedTitles := make(map[string]int) // normalized title → issue number
 	if existing, err := listAllCobblerIssues(repo, generation); err == nil {
+		hasOpen := false
 		for _, ex := range existing {
-			if ex.State == "closed" {
-				closedTitles[normalizeIssueTitle(ex.Title)] = ex.Number
+			if ex.State == "open" {
+				hasOpen = true
+				break
+			}
+		}
+		if hasOpen {
+			for _, ex := range existing {
+				if ex.State == "closed" {
+					closedTitles[normalizeIssueTitle(ex.Title)] = ex.Number
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Recurring test:usecase run discovered and fixed a regression from GH-1026: the measure dedup logic incorrectly skipped proposed issues in fresh generation runs when old closed issues with matching titles existed from previous test runs.

## Changes

- Fixed dedup in `importIssuesImpl` to only activate when generation has open issues (active run)
- Prevents false skips on fresh starts where all previous issues are closed

## Stats

- go_loc_prod: 14219
- go_loc_test: 20285

## Test plan

- [x] `mage analyze` passes
- [x] All unit tests pass
- [x] All use case tests pass (including UC003)

Closes #1020