### PR TITLE
GH-1118: Fix stitch prompt size blowup from unparsed required_reading

### DIFF
--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -193,8 +193,8 @@ type CobblerConfig struct {
 	// MaxContextBytes is the maximum serialized size (in bytes) of the
 	// ProjectContext injected into the stitch prompt. When the context
 	// exceeds this budget, non-required source files are progressively
-	// removed. Recommended value: 200000 (~50K tokens at 4 bytes/token).
-	// When 0 (the default), budget enforcement is skipped.
+	// removed. Defaults to 200000 (~50K tokens at 4 bytes/token) when 0.
+	// Set to -1 to disable budget enforcement entirely.
 	MaxContextBytes int `yaml:"max_context_bytes"`
 
 	// EnforceMeasureValidation enables strict validation of measure output.

--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -909,14 +909,23 @@ func filterSourceFiles(sources []SourceFile, requiredPaths []string) []SourceFil
 	return filtered
 }
 
+// defaultMaxContextBytes is the fallback budget when MaxContextBytes is not
+// configured. 200KB is approximately 50K tokens at 4 bytes/token, leaving
+// room for the rest of the stitch prompt (constitutions, task description).
+const defaultMaxContextBytes = 200_000
+
 // applyContextBudget measures the YAML-serialized size of ctx and, if it
 // exceeds budget, progressively removes SourceCode entries not in
 // requiredPaths until within budget. Files are removed in reverse order
 // (last loaded first) to preserve files closer to the top of the directory
-// tree. When budget is 0 or negative, this function is a no-op.
+// tree. When budget is 0, the default of 200KB is used. A negative budget
+// disables enforcement entirely.
 func applyContextBudget(ctx *ProjectContext, budget int, requiredPaths []string) {
-	if budget <= 0 || ctx == nil {
+	if ctx == nil || budget < 0 {
 		return
+	}
+	if budget == 0 {
+		budget = defaultMaxContextBytes
 	}
 
 	data, err := yaml.Marshal(ctx)

--- a/pkg/orchestrator/context_test.go
+++ b/pkg/orchestrator/context_test.go
@@ -4,6 +4,7 @@
 package orchestrator
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1386,6 +1387,53 @@ func TestApplyContextBudget_ExactlyAtLimit(t *testing.T) {
 func TestApplyContextBudget_NilContext(t *testing.T) {
 	// Should not panic.
 	applyContextBudget(nil, 100, nil)
+}
+
+func TestApplyContextBudget_NegativeBudget(t *testing.T) {
+	ctx := &ProjectContext{
+		SourceCode: []SourceFile{
+			{File: "pkg/a.go", Lines: strings.Repeat("x", 5000)},
+			{File: "pkg/b.go", Lines: strings.Repeat("y", 5000)},
+		},
+	}
+
+	applyContextBudget(ctx, -1, nil)
+
+	if len(ctx.SourceCode) != 2 {
+		t.Errorf("negative budget should disable enforcement, got %d files", len(ctx.SourceCode))
+	}
+}
+
+func TestApplyContextBudget_DefaultBudget(t *testing.T) {
+	// With budget=0, the default (200KB) should be used. A context well
+	// over 200KB should have non-required files removed.
+	var sources []SourceFile
+	for i := 0; i < 100; i++ {
+		sources = append(sources, SourceFile{
+			File:  fmt.Sprintf("pkg/file%03d.go", i),
+			Lines: strings.Repeat("x", 3000),
+		})
+	}
+	ctx := &ProjectContext{SourceCode: sources}
+
+	required := []string{"pkg/file000.go"}
+	applyContextBudget(ctx, 0, required)
+
+	// Required file must survive.
+	found := false
+	for _, sf := range ctx.SourceCode {
+		if sf.File == "pkg/file000.go" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("required file pkg/file000.go was removed by default budget")
+	}
+
+	// Some files should have been removed to fit under 200KB.
+	if len(ctx.SourceCode) >= 100 {
+		t.Errorf("expected default budget to remove files, still have %d", len(ctx.SourceCode))
+	}
 }
 
 func TestContextExcludeEverything(t *testing.T) {

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -316,19 +316,38 @@ func pickTask(baseBranch, worktreeBase, repo, generation string) (stitchTask, er
 }
 
 // parseRequiredReading extracts the required_reading list from a YAML task
-// description. Returns nil if the field is absent or unparseable.
+// description. Handles both the canonical string format ("- path (reason)")
+// and the map format ("- path: foo.go") that Claude sometimes emits.
+// Returns nil if the field is absent or unparseable.
 func parseRequiredReading(description string) []string {
 	if description == "" {
 		return nil
 	}
-	var parsed struct {
+
+	// Try []string first (canonical format: "- path/to/file.go (reason)").
+	var stringParsed struct {
 		RequiredReading []string `yaml:"required_reading"`
 	}
-	if err := yaml.Unmarshal([]byte(description), &parsed); err != nil {
+	if err := yaml.Unmarshal([]byte(description), &stringParsed); err == nil {
+		return stringParsed.RequiredReading
+	}
+
+	// Fall back to []map format when Claude emits structured entries
+	// like {path: "foo.go", reason: "..."}.
+	var mapParsed struct {
+		RequiredReading []map[string]string `yaml:"required_reading"`
+	}
+	if err := yaml.Unmarshal([]byte(description), &mapParsed); err != nil {
 		logf("parseRequiredReading: YAML parse error: %v", err)
 		return nil
 	}
-	return parsed.RequiredReading
+	var result []string
+	for _, entry := range mapParsed.RequiredReading {
+		if p := entry["path"]; p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
 }
 
 // scopeSourceDirs narrows GoSourceDirs based on the task description's files

--- a/pkg/orchestrator/stitch_test.go
+++ b/pkg/orchestrator/stitch_test.go
@@ -314,6 +314,45 @@ func TestParseRequiredReading_ValidYAML(t *testing.T) {
 	}
 }
 
+func TestParseRequiredReading_MapFormat(t *testing.T) {
+	t.Parallel()
+	desc := `required_reading:
+  - path: pkg/orchestrator/generator.go
+    reason: contains GeneratorStats
+  - path: pkg/orchestrator/stitch.go
+    reason: buildStitchPrompt implementation
+  - path: docs/ARCHITECTURE.yaml
+    reason: system context
+`
+	got := parseRequiredReading(desc)
+	if len(got) != 3 {
+		t.Fatalf("parseRequiredReading() returned %d items, want 3: %v", len(got), got)
+	}
+	want := []string{
+		"pkg/orchestrator/generator.go",
+		"pkg/orchestrator/stitch.go",
+		"docs/ARCHITECTURE.yaml",
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("got[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestParseRequiredReading_MapFormat_MissingPath(t *testing.T) {
+	t.Parallel()
+	desc := `required_reading:
+  - path: pkg/orchestrator/generator.go
+    reason: has path
+  - reason: no path field here
+`
+	got := parseRequiredReading(desc)
+	if len(got) != 1 {
+		t.Errorf("parseRequiredReading() returned %d items, want 1 (only entries with path): %v", len(got), got)
+	}
+}
+
 // --- cleanGoBinaries ---
 
 func TestCleanGoBinaries_RemovesExecutableNoExtension(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes the root cause of 790KB stitch prompts: `parseRequiredReading` failed on map-format YAML that Claude sometimes emits, causing all source files to be included unfiltered. Also adds a default 200KB context budget as a safety net.

## Changes

- `parseRequiredReading` now handles both `[]string` and `[]map[string]string` formats
- `applyContextBudget` defaults to 200KB when `MaxContextBytes` is 0 (set -1 to disable)
- Updated config comment to reflect new default behavior
- Added tests for map-format parsing, negative budget, and default budget enforcement

## Stats

- go_loc_prod: 14441 (+32)
- go_loc_test: 20417 (+87)

## Test plan

- [x] `mage analyze` passes
- [x] All unit tests pass
- [x] New tests: `TestParseRequiredReading_MapFormat`, `_MapFormat_MissingPath`, `TestApplyContextBudget_NegativeBudget`, `_DefaultBudget`

Closes #1118