### PR TITLE
GH-1153: Add input/output token counts to stats:generator

### DIFF
--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -27,6 +27,8 @@ type generatorIssueStats struct {
 	locDeltaTest int
 	numReqs      int // number of requirements in the task description
 	promptBytes  int // prompt size in bytes from "Stitch started" comment
+	inputTokens  int // total input tokens from stitch completion comments
+	outputTokens int // total output tokens from stitch completion comments
 	prds         []string
 	release      string // roadmap release version, e.g. "01.0"
 }
@@ -65,6 +67,7 @@ func (o *Orchestrator) GeneratorStats() error {
 	rows := make([]generatorIssueStats, 0, len(issues))
 	var totalCost float64
 	var totalTurns, totalLocProd, totalLocTest, totalReqs, totalPromptBytes int
+	var totalInputTokens, totalOutputTokens int
 	var nDone, nFailed, nInProgress, nPending int
 	prdStatus := make(map[string]string) // prd name → highest-priority status
 	prdReleaseMap := buildPRDReleaseMap()
@@ -105,12 +108,16 @@ func (o *Orchestrator) GeneratorStats() error {
 			if p.promptBytes > 0 {
 				s.promptBytes = p.promptBytes
 			}
+			s.inputTokens += p.inputTokens
+			s.outputTokens += p.outputTokens
 		}
 		totalCost += s.costUSD
 		totalTurns += s.numTurns
 		totalLocProd += s.locDeltaProd
 		totalLocTest += s.locDeltaTest
 		totalPromptBytes += s.promptBytes
+		totalInputTokens += s.inputTokens
+		totalOutputTokens += s.outputTokens
 
 		s.numReqs = countDescriptionReqs(iss.Description)
 		totalReqs += s.numReqs
@@ -160,6 +167,9 @@ func (o *Orchestrator) GeneratorStats() error {
 	if totalPromptBytes > 0 {
 		fmt.Printf("Prompt total: %s\n", formatBytes(totalPromptBytes))
 	}
+	if totalInputTokens > 0 || totalOutputTokens > 0 {
+		fmt.Printf("Tokens: %s in, %s out\n", formatTokens(totalInputTokens), formatTokens(totalOutputTokens))
+	}
 
 	// Per-release breakdown.
 	type relCounts struct{ done, inProgress, pending, failed int }
@@ -204,7 +214,7 @@ func (o *Orchestrator) GeneratorStats() error {
 
 	// Issue table.
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "#\tStatus\tRel\tReqs\tPrompt\tCost\tDuration\tTurns\tProd\tTest\tTitle")
+	fmt.Fprintln(w, "#\tStatus\tRel\tReqs\tPrompt\tCost\tDuration\tTurns\tTokIn\tTokOut\tProd\tTest\tTitle")
 	for _, r := range rows {
 		prompt := "-"
 		if r.promptBytes > 0 {
@@ -221,6 +231,14 @@ func (o *Orchestrator) GeneratorStats() error {
 		turns := "-"
 		if r.numTurns > 0 {
 			turns = strconv.Itoa(r.numTurns)
+		}
+		tokIn := "-"
+		if r.inputTokens > 0 {
+			tokIn = formatTokens(r.inputTokens)
+		}
+		tokOut := "-"
+		if r.outputTokens > 0 {
+			tokOut = formatTokens(r.outputTokens)
 		}
 		prod := "-"
 		if r.locDeltaProd != 0 {
@@ -242,8 +260,8 @@ func (o *Orchestrator) GeneratorStats() error {
 		if len(title) > 48 {
 			title = title[:45] + "..."
 		}
-		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			r.Number, r.status, rel, reqs, prompt, cost, dur, turns, prod, test, title)
+		fmt.Fprintf(w, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			r.Number, r.status, rel, reqs, prompt, cost, dur, turns, tokIn, tokOut, prod, test, title)
 	}
 	if err := w.Flush(); err != nil {
 		return err
@@ -295,6 +313,8 @@ type stitchCommentData struct {
 	locDeltaProd int
 	locDeltaTest int
 	promptBytes  int
+	inputTokens  int
+	outputTokens int
 }
 
 // parseStitchComment extracts cost and duration from a stitch progress comment
@@ -345,6 +365,16 @@ func parseStitchComment(body string) stitchCommentData {
 		bytesStr = strings.TrimRight(bytesStr, ".,;")
 		if v, err := strconv.Atoi(bytesStr); err == nil {
 			d.promptBytes = v
+		}
+	}
+
+	// Parse "Tokens: Nin Nout" from stitch completion comment.
+	if i := strings.Index(body, "Tokens: "); i >= 0 {
+		rest := body[i+8:]
+		var in, out int
+		if n, _ := fmt.Sscanf(rest, "%din %dout", &in, &out); n == 2 {
+			d.inputTokens = in
+			d.outputTokens = out
 		}
 	}
 
@@ -472,6 +502,18 @@ func extractRelease(text string) string {
 		return ""
 	}
 	return m[1]
+}
+
+// formatTokens returns a human-readable token count, e.g. "125K" or "1.2M".
+func formatTokens(n int) string {
+	switch {
+	case n >= 1_000_000:
+		return fmt.Sprintf("%.1fM", float64(n)/1_000_000)
+	case n >= 1_000:
+		return fmt.Sprintf("%dK", n/1_000)
+	default:
+		return strconv.Itoa(n)
+	}
 }
 
 // formatBytes returns a human-readable byte size, e.g. "125K" or "1.2M".

--- a/pkg/orchestrator/generator_stats_test.go
+++ b/pkg/orchestrator/generator_stats_test.go
@@ -109,6 +109,30 @@ func TestParseStitchComment_PromptBytes_NoMatch(t *testing.T) {
 	}
 }
 
+func TestParseStitchComment_Tokens(t *testing.T) {
+	t.Parallel()
+	body := "Stitch completed in 3m 15s. LOC delta: +20 prod, +10 test. Cost: $0.55. Turns: 12. Tokens: 125000in 5000out."
+	d := parseStitchComment(body)
+	if d.inputTokens != 125000 {
+		t.Errorf("inputTokens = %d, want 125000", d.inputTokens)
+	}
+	if d.outputTokens != 5000 {
+		t.Errorf("outputTokens = %d, want 5000", d.outputTokens)
+	}
+}
+
+func TestParseStitchComment_Tokens_NoMatch(t *testing.T) {
+	t.Parallel()
+	body := "Stitch completed in 5m 32s. LOC delta: +45 prod, +17 test. Cost: $0.42."
+	d := parseStitchComment(body)
+	if d.inputTokens != 0 {
+		t.Errorf("inputTokens = %d, want 0", d.inputTokens)
+	}
+	if d.outputTokens != 0 {
+		t.Errorf("outputTokens = %d, want 0", d.outputTokens)
+	}
+}
+
 // --- formatBytes (GH-1116) ---
 
 func TestFormatBytes(t *testing.T) {
@@ -131,6 +155,33 @@ func TestFormatBytes(t *testing.T) {
 			got := formatBytes(tc.bytes)
 			if got != tc.want {
 				t.Errorf("formatBytes(%d) = %q, want %q", tc.bytes, got, tc.want)
+			}
+		})
+	}
+}
+
+// --- formatTokens (GH-1153) ---
+
+func TestFormatTokens(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		tokens int
+		want   string
+	}{
+		{"millions", 1_500_000, "1.5M"},
+		{"exactly 1M", 1_000_000, "1.0M"},
+		{"thousands", 125000, "125K"},
+		{"small thousands", 1000, "1K"},
+		{"small", 999, "999"},
+		{"zero", 0, "0"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := formatTokens(tc.tokens)
+			if got != tc.want {
+				t.Errorf("formatTokens(%d) = %q, want %q", tc.tokens, got, tc.want)
 			}
 		})
 	}

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -918,11 +918,12 @@ func (o *Orchestrator) closeStitchTask(task stitchTask, rec InvocationRecord) {
 	locDeltaProd := rec.LOCAfter.Production - rec.LOCBefore.Production
 	locDeltaTest := rec.LOCAfter.Test - rec.LOCBefore.Test
 	comment := fmt.Sprintf(
-		"Stitch completed in %dm %ds. LOC delta: %+d prod, %+d test. Cost: $%.2f. Turns: %d.",
+		"Stitch completed in %dm %ds. LOC delta: %+d prod, %+d test. Cost: $%.2f. Turns: %d. Tokens: %din %dout.",
 		rec.DurationS/60, rec.DurationS%60,
 		locDeltaProd, locDeltaTest,
 		rec.Tokens.CostUSD,
 		rec.NumTurns,
+		rec.Tokens.Input, rec.Tokens.Output,
 	)
 	commentCobblerIssue(task.repo, task.ghNumber, comment)
 	if err := closeCobblerIssue(task.repo, task.ghNumber, task.generation); err != nil {


### PR DESCRIPTION
## Summary

Adds TokIn and TokOut columns to the `stats:generator` issue table, showing total input and output tokens per task parsed from stitch completion comments. Token counts are displayed in human-readable format (e.g., "125K") with aggregate totals in the header.

## Changes

- Extended stitch completion comment to include `Tokens: Nin Nout`
- Added token parsing to `parseStitchComment`
- Added `formatTokens` helper for human-readable display
- Added TokIn/TokOut columns to the issue table
- Added aggregate token totals to the header summary
- Added tests for token parsing and formatting

## Test plan

- [x] All existing tests pass
- [x] New token parsing tests pass
- [x] New formatTokens tests pass
- [ ] `mage analyze` passes
- [ ] Manual verification with active generation

Closes #1153