### PR TITLE
GH-1177: Extract build/ into internal sub-package

### DIFF
--- a/pkg/orchestrator/build.go
+++ b/pkg/orchestrator/build.go
@@ -6,30 +6,32 @@ package orchestrator
 import (
 	"fmt"
 	"os"
-	"os/exec"
-	"path/filepath"
+
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/build"
 )
+
+// ---------------------------------------------------------------------------
+// Dependency injection: wire the parent package's logf, binary paths,
+// and helper functions into the internal/build package at init time.
+// ---------------------------------------------------------------------------
+
+func init() {
+	build.Log = logf
+	build.BinGo = binGo
+	build.BinLint = binLint
+	build.BinSecurity = binSecurity
+	build.BinPodman = binPodman
+	build.BinMage = binMage
+	build.BinGit = binGit
+	build.PodmanBuildFn = podmanBuild
+	build.ReadVersionConstFn = readVersionConst
+	build.GitListTagsFn = gitListTags
+}
 
 // Build compiles the project binary. If MainPackage is empty, the
 // target is skipped.
 func (o *Orchestrator) Build() error {
-	if o.cfg.Project.MainPackage == "" {
-		logf("build: skipping (no main_package configured)")
-		return nil
-	}
-	outPath := filepath.Join(o.cfg.Project.BinaryDir, o.cfg.Project.BinaryName)
-	logf("build: go build -o %s %s", outPath, o.cfg.Project.MainPackage)
-	if err := os.MkdirAll(o.cfg.Project.BinaryDir, 0o755); err != nil {
-		return fmt.Errorf("creating output directory: %w", err)
-	}
-	cmd := exec.Command(binGo, "build", "-o", outPath, o.cfg.Project.MainPackage)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("go build: %w", err)
-	}
-	logf("build: done")
-	return nil
+	return build.Build(o.buildConfig())
 }
 
 // BuildAll compiles all cmd/ sub-packages to BinaryDir when MainPackage is
@@ -37,104 +39,29 @@ func (o *Orchestrator) Build() error {
 // bin/<name> using go build -o bin/<name> ./cmd/<name>/. If no cmd/
 // directory exists the target is skipped. prd003 B1.1.
 func (o *Orchestrator) BuildAll() error {
-	if o.cfg.Project.MainPackage != "" {
-		// Single-package project — delegate to Build.
-		return o.Build()
-	}
-
-	pkgs, err := discoverCmdPackages(".")
-	if err != nil {
-		return fmt.Errorf("discovering cmd packages: %w", err)
-	}
-	if len(pkgs) == 0 {
-		logf("build:all: no cmd/ packages found, skipping")
-		return nil
-	}
-
-	if err := os.MkdirAll(o.cfg.Project.BinaryDir, 0o755); err != nil {
-		return fmt.Errorf("creating output directory: %w", err)
-	}
-
-	for _, pkg := range pkgs {
-		name := filepath.Base(pkg)
-		outPath := filepath.Join(o.cfg.Project.BinaryDir, name)
-		logf("build:all: go build -o %s %s", outPath, pkg)
-		cmd := exec.Command(binGo, "build", "-o", outPath, pkg)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			return fmt.Errorf("go build %s: %w", pkg, err)
-		}
-	}
-
-	logf("build:all: built %d package(s) to %s", len(pkgs), o.cfg.Project.BinaryDir)
-	return nil
+	return build.BuildAll(o.buildConfig())
 }
 
 // discoverCmdPackages returns the import paths of all packages under cmd/
 // that contain a main.go file, relative to root.
 func discoverCmdPackages(root string) ([]string, error) {
-	cmdDir := filepath.Join(root, "cmd")
-	entries, err := os.ReadDir(cmdDir)
-	if os.IsNotExist(err) {
-		return nil, nil
-	}
-	if err != nil {
-		return nil, fmt.Errorf("reading cmd/: %w", err)
-	}
-
-	var pkgs []string
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		mainGo := filepath.Join(cmdDir, e.Name(), "main.go")
-		if _, err := os.Stat(mainGo); err == nil {
-			pkgs = append(pkgs, "./cmd/"+e.Name()+"/")
-		}
-	}
-	return pkgs, nil
+	return build.DiscoverCmdPackages(root)
 }
 
 // Lint runs golangci-lint on the project.
 func (o *Orchestrator) Lint() error {
-	logf("lint: running golangci-lint")
-	cmd := exec.Command(binLint, "run", "./...")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("golangci-lint: %w", err)
-	}
-	logf("lint: done")
-	return nil
+	return build.Lint()
 }
 
 // Install runs go install for the main package. If MainPackage
 // is empty, the target is skipped.
 func (o *Orchestrator) Install() error {
-	if o.cfg.Project.MainPackage == "" {
-		logf("install: skipping (no main_package configured)")
-		return nil
-	}
-	logf("install: go install %s", o.cfg.Project.MainPackage)
-	cmd := exec.Command(binGo, "install", o.cfg.Project.MainPackage)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("go install: %w", err)
-	}
-	logf("install: done")
-	return nil
+	return build.Install(o.buildConfig())
 }
 
 // Clean removes the build artifact directory.
 func (o *Orchestrator) Clean() error {
-	logf("clean: removing %s", o.cfg.Project.BinaryDir)
-	if err := os.RemoveAll(o.cfg.Project.BinaryDir); err != nil {
-		return fmt.Errorf("removing %s: %w", o.cfg.Project.BinaryDir, err)
-	}
-	logf("clean: done")
-	return nil
+	return build.Clean(o.cfg.Project.BinaryDir)
 }
 
 // DumpMeasurePrompt assembles and prints the measure prompt to stdout.
@@ -171,19 +98,14 @@ func (o *Orchestrator) DumpStitchPrompt() error {
 // ExtractCredentials reads Claude credentials from the macOS Keychain
 // and writes them to SecretsDir/TokenFile.
 func (o *Orchestrator) ExtractCredentials() error {
-	outPath := filepath.Join(o.cfg.Claude.SecretsDir, o.cfg.EffectiveTokenFile())
-	logf("credentials: extracting to %s", outPath)
-	if err := os.MkdirAll(o.cfg.Claude.SecretsDir, 0o700); err != nil {
-		return fmt.Errorf("creating secrets directory: %w", err)
+	return build.ExtractCredentials(o.cfg.Claude.SecretsDir, o.cfg.EffectiveTokenFile())
+}
+
+// buildConfig returns a build.BuildConfig from the orchestrator's config.
+func (o *Orchestrator) buildConfig() build.BuildConfig {
+	return build.BuildConfig{
+		MainPackage: o.cfg.Project.MainPackage,
+		BinaryDir:   o.cfg.Project.BinaryDir,
+		BinaryName:  o.cfg.Project.BinaryName,
 	}
-	out, err := exec.Command(binSecurity, "find-generic-password",
-		"-s", "Claude Code-credentials", "-w").Output()
-	if err != nil {
-		return fmt.Errorf("extracting credentials from keychain: %w", err)
-	}
-	if err := os.WriteFile(outPath, out, 0o600); err != nil {
-		return fmt.Errorf("writing credentials: %w", err)
-	}
-	logf("credentials: written to %s", outPath)
-	return nil
 }

--- a/pkg/orchestrator/docker.go
+++ b/pkg/orchestrator/docker.go
@@ -4,13 +4,9 @@
 package orchestrator
 
 import (
-	"context"
 	_ "embed"
-	"fmt"
-	"os"
-	"os/exec"
-	"strings"
-	"time"
+
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/build"
 )
 
 //go:embed Dockerfile.claude
@@ -25,30 +21,10 @@ var embeddedDockerfile string
 //
 // Exposed as a mage target (e.g., mage buildImage).
 func (o *Orchestrator) BuildImage() error {
-	imageName := imageBaseName(o.cfg.Podman.Image)
-	if imageName == "" {
-		return fmt.Errorf("podman.image not set in configuration; cannot determine image name")
-	}
-
-	// Prefer version from the project's version file; fall back to git tags.
-	tag := readVersionConst(o.cfg.Project.VersionFile)
-	if tag == "" {
-		tag = latestVersionTag()
-	}
-	if tag == "" {
-		return fmt.Errorf("no version found; set version_file in configuration.yaml or tag the repository (e.g., v[REL].YYYYMMDD.N)")
-	}
-
-	versionedImage := imageName + ":" + tag
-	latestImage := imageName + ":latest"
-
-	logf("buildImage: building %s", versionedImage)
-	if err := buildFromEmbeddedDockerfile(versionedImage, latestImage); err != nil {
-		return fmt.Errorf("podman build: %w", err)
-	}
-
-	logf("buildImage: done — %s and %s", versionedImage, latestImage)
-	return nil
+	return build.BuildImage(build.DockerConfig{
+		Image:       o.cfg.Podman.Image,
+		VersionFile: o.cfg.Project.VersionFile,
+	}, embeddedDockerfile)
 }
 
 // PodmanClean removes all podman containers (running or stopped) that
@@ -60,131 +36,37 @@ func (o *Orchestrator) BuildImage() error {
 //
 // Exposed as a mage target (e.g., mage podman:clean).
 func (o *Orchestrator) PodmanClean() error {
-	image := o.cfg.Podman.Image
-	if image == "" {
-		return fmt.Errorf("podman.image not set in configuration")
-	}
-
-	// Resolve to image ID so we catch containers from any name alias.
-	imageID, err := podmanImageID(image)
-	if err != nil {
-		return fmt.Errorf("resolving image ID for %s: %w", image, err)
-	}
-	if imageID == "" {
-		logf("podmanClean: image %s not found locally, nothing to clean", image)
-		return nil
-	}
-
-	// List all containers (running + stopped) created from this image ID.
-	out, err := exec.Command(binPodman, "ps", "-a",
-		"--filter", "ancestor="+imageID,
-		"--format", "{{.ID}} {{.Status}}",
-	).Output()
-	if err != nil {
-		return fmt.Errorf("listing containers for %s (%s): %w", image, imageID, err)
-	}
-
-	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
-	if len(lines) == 0 || lines[0] == "" {
-		logf("podmanClean: no containers found for image %s (%s)", image, shortID(imageID))
-		return nil
-	}
-
-	var ids []string
-	for _, line := range lines {
-		if fields := strings.Fields(line); len(fields) > 0 && fields[0] != "" {
-			ids = append(ids, fields[0])
-		}
-	}
-
-	logf("podmanClean: removing %d container(s) for image %s (%s)", len(ids), image, shortID(imageID))
-	args := append([]string{"rm", "-f"}, ids...)
-	cmd := exec.Command(binPodman, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("removing containers: %w", err)
-	}
-
-	logf("podmanClean: done")
-	return nil
+	return build.PodmanClean(o.cfg.Podman.Image)
 }
 
 // ensureImage checks whether the configured PodmanImage exists locally.
 // If missing, it builds it from the embedded Dockerfile.
 func (o *Orchestrator) ensureImage() error {
-	if podmanImageExists(o.cfg.Podman.Image) {
-		return nil
-	}
-
-	logf("ensureImage: %s not found locally, building from embedded Dockerfile", o.cfg.Podman.Image)
-	if err := buildFromEmbeddedDockerfile(o.cfg.Podman.Image); err != nil {
-		return fmt.Errorf("auto-building %s: %w", o.cfg.Podman.Image, err)
-	}
-	logf("ensureImage: built %s", o.cfg.Podman.Image)
-	return nil
+	return build.EnsureImage(o.cfg.Podman.Image, embeddedDockerfile)
 }
 
 // buildFromEmbeddedDockerfile writes the embedded Dockerfile to a temp
 // file and runs podman build with the given image tags.
 func buildFromEmbeddedDockerfile(tags ...string) error {
-	tmp, err := os.CreateTemp("", "Dockerfile.claude-*")
-	if err != nil {
-		return fmt.Errorf("creating temp Dockerfile: %w", err)
-	}
-	defer func() {
-		if err := os.Remove(tmp.Name()); err != nil && !os.IsNotExist(err) {
-			logf("docker: warning: removing temp Dockerfile: %v", err)
-		}
-	}()
-
-	if _, err := tmp.WriteString(embeddedDockerfile); err != nil {
-		tmp.Close()
-		return fmt.Errorf("writing temp Dockerfile: %w", err)
-	}
-	tmp.Close()
-
-	return podmanBuild(tmp.Name(), tags...)
+	return build.BuildFromEmbeddedDockerfile(embeddedDockerfile, tags...)
 }
 
 // podmanImageExists returns true if the given image reference exists
-// in the local podman image store. A 15-second deadline prevents a
-// slow or unresponsive podman socket from blocking indefinitely.
+// in the local podman image store.
 func podmanImageExists(image string) bool {
-	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
-	defer cancel()
-	if err := exec.CommandContext(ctx, binPodman, "image", "exists", image).Run(); err != nil {
-		if ctx.Err() != nil {
-			logf("podmanImageExists: timed out querying podman for %s", image)
-		}
-		return false
-	}
-	return true
+	return build.PodmanImageExists(image)
 }
 
 // podmanImageID resolves an image name/tag to its full image ID.
 // Returns "" if the image does not exist locally.
 func podmanImageID(image string) (string, error) {
-	out, err := exec.Command(binPodman, "image", "inspect", image,
-		"--format", "{{.Id}}",
-	).Output()
-	if err != nil {
-		// image not found is not an error for our purposes
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 125 {
-			return "", nil
-		}
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
+	return build.PodmanImageID(image)
 }
 
 // shortID returns the first 12 characters of an image ID for display,
 // or the full string if it is shorter than 12 characters.
 func shortID(id string) string {
-	if len(id) > 12 {
-		return id[:12]
-	}
-	return id
+	return build.ShortID(id)
 }
 
 // imageBaseName extracts the image name without a tag from a full image
@@ -192,19 +74,11 @@ func shortID(id string) string {
 // "cobbler-scaffold". If no tag is present, the input is returned
 // as-is.
 func imageBaseName(image string) string {
-	if i := strings.LastIndex(image, ":"); i > 0 {
-		return image[:i]
-	}
-	return image
+	return build.ImageBaseName(image)
 }
 
 // latestVersionTag returns the most recent v* git tag, or "" if none exist.
 func latestVersionTag() string {
-	tags := gitListTags("v*", ".")
-	if len(tags) == 0 {
-		return ""
-	}
-	// gitListTags returns tags sorted by name; the last one is the highest
-	// version when using the v[REL].[DATE].[REVISION] convention.
-	return tags[len(tags)-1]
+	return build.LatestVersionTag()
 }
+

--- a/pkg/orchestrator/internal/build/build.go
+++ b/pkg/orchestrator/internal/build/build.go
@@ -1,0 +1,192 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Package build implements Go project compilation, linting, installation,
+// cleanup, and credential extraction. The parent orchestrator package
+// provides thin receiver-method wrappers around these functions.
+package build
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// ---------------------------------------------------------------------------
+// Injected dependencies
+// ---------------------------------------------------------------------------
+
+// Logger is a function that formats and emits log messages.
+type Logger func(format string, args ...any)
+
+// Package-level variables set by the parent package at init time.
+var (
+	Log         Logger = func(string, ...any) {}
+	BinGo              = "go"
+	BinLint            = "golangci-lint"
+	BinSecurity        = "security"
+)
+
+// ---------------------------------------------------------------------------
+// Build / BuildAll / Lint / Install / Clean
+// ---------------------------------------------------------------------------
+
+// BuildConfig holds the project configuration fields needed by Build,
+// BuildAll, Install, and Clean.
+type BuildConfig struct {
+	MainPackage string
+	BinaryDir   string
+	BinaryName  string
+}
+
+// Build compiles the project binary. If MainPackage is empty, the
+// target is skipped.
+func Build(cfg BuildConfig) error {
+	if cfg.MainPackage == "" {
+		Log("build: skipping (no main_package configured)")
+		return nil
+	}
+	outPath := filepath.Join(cfg.BinaryDir, cfg.BinaryName)
+	Log("build: go build -o %s %s", outPath, cfg.MainPackage)
+	if err := os.MkdirAll(cfg.BinaryDir, 0o755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+	cmd := exec.Command(BinGo, "build", "-o", outPath, cfg.MainPackage)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("go build: %w", err)
+	}
+	Log("build: done")
+	return nil
+}
+
+// BuildAll compiles all cmd/ sub-packages to BinaryDir when MainPackage
+// is empty. It discovers every cmd/*/main.go package and builds each to
+// bin/<name>. If MainPackage is set, it delegates to Build. If no cmd/
+// directory exists the target is skipped.
+func BuildAll(cfg BuildConfig) error {
+	if cfg.MainPackage != "" {
+		return Build(cfg)
+	}
+
+	pkgs, err := DiscoverCmdPackages(".")
+	if err != nil {
+		return fmt.Errorf("discovering cmd packages: %w", err)
+	}
+	if len(pkgs) == 0 {
+		Log("build:all: no cmd/ packages found, skipping")
+		return nil
+	}
+
+	if err := os.MkdirAll(cfg.BinaryDir, 0o755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	for _, pkg := range pkgs {
+		name := filepath.Base(pkg)
+		outPath := filepath.Join(cfg.BinaryDir, name)
+		Log("build:all: go build -o %s %s", outPath, pkg)
+		cmd := exec.Command(BinGo, "build", "-o", outPath, pkg)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("go build %s: %w", pkg, err)
+		}
+	}
+
+	Log("build:all: built %d package(s) to %s", len(pkgs), cfg.BinaryDir)
+	return nil
+}
+
+// DiscoverCmdPackages returns the import paths of all packages under cmd/
+// that contain a main.go file, relative to root.
+func DiscoverCmdPackages(root string) ([]string, error) {
+	cmdDir := filepath.Join(root, "cmd")
+	entries, err := os.ReadDir(cmdDir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading cmd/: %w", err)
+	}
+
+	var pkgs []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		mainGo := filepath.Join(cmdDir, e.Name(), "main.go")
+		if _, err := os.Stat(mainGo); err == nil {
+			pkgs = append(pkgs, "./cmd/"+e.Name()+"/")
+		}
+	}
+	return pkgs, nil
+}
+
+// Lint runs golangci-lint on the project.
+func Lint() error {
+	Log("lint: running golangci-lint")
+	cmd := exec.Command(BinLint, "run", "./...")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("golangci-lint: %w", err)
+	}
+	Log("lint: done")
+	return nil
+}
+
+// Install runs go install for the main package. If MainPackage is empty,
+// the target is skipped.
+func Install(cfg BuildConfig) error {
+	if cfg.MainPackage == "" {
+		Log("install: skipping (no main_package configured)")
+		return nil
+	}
+	Log("install: go install %s", cfg.MainPackage)
+	cmd := exec.Command(BinGo, "install", cfg.MainPackage)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("go install: %w", err)
+	}
+	Log("install: done")
+	return nil
+}
+
+// Clean removes the build artifact directory.
+func Clean(binaryDir string) error {
+	Log("clean: removing %s", binaryDir)
+	if err := os.RemoveAll(binaryDir); err != nil {
+		return fmt.Errorf("removing %s: %w", binaryDir, err)
+	}
+	Log("clean: done")
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Credentials
+// ---------------------------------------------------------------------------
+
+// ExtractCredentials reads Claude credentials from the macOS Keychain
+// and writes them to the given secretsDir/tokenFile path.
+func ExtractCredentials(secretsDir, tokenFile string) error {
+	outPath := filepath.Join(secretsDir, tokenFile)
+	Log("credentials: extracting to %s", outPath)
+	if err := os.MkdirAll(secretsDir, 0o700); err != nil {
+		return fmt.Errorf("creating secrets directory: %w", err)
+	}
+	out, err := exec.Command(BinSecurity, "find-generic-password",
+		"-s", "Claude Code-credentials", "-w").Output()
+	if err != nil {
+		return fmt.Errorf("extracting credentials from keychain: %w", err)
+	}
+	if err := os.WriteFile(outPath, out, 0o600); err != nil {
+		return fmt.Errorf("writing credentials: %w", err)
+	}
+	Log("credentials: written to %s", outPath)
+	return nil
+}
+

--- a/pkg/orchestrator/internal/build/build_test.go
+++ b/pkg/orchestrator/internal/build/build_test.go
@@ -1,0 +1,175 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- Build ---
+
+func TestBuild_SkipsWhenNoMainPackage(t *testing.T) {
+	t.Parallel()
+	cfg := BuildConfig{
+		MainPackage: "",
+		BinaryDir:   t.TempDir(),
+		BinaryName:  "mybin",
+	}
+	if err := Build(cfg); err != nil {
+		t.Errorf("Build() with empty MainPackage should not error, got: %v", err)
+	}
+}
+
+func TestBuild_CreatesBinaryDir(t *testing.T) {
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin", "nested")
+
+	cfg := BuildConfig{
+		MainPackage: "nonexistent/package/that/will/fail",
+		BinaryDir:   binDir,
+		BinaryName:  "mybin",
+	}
+
+	// Build will fail because the package doesn't exist, but the directory
+	// should have been created before the go build attempt.
+	_ = Build(cfg)
+
+	if _, err := os.Stat(binDir); os.IsNotExist(err) {
+		t.Error("Build() should create binary directory even on build failure")
+	}
+}
+
+// --- Install ---
+
+func TestInstall_SkipsWhenNoMainPackage(t *testing.T) {
+	t.Parallel()
+	cfg := BuildConfig{MainPackage: ""}
+	if err := Install(cfg); err != nil {
+		t.Errorf("Install() with empty MainPackage should not error, got: %v", err)
+	}
+}
+
+func TestInstall_ErrorsWhenGoInstallFails(t *testing.T) {
+	t.Parallel()
+	cfg := BuildConfig{MainPackage: "nonexistent/package/that/will/fail"}
+	if err := Install(cfg); err == nil {
+		t.Error("Install() with nonexistent package should return error")
+	}
+}
+
+// --- BuildAll ---
+
+func TestBuildAll_SkipsWhenNoCmdDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	cfg := BuildConfig{BinaryDir: filepath.Join(dir, "bin")}
+	if err := BuildAll(cfg); err != nil {
+		t.Errorf("BuildAll() with no cmd/ should not error, got: %v", err)
+	}
+	// bin/ should not be created when there are no packages.
+	if _, err := os.Stat(filepath.Join(dir, "bin")); !os.IsNotExist(err) {
+		t.Error("BuildAll() should not create bin/ when no cmd/ packages exist")
+	}
+}
+
+func TestBuildAll_DelegatesToBuildWhenMainPackageSet(t *testing.T) {
+	t.Parallel()
+	cfg := BuildConfig{
+		MainPackage: "nonexistent/pkg",
+		BinaryDir:   t.TempDir(),
+		BinaryName:  "mybin",
+	}
+	// Should attempt Build() and fail because package doesn't exist.
+	err := BuildAll(cfg)
+	if err == nil {
+		t.Error("BuildAll() with nonexistent MainPackage should fail")
+	}
+	if !strings.Contains(err.Error(), "go build") {
+		t.Errorf("error = %q, want to contain 'go build'", err.Error())
+	}
+}
+
+func TestDiscoverCmdPackages_NoCmdDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	pkgs, err := DiscoverCmdPackages(dir)
+	if err != nil {
+		t.Fatalf("DiscoverCmdPackages error = %v", err)
+	}
+	if len(pkgs) != 0 {
+		t.Errorf("pkgs = %v, want empty", pkgs)
+	}
+}
+
+func TestDiscoverCmdPackages_FindsMainPackages(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+
+	// Create cmd/foo/main.go and cmd/bar/main.go; cmd/notmain/ has no main.go.
+	for _, path := range []string{
+		"cmd/foo/main.go",
+		"cmd/bar/main.go",
+	} {
+		full := filepath.Join(dir, path)
+		os.MkdirAll(filepath.Dir(full), 0o755)
+		os.WriteFile(full, []byte("package main\n"), 0o644)
+	}
+	os.MkdirAll(filepath.Join(dir, "cmd/notmain"), 0o755)
+
+	pkgs, err := DiscoverCmdPackages(dir)
+	if err != nil {
+		t.Fatalf("DiscoverCmdPackages error = %v", err)
+	}
+	if len(pkgs) != 2 {
+		t.Errorf("pkgs = %v, want 2 entries", pkgs)
+	}
+	for _, p := range pkgs {
+		if !strings.HasPrefix(p, "./cmd/") || !strings.HasSuffix(p, "/") {
+			t.Errorf("pkg %q should be of form ./cmd/<name>/", p)
+		}
+	}
+}
+
+// --- Clean ---
+
+func TestClean_RemovesBinaryDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	os.MkdirAll(binDir, 0o755)
+	os.WriteFile(filepath.Join(binDir, "mybin"), []byte("binary"), 0o755)
+
+	if err := Clean(binDir); err != nil {
+		t.Fatalf("Clean() error = %v", err)
+	}
+
+	if _, err := os.Stat(binDir); !os.IsNotExist(err) {
+		t.Error("Clean() should have removed binary directory")
+	}
+}
+
+func TestClean_NonExistentDir(t *testing.T) {
+	t.Parallel()
+	if err := Clean("/nonexistent/dir/that/does/not/exist/build_test"); err != nil {
+		t.Errorf("Clean() on nonexistent dir should not error, got: %v", err)
+	}
+}
+
+func TestClean_EmptyDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	binDir := filepath.Join(dir, "bin")
+	os.MkdirAll(binDir, 0o755)
+
+	if err := Clean(binDir); err != nil {
+		t.Fatalf("Clean() error = %v", err)
+	}
+
+	if _, err := os.Stat(binDir); !os.IsNotExist(err) {
+		t.Error("Clean() should have removed empty binary directory")
+	}
+}

--- a/pkg/orchestrator/internal/build/docker.go
+++ b/pkg/orchestrator/internal/build/docker.go
@@ -1,0 +1,217 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package build
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Package-level variables for docker/podman operations.
+var (
+	BinPodman = "podman"
+)
+
+// PodmanBuildFn is the function used to run podman build. The parent
+// package injects the real implementation; tests can replace it.
+var PodmanBuildFn func(dockerfile string, tags ...string) error
+
+// ReadVersionConstFn reads a Version constant from a Go source file.
+// Injected by the parent package.
+var ReadVersionConstFn func(filePath string) string
+
+// GitListTagsFn returns git tags matching a pattern in a directory.
+// Injected by the parent package.
+var GitListTagsFn func(pattern, dir string) []string
+
+// ---------------------------------------------------------------------------
+// Docker / Podman image operations
+// ---------------------------------------------------------------------------
+
+// DockerConfig holds configuration for image build/clean operations.
+type DockerConfig struct {
+	Image       string
+	VersionFile string
+}
+
+// BuildImage builds the container image using podman from the embedded
+// Dockerfile content. It reads the version from the consuming project's
+// version file (VersionFile in Config). If no version file is configured
+// or it has no Version constant, it falls back to the latest v* git tag.
+// Both a versioned tag and "latest" are applied to the built image.
+func BuildImage(cfg DockerConfig, embeddedDockerfile string) error {
+	imageName := ImageBaseName(cfg.Image)
+	if imageName == "" {
+		return fmt.Errorf("podman.image not set in configuration; cannot determine image name")
+	}
+
+	tag := ReadVersionConstFn(cfg.VersionFile)
+	if tag == "" {
+		tag = LatestVersionTag()
+	}
+	if tag == "" {
+		return fmt.Errorf("no version found; set version_file in configuration.yaml or tag the repository (e.g., v[REL].YYYYMMDD.N)")
+	}
+
+	versionedImage := imageName + ":" + tag
+	latestImage := imageName + ":latest"
+
+	Log("buildImage: building %s", versionedImage)
+	if err := BuildFromEmbeddedDockerfile(embeddedDockerfile, versionedImage, latestImage); err != nil {
+		return fmt.Errorf("podman build: %w", err)
+	}
+
+	Log("buildImage: done — %s and %s", versionedImage, latestImage)
+	return nil
+}
+
+// PodmanClean removes all podman containers (running or stopped) that
+// were created from the given image. It resolves the image name to its
+// image ID so that containers created from any alias are caught.
+func PodmanClean(image string) error {
+	if image == "" {
+		return fmt.Errorf("podman.image not set in configuration")
+	}
+
+	imageID, err := PodmanImageID(image)
+	if err != nil {
+		return fmt.Errorf("resolving image ID for %s: %w", image, err)
+	}
+	if imageID == "" {
+		Log("podmanClean: image %s not found locally, nothing to clean", image)
+		return nil
+	}
+
+	out, err := exec.Command(BinPodman, "ps", "-a",
+		"--filter", "ancestor="+imageID,
+		"--format", "{{.ID}} {{.Status}}",
+	).Output()
+	if err != nil {
+		return fmt.Errorf("listing containers for %s (%s): %w", image, imageID, err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) == 0 || lines[0] == "" {
+		Log("podmanClean: no containers found for image %s (%s)", image, ShortID(imageID))
+		return nil
+	}
+
+	var ids []string
+	for _, line := range lines {
+		if fields := strings.Fields(line); len(fields) > 0 && fields[0] != "" {
+			ids = append(ids, fields[0])
+		}
+	}
+
+	Log("podmanClean: removing %d container(s) for image %s (%s)", len(ids), image, ShortID(imageID))
+	args := append([]string{"rm", "-f"}, ids...)
+	cmd := exec.Command(BinPodman, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("removing containers: %w", err)
+	}
+
+	Log("podmanClean: done")
+	return nil
+}
+
+// EnsureImage checks whether the given image exists locally. If missing,
+// it builds it from the provided embedded Dockerfile content.
+func EnsureImage(image, embeddedDockerfile string) error {
+	if PodmanImageExists(image) {
+		return nil
+	}
+
+	Log("ensureImage: %s not found locally, building from embedded Dockerfile", image)
+	if err := BuildFromEmbeddedDockerfile(embeddedDockerfile, image); err != nil {
+		return fmt.Errorf("auto-building %s: %w", image, err)
+	}
+	Log("ensureImage: built %s", image)
+	return nil
+}
+
+// BuildFromEmbeddedDockerfile writes the given Dockerfile content to a
+// temp file and runs podman build with the given image tags.
+func BuildFromEmbeddedDockerfile(dockerfileContent string, tags ...string) error {
+	tmp, err := os.CreateTemp("", "Dockerfile.claude-*")
+	if err != nil {
+		return fmt.Errorf("creating temp Dockerfile: %w", err)
+	}
+	defer func() {
+		if err := os.Remove(tmp.Name()); err != nil && !os.IsNotExist(err) {
+			Log("docker: warning: removing temp Dockerfile: %v", err)
+		}
+	}()
+
+	if _, err := tmp.WriteString(dockerfileContent); err != nil {
+		tmp.Close()
+		return fmt.Errorf("writing temp Dockerfile: %w", err)
+	}
+	tmp.Close()
+
+	return PodmanBuildFn(tmp.Name(), tags...)
+}
+
+// PodmanImageExists returns true if the given image reference exists
+// in the local podman image store. A 15-second deadline prevents a
+// slow or unresponsive podman socket from blocking indefinitely.
+func PodmanImageExists(image string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := exec.CommandContext(ctx, BinPodman, "image", "exists", image).Run(); err != nil {
+		if ctx.Err() != nil {
+			Log("podmanImageExists: timed out querying podman for %s", image)
+		}
+		return false
+	}
+	return true
+}
+
+// PodmanImageID resolves an image name/tag to its full image ID.
+// Returns "" if the image does not exist locally.
+func PodmanImageID(image string) (string, error) {
+	out, err := exec.Command(BinPodman, "image", "inspect", image,
+		"--format", "{{.Id}}",
+	).Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 125 {
+			return "", nil
+		}
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// ShortID returns the first 12 characters of an image ID for display,
+// or the full string if it is shorter than 12 characters.
+func ShortID(id string) string {
+	if len(id) > 12 {
+		return id[:12]
+	}
+	return id
+}
+
+// ImageBaseName extracts the image name without a tag from a full image
+// reference. For example, "cobbler-scaffold:latest" returns
+// "cobbler-scaffold". If no tag is present, the input is returned as-is.
+func ImageBaseName(image string) string {
+	if i := strings.LastIndex(image, ":"); i > 0 {
+		return image[:i]
+	}
+	return image
+}
+
+// LatestVersionTag returns the most recent v* git tag, or "" if none exist.
+func LatestVersionTag() string {
+	tags := GitListTagsFn("v*", ".")
+	if len(tags) == 0 {
+		return ""
+	}
+	return tags[len(tags)-1]
+}

--- a/pkg/orchestrator/internal/build/docker_test.go
+++ b/pkg/orchestrator/internal/build/docker_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package build
+
+import "testing"
+
+// --- ShortID ---
+
+func TestShortID_LongID(t *testing.T) {
+	t.Parallel()
+	got := ShortID("e60ba5bdd19ddb026f7afa4919e45757d10c609bce112586ee6c4d8ba05bda64")
+	want := "e60ba5bdd19d"
+	if got != want {
+		t.Errorf("ShortID(long) = %q, want %q", got, want)
+	}
+}
+
+func TestShortID_ShortID(t *testing.T) {
+	t.Parallel()
+	got := ShortID("abc123")
+	want := "abc123"
+	if got != want {
+		t.Errorf("ShortID(short) = %q, want %q", got, want)
+	}
+}
+
+func TestShortID_Exactly12(t *testing.T) {
+	t.Parallel()
+	got := ShortID("123456789012")
+	want := "123456789012"
+	if got != want {
+		t.Errorf("ShortID(12) = %q, want %q", got, want)
+	}
+}
+
+func TestShortID_Empty(t *testing.T) {
+	t.Parallel()
+	got := ShortID("")
+	if got != "" {
+		t.Errorf("ShortID(empty) = %q, want empty", got)
+	}
+}
+
+// --- ImageBaseName ---
+
+func TestImageBaseName_WithTag(t *testing.T) {
+	t.Parallel()
+	got := ImageBaseName("cobbler-scaffold:latest")
+	want := "cobbler-scaffold"
+	if got != want {
+		t.Errorf("ImageBaseName() = %q, want %q", got, want)
+	}
+}
+
+func TestImageBaseName_WithVersionTag(t *testing.T) {
+	t.Parallel()
+	got := ImageBaseName("claude-cli:v2026-02-13.1")
+	want := "claude-cli"
+	if got != want {
+		t.Errorf("ImageBaseName() = %q, want %q", got, want)
+	}
+}
+
+func TestImageBaseName_NoTag(t *testing.T) {
+	t.Parallel()
+	got := ImageBaseName("my-image")
+	want := "my-image"
+	if got != want {
+		t.Errorf("ImageBaseName() = %q, want %q", got, want)
+	}
+}
+
+func TestImageBaseName_Empty(t *testing.T) {
+	t.Parallel()
+	got := ImageBaseName("")
+	if got != "" {
+		t.Errorf("ImageBaseName(empty) = %q, want empty", got)
+	}
+}

--- a/pkg/orchestrator/internal/build/scaffold.go
+++ b/pkg/orchestrator/internal/build/scaffold.go
@@ -1,0 +1,380 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package build
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// Package-level variables for scaffold operations.
+var (
+	BinMage = "mage"
+	BinGit  = "git"
+)
+
+// OrchestratorModule is the Go module path for this orchestrator library.
+const OrchestratorModule = "github.com/mesh-intelligence/cobbler-scaffold"
+
+// GoModDownloadResult holds the fields needed from go mod download -json.
+type GoModDownloadResult struct {
+	Dir string `json:"Dir"`
+}
+
+// ---------------------------------------------------------------------------
+// Scaffold helper functions
+// ---------------------------------------------------------------------------
+
+// ClearMageGoFiles removes all .go files from mageDir, preserving
+// go.mod, go.sum, and non-Go files. If mageDir does not exist, this
+// is a no-op.
+func ClearMageGoFiles(mageDir string) error {
+	entries, err := os.ReadDir(mageDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
+			continue
+		}
+		path := filepath.Join(mageDir, e.Name())
+		Log("scaffold: removing existing %s", path)
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("removing %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// CopyFile copies src to dst, creating parent directories as needed.
+func CopyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o644)
+}
+
+// DetectModulePath reads go.mod in the target directory and extracts
+// the module path from the first "module" directive.
+func DetectModulePath(targetDir string) (string, error) {
+	modPath := filepath.Join(targetDir, "go.mod")
+	f, err := os.Open(modPath)
+	if err != nil {
+		return "", fmt.Errorf("opening go.mod: %w", err)
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module")), nil
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("reading go.mod: %w", err)
+	}
+	return "", fmt.Errorf("no module directive in %s", modPath)
+}
+
+// DetectMainPackage scans cmd/ for directories containing main.go.
+// Returns the module-relative import path of the first main package
+// found, or empty string if none exist.
+func DetectMainPackage(targetDir, modulePath string) string {
+	cmdDir := filepath.Join(targetDir, "cmd")
+	entries, err := os.ReadDir(cmdDir)
+	if err != nil {
+		return ""
+	}
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		mainGo := filepath.Join(cmdDir, e.Name(), "main.go")
+		if _, err := os.Stat(mainGo); err == nil {
+			return modulePath + "/cmd/" + e.Name()
+		}
+	}
+	// Check for main.go directly in cmd/.
+	if _, err := os.Stat(filepath.Join(cmdDir, "main.go")); err == nil {
+		return modulePath + "/cmd"
+	}
+	return ""
+}
+
+// DetectSourceDirs returns existing Go source directories in the target.
+func DetectSourceDirs(targetDir string) []string {
+	candidates := []string{"cmd/", "pkg/", "internal/", "tests/"}
+	var found []string
+	for _, d := range candidates {
+		if _, err := os.Stat(filepath.Join(targetDir, d)); err == nil {
+			found = append(found, d)
+		}
+	}
+	return found
+}
+
+// DetectBinaryName extracts a binary name from the module path by
+// using its last path component.
+func DetectBinaryName(modulePath string) string {
+	parts := strings.Split(modulePath, "/")
+	if len(parts) == 0 {
+		return "app"
+	}
+	return parts[len(parts)-1]
+}
+
+// ScaffoldSeedTemplate creates a version.go.tmpl in the magefiles directory
+// and returns the destination path (relative to repo root) and the template
+// source path (relative to repo root) for use in seed_files configuration.
+// dirMagefiles is passed in by the caller.
+func ScaffoldSeedTemplate(targetDir, modulePath, mainPkg, dirMagefiles string) (destPath, tmplPath string, err error) {
+	relDir := strings.TrimPrefix(mainPkg, modulePath+"/")
+	if relDir == mainPkg {
+		relDir = "."
+	}
+
+	destPath = filepath.Join(relDir, "version.go")
+	tmplPath = filepath.Join(dirMagefiles, "version.go.tmpl")
+
+	tmplContent := `// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package main
+
+// Version is set during the generation process.
+const Version = "{{.Version}}"
+`
+	absPath := filepath.Join(targetDir, tmplPath)
+	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
+		return "", "", err
+	}
+	if err := os.WriteFile(absPath, []byte(tmplContent), 0o644); err != nil {
+		return "", "", err
+	}
+	return destPath, tmplPath, nil
+}
+
+// WriteScaffoldConfig marshals cfg as YAML and writes it to path.
+// The marshalFn parameter allows the caller to provide the YAML
+// marshalling without importing the Config type here.
+func WriteScaffoldConfig(path string, marshalFn func() ([]byte, error)) error {
+	data, err := marshalFn()
+	if err != nil {
+		return fmt.Errorf("marshalling config: %w", err)
+	}
+	header := "# Orchestrator configuration — generated by scaffold.\n# See docs/ARCHITECTURE.yaml for field descriptions.\n\n"
+	return os.WriteFile(path, append([]byte(header), data...), 0o644)
+}
+
+// ScaffoldMageGoMod ensures magefiles/go.mod exists with the orchestrator
+// dependency. If a published version of the orchestrator module is available
+// on the Go module proxy, it is required directly. Otherwise the function
+// falls back to a local replace directive pointing at orchestratorRoot.
+func ScaffoldMageGoMod(mageDir, rootModule, orchestratorRoot string) error {
+	goMod := filepath.Join(mageDir, "go.mod")
+
+	if _, err := os.Stat(goMod); os.IsNotExist(err) {
+		mageModule := rootModule + "/magefiles"
+		Log("scaffold: creating %s (module %s)", goMod, mageModule)
+		initCmd := exec.Command(BinGo, "mod", "init", mageModule)
+		initCmd.Dir = mageDir
+		if err := initCmd.Run(); err != nil {
+			return fmt.Errorf("go mod init: %w", err)
+		}
+	}
+
+	usedPublished := false
+	if version := LatestPublishedVersion(OrchestratorModule); version != "" {
+		Log("scaffold: trying published %s@%s", OrchestratorModule, version)
+
+		dropCmd := exec.Command(BinGo, "mod", "edit",
+			"-dropreplace", OrchestratorModule)
+		dropCmd.Dir = mageDir
+		_ = dropCmd.Run()
+
+		requireCmd := exec.Command(BinGo, "mod", "edit",
+			"-require", OrchestratorModule+"@"+version)
+		requireCmd.Dir = mageDir
+		if err := requireCmd.Run(); err != nil {
+			return fmt.Errorf("go mod edit -require: %w", err)
+		}
+
+		tidyCmd := exec.Command(BinGo, "mod", "tidy")
+		tidyCmd.Dir = mageDir
+		if err := tidyCmd.Run(); err != nil {
+			Log("scaffold: published %s@%s unusable (%v); falling back to local replace", OrchestratorModule, version, err)
+		} else {
+			usedPublished = true
+		}
+	}
+
+	if !usedPublished {
+		Log("scaffold: using local replace for %s", OrchestratorModule)
+		replaceCmd := exec.Command(BinGo, "mod", "edit",
+			"-replace", OrchestratorModule+"="+orchestratorRoot)
+		replaceCmd.Dir = mageDir
+		if err := replaceCmd.Run(); err != nil {
+			return fmt.Errorf("go mod edit -replace: %w", err)
+		}
+
+		tidyCmd := exec.Command(BinGo, "mod", "tidy")
+		tidyCmd.Dir = mageDir
+		tidyCmd.Stdout = os.Stdout
+		tidyCmd.Stderr = os.Stderr
+		if err := tidyCmd.Run(); err != nil {
+			return fmt.Errorf("go mod tidy: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// LatestPublishedVersion queries the Go module proxy for the latest
+// published version of module. Returns empty string if no versions
+// are available or the proxy cannot be reached.
+func LatestPublishedVersion(module string) string {
+	tmpDir, err := os.MkdirTemp("", "version-check-*")
+	if err != nil {
+		return ""
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			Log("scaffold: warning: removing temp dir: %v", err)
+		}
+	}()
+
+	initCmd := exec.Command(BinGo, "mod", "init", "temp")
+	initCmd.Dir = tmpDir
+	if err := initCmd.Run(); err != nil {
+		return ""
+	}
+
+	cmd := exec.Command(BinGo, "list", "-m", "-versions", module)
+	cmd.Dir = tmpDir
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	parts := strings.Fields(strings.TrimSpace(string(out)))
+	if len(parts) < 2 {
+		return ""
+	}
+	return parts[len(parts)-1]
+}
+
+// VerifyMage runs mage -l in the target directory to confirm the
+// orchestrator template is correctly wired.
+func VerifyMage(targetDir string) error {
+	magePath, err := FindMage()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(magePath, "-l")
+	cmd.Dir = targetDir
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// FindMage locates the mage binary. It checks PATH first, then falls
+// back to $(go env GOPATH)/bin/mage for installations via go install.
+func FindMage() (string, error) {
+	if p, err := exec.LookPath(BinMage); err == nil {
+		return p, nil
+	}
+	out, err := exec.Command(BinGo, "env", "GOPATH").Output()
+	if err != nil {
+		return "", fmt.Errorf("mage not found on PATH and cannot determine GOPATH: %w", err)
+	}
+	gopath := strings.TrimSpace(string(out))
+	candidate := filepath.Join(gopath, "bin", BinMage)
+	if _, err := os.Stat(candidate); err != nil {
+		return "", fmt.Errorf("mage not found on PATH or at %s", candidate)
+	}
+	return candidate, nil
+}
+
+// GoModDownload fetches a Go module at the specified version using the
+// Go module proxy and returns the path to the cached source directory.
+// The cache directory is read-only; callers must copy before modifying.
+func GoModDownload(module, version string) (string, error) {
+	tmpDir, err := os.MkdirTemp("", "gomod-dl-*")
+	if err != nil {
+		return "", fmt.Errorf("creating temp dir: %w", err)
+	}
+	defer func() {
+		if err := os.RemoveAll(tmpDir); err != nil {
+			Log("scaffold: warning: removing temp dir: %v", err)
+		}
+	}()
+
+	initCmd := exec.Command(BinGo, "mod", "init", "temp")
+	initCmd.Dir = tmpDir
+	if err := initCmd.Run(); err != nil {
+		return "", fmt.Errorf("go mod init: %w", err)
+	}
+
+	ref := module + "@" + version
+	dlCmd := exec.Command(BinGo, "mod", "download", "-json", ref)
+	dlCmd.Dir = tmpDir
+	out, err := dlCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("go mod download %s: %w", ref, err)
+	}
+
+	var result GoModDownloadResult
+	if err := json.Unmarshal(out, &result); err != nil {
+		return "", fmt.Errorf("parsing go mod download output: %w", err)
+	}
+	if result.Dir == "" {
+		return "", fmt.Errorf("go mod download %s: empty Dir in output", ref)
+	}
+	return result.Dir, nil
+}
+
+// CopyDir recursively copies src to dst, making all files writable.
+// The Go module cache is read-only, so this produces a mutable copy.
+func CopyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		if d.IsDir() {
+			return os.MkdirAll(target, 0o755)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		return os.WriteFile(target, data, 0o644)
+	})
+}
+
+// RemoveIfExists removes path if it exists, logging the action.
+func RemoveIfExists(path string) error {
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return nil
+	}
+	Log("uninstall: removing %s", path)
+	return os.Remove(path)
+}

--- a/pkg/orchestrator/internal/build/scaffold_test.go
+++ b/pkg/orchestrator/internal/build/scaffold_test.go
@@ -1,0 +1,333 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package build
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// --- DetectBinaryName ---
+
+func TestDetectBinaryName_LastSegment(t *testing.T) {
+	cases := []struct {
+		module string
+		want   string
+	}{
+		{"github.com/org/myproject", "myproject"},
+		{"github.com/org/my-tool", "my-tool"},
+		{"example.com/foo/bar/baz", "baz"},
+		{"singleword", "singleword"},
+		{"", ""},
+	}
+	for _, tc := range cases {
+		if got := DetectBinaryName(tc.module); got != tc.want {
+			t.Errorf("DetectBinaryName(%q) = %q, want %q", tc.module, got, tc.want)
+		}
+	}
+}
+
+// --- DetectModulePath ---
+
+func TestDetectModulePath_ReadsGoMod(t *testing.T) {
+	dir := t.TempDir()
+	gomod := "module github.com/org/repo\n\ngo 1.21\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(gomod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := DetectModulePath(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "github.com/org/repo" {
+		t.Errorf("got %q, want %q", got, "github.com/org/repo")
+	}
+}
+
+func TestDetectModulePath_MissingGoMod(t *testing.T) {
+	_, err := DetectModulePath(t.TempDir())
+	if err == nil {
+		t.Error("expected error for missing go.mod, got nil")
+	}
+}
+
+func TestDetectModulePath_NoModuleDirective(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("go 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_, err := DetectModulePath(dir)
+	if err == nil {
+		t.Error("expected error for go.mod without module directive, got nil")
+	}
+}
+
+// --- DetectMainPackage ---
+
+func TestDetectMainPackage_CmdSubdir(t *testing.T) {
+	dir := t.TempDir()
+	appDir := filepath.Join(dir, "cmd", "myapp")
+	if err := os.MkdirAll(appDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(appDir, "main.go"), []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := DetectMainPackage(dir, "github.com/org/repo")
+	if got != "github.com/org/repo/cmd/myapp" {
+		t.Errorf("got %q, want %q", got, "github.com/org/repo/cmd/myapp")
+	}
+}
+
+func TestDetectMainPackage_CmdDirect(t *testing.T) {
+	dir := t.TempDir()
+	cmdDir := filepath.Join(dir, "cmd")
+	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cmdDir, "main.go"), []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := DetectMainPackage(dir, "github.com/org/repo")
+	if got != "github.com/org/repo/cmd" {
+		t.Errorf("got %q, want %q", got, "github.com/org/repo/cmd")
+	}
+}
+
+func TestDetectMainPackage_NoCmdDir(t *testing.T) {
+	got := DetectMainPackage(t.TempDir(), "github.com/org/repo")
+	if got != "" {
+		t.Errorf("got %q, want empty string when no cmd/ exists", got)
+	}
+}
+
+func TestDetectMainPackage_CmdDirNoMainGo(t *testing.T) {
+	dir := t.TempDir()
+	subDir := filepath.Join(dir, "cmd", "app")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got := DetectMainPackage(dir, "github.com/org/repo")
+	if got != "" {
+		t.Errorf("got %q, want empty string when cmd/app/ has no main.go", got)
+	}
+}
+
+// --- DetectSourceDirs ---
+
+func TestDetectSourceDirs_ReturnsExisting(t *testing.T) {
+	dir := t.TempDir()
+	for _, d := range []string{"cmd/", "pkg/"} {
+		if err := os.MkdirAll(filepath.Join(dir, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := DetectSourceDirs(dir)
+	if len(got) != 2 {
+		t.Fatalf("got %v, want [cmd/ pkg/]", got)
+	}
+	if got[0] != "cmd/" || got[1] != "pkg/" {
+		t.Errorf("got %v, want [cmd/ pkg/]", got)
+	}
+}
+
+func TestDetectSourceDirs_NoneExist(t *testing.T) {
+	got := DetectSourceDirs(t.TempDir())
+	if len(got) != 0 {
+		t.Errorf("got %v, want empty slice when no source dirs exist", got)
+	}
+}
+
+// --- ClearMageGoFiles ---
+
+func TestClearMageGoFiles_RemovesGoFiles(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"a.go", "b.go", "go.mod", "go.sum", "README.md"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := ClearMageGoFiles(dir); err != nil {
+		t.Fatalf("ClearMageGoFiles: %v", err)
+	}
+	for _, name := range []string{"a.go", "b.go"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			t.Errorf("%s should have been removed", name)
+		}
+	}
+	for _, name := range []string{"go.mod", "go.sum", "README.md"} {
+		if _, err := os.Stat(filepath.Join(dir, name)); err != nil {
+			t.Errorf("%s should still exist: %v", name, err)
+		}
+	}
+}
+
+func TestClearMageGoFiles_MissingDir_IsNoOp(t *testing.T) {
+	err := ClearMageGoFiles(filepath.Join(t.TempDir(), "nonexistent"))
+	if err != nil {
+		t.Errorf("ClearMageGoFiles on missing dir should be no-op, got: %v", err)
+	}
+}
+
+// --- RemoveIfExists ---
+
+func TestRemoveIfExists_RemovesFile(t *testing.T) {
+	f := filepath.Join(t.TempDir(), "file.txt")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := RemoveIfExists(f); err != nil {
+		t.Fatalf("RemoveIfExists: %v", err)
+	}
+	if _, err := os.Stat(f); err == nil {
+		t.Error("file should have been removed")
+	}
+}
+
+func TestRemoveIfExists_MissingFile_IsNoOp(t *testing.T) {
+	err := RemoveIfExists(filepath.Join(t.TempDir(), "nonexistent.txt"))
+	if err != nil {
+		t.Errorf("RemoveIfExists on missing file should be no-op, got: %v", err)
+	}
+}
+
+// --- ScaffoldSeedTemplate ---
+
+func TestScaffoldSeedTemplate_CreatesFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	destPath, tmplPath, err := ScaffoldSeedTemplate(dir, "github.com/org/repo", "github.com/org/repo/cmd/app", "magefiles")
+	if err != nil {
+		t.Fatalf("ScaffoldSeedTemplate: %v", err)
+	}
+
+	if destPath != "cmd/app/version.go" {
+		t.Errorf("destPath = %q, want cmd/app/version.go", destPath)
+	}
+	if tmplPath != "magefiles/version.go.tmpl" {
+		t.Errorf("tmplPath = %q, want magefiles/version.go.tmpl", tmplPath)
+	}
+
+	absPath := filepath.Join(dir, tmplPath)
+	data, err := os.ReadFile(absPath)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "package main") {
+		t.Error("template missing 'package main'")
+	}
+	if !strings.Contains(content, "{{.Version}}") {
+		t.Error("template missing Version placeholder")
+	}
+	if strings.Contains(content, "func main") {
+		t.Error("template must not contain func main() — version.go is constants-only")
+	}
+}
+
+func TestScaffoldSeedTemplate_RootMainPkg(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	destPath, _, err := ScaffoldSeedTemplate(dir, "github.com/org/tool", "github.com/org/tool", "magefiles")
+	if err != nil {
+		t.Fatalf("ScaffoldSeedTemplate: %v", err)
+	}
+	if destPath != "version.go" {
+		t.Errorf("destPath = %q, want version.go for root main pkg", destPath)
+	}
+}
+
+// --- CopyFile ---
+
+func TestCopyFile_Success(t *testing.T) {
+	t.Parallel()
+	src := filepath.Join(t.TempDir(), "src.txt")
+	os.WriteFile(src, []byte("hello"), 0o644)
+
+	dst := filepath.Join(t.TempDir(), "sub", "dir", "dst.txt")
+	if err := CopyFile(src, dst); err != nil {
+		t.Fatalf("CopyFile: %v", err)
+	}
+
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(got) != "hello" {
+		t.Errorf("content = %q, want hello", got)
+	}
+}
+
+func TestCopyFile_MissingSrc(t *testing.T) {
+	t.Parallel()
+	dst := filepath.Join(t.TempDir(), "dst.txt")
+	if err := CopyFile("/nonexistent/file.txt", dst); err == nil {
+		t.Error("expected error for missing source")
+	}
+}
+
+// --- CopyDir ---
+
+func TestCopyDir_CopiesRecursively(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	os.MkdirAll(filepath.Join(src, "a", "b"), 0o755)
+	os.WriteFile(filepath.Join(src, "root.txt"), []byte("root"), 0o644)
+	os.WriteFile(filepath.Join(src, "a", "mid.txt"), []byte("mid"), 0o644)
+	os.WriteFile(filepath.Join(src, "a", "b", "deep.txt"), []byte("deep"), 0o644)
+
+	dst := filepath.Join(t.TempDir(), "out")
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatalf("CopyDir: %v", err)
+	}
+
+	for _, rel := range []string{"root.txt", "a/mid.txt", "a/b/deep.txt"} {
+		path := filepath.Join(dst, rel)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("expected %s to exist", rel)
+		}
+	}
+	got, _ := os.ReadFile(filepath.Join(dst, "a", "b", "deep.txt"))
+	if string(got) != "deep" {
+		t.Errorf("deep.txt content = %q, want deep", got)
+	}
+}
+
+func TestCopyDir_EmptySrc(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	dst := filepath.Join(t.TempDir(), "out")
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatalf("CopyDir: %v", err)
+	}
+	entries, _ := os.ReadDir(dst)
+	if len(entries) != 0 {
+		t.Errorf("expected empty dst, got %d entries", len(entries))
+	}
+}
+
+func TestCopyDir_PreservesContent(t *testing.T) {
+	t.Parallel()
+	src := t.TempDir()
+	os.WriteFile(filepath.Join(src, "a.txt"), []byte("alpha"), 0o644)
+	os.WriteFile(filepath.Join(src, "b.txt"), []byte("beta"), 0o644)
+
+	dst := filepath.Join(t.TempDir(), "out")
+	if err := CopyDir(src, dst); err != nil {
+		t.Fatalf("CopyDir: %v", err)
+	}
+	for _, tc := range []struct{ name, want string }{
+		{"a.txt", "alpha"},
+		{"b.txt", "beta"},
+	} {
+		got, err := os.ReadFile(filepath.Join(dst, tc.name))
+		if err != nil {
+			t.Errorf("ReadFile(%s): %v", tc.name, err)
+		} else if string(got) != tc.want {
+			t.Errorf("%s = %q, want %q", tc.name, got, tc.want)
+		}
+	}
+}

--- a/pkg/orchestrator/scaffold.go
+++ b/pkg/orchestrator/scaffold.go
@@ -4,18 +4,15 @@
 package orchestrator
 
 import (
-	"bufio"
 	_ "embed"
-	"encoding/json"
 	"fmt"
-	"io/fs"
 	"maps"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"slices"
-	"strings"
 
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/build"
 	"gopkg.in/yaml.v3"
 )
 
@@ -26,7 +23,7 @@ var designConstitution string
 var testingConstitution string
 
 // orchestratorModule is the Go module path for this orchestrator library.
-const orchestratorModule = "github.com/mesh-intelligence/cobbler-scaffold"
+const orchestratorModule = build.OrchestratorModule
 
 // Scaffold sets up a target Go repository to use the orchestrator.
 // It copies the orchestrator.go template into magefiles/, detects
@@ -39,13 +36,13 @@ func (o *Orchestrator) Scaffold(targetDir, orchestratorRoot string) error {
 
 	// 1. Remove existing .go files in magefiles/ (the orchestrator
 	//    template replaces the target's build system) and copy ours.
-	if err := clearMageGoFiles(mageDir); err != nil {
+	if err := build.ClearMageGoFiles(mageDir); err != nil {
 		return fmt.Errorf("clearing magefiles: %w", err)
 	}
 	src := filepath.Join(orchestratorRoot, "orchestrator.go.tmpl")
 	dst := filepath.Join(mageDir, "orchestrator.go")
 	logf("scaffold: copying %s -> %s", src, dst)
-	if err := copyFile(src, dst); err != nil {
+	if err := build.CopyFile(src, dst); err != nil {
 		return fmt.Errorf("copying orchestrator.go: %w", err)
 	}
 
@@ -108,19 +105,19 @@ func (o *Orchestrator) Scaffold(targetDir, orchestratorRoot string) error {
 	}
 
 	// 2. Detect project structure.
-	modulePath, err := detectModulePath(targetDir)
+	modulePath, err := build.DetectModulePath(targetDir)
 	if err != nil {
 		return fmt.Errorf("detecting module path: %w", err)
 	}
 	logf("scaffold: detected module_path=%s", modulePath)
 
-	mainPkg := detectMainPackage(targetDir, modulePath)
+	mainPkg := build.DetectMainPackage(targetDir, modulePath)
 	logf("scaffold: detected main_package=%s", mainPkg)
 
-	srcDirs := detectSourceDirs(targetDir)
+	srcDirs := build.DetectSourceDirs(targetDir)
 	logf("scaffold: detected go_source_dirs=%v", srcDirs)
 
-	binName := detectBinaryName(modulePath)
+	binName := build.DetectBinaryName(modulePath)
 	logf("scaffold: detected binary_name=%s", binName)
 
 	// 3. Generate seed files and configuration.yaml in the target root.
@@ -141,7 +138,7 @@ func (o *Orchestrator) Scaffold(targetDir, orchestratorRoot string) error {
 	// binary. The template is stored in magefiles/ and referenced by
 	// seed_files in configuration.yaml.
 	if mainPkg != "" {
-		seedPath, tmplPath, err := scaffoldSeedTemplate(targetDir, modulePath, mainPkg)
+		seedPath, tmplPath, err := build.ScaffoldSeedTemplate(targetDir, modulePath, mainPkg, dirMagefiles)
 		if err != nil {
 			return fmt.Errorf("creating seed template: %w", err)
 		}
@@ -174,7 +171,7 @@ func (o *Orchestrator) Scaffold(targetDir, orchestratorRoot string) error {
 						absFile := filepath.Join(targetDir, src)
 						if _, err := os.Stat(absFile); os.IsNotExist(err) {
 							logf("scaffold: re-creating missing seed template %s", src)
-							if _, _, err := scaffoldSeedTemplate(targetDir, modulePath, existCfg.Project.MainPackage); err != nil {
+							if _, _, err := build.ScaffoldSeedTemplate(targetDir, modulePath, existCfg.Project.MainPackage, dirMagefiles); err != nil {
 								return fmt.Errorf("re-creating seed template: %w", err)
 							}
 						}
@@ -190,7 +187,7 @@ func (o *Orchestrator) Scaffold(targetDir, orchestratorRoot string) error {
 	if err != nil {
 		return fmt.Errorf("resolving orchestrator path: %w", err)
 	}
-	if err := scaffoldMageGoMod(mageDir, modulePath, absOrch); err != nil {
+	if err := build.ScaffoldMageGoMod(mageDir, modulePath, absOrch); err != nil {
 		return fmt.Errorf("wiring magefiles/go.mod: %w", err)
 	}
 
@@ -198,7 +195,7 @@ func (o *Orchestrator) Scaffold(targetDir, orchestratorRoot string) error {
 	// retry with a local replace — the published module may be missing
 	// methods that the scaffolded orchestrator.go references.
 	logf("scaffold: verifying with mage -l")
-	if err := verifyMage(targetDir); err != nil {
+	if err := build.VerifyMage(targetDir); err != nil {
 		logf("scaffold: verification failed; retrying with local replace -> %s", absOrch)
 		retryReplace := exec.Command(binGo, "mod", "edit",
 			"-replace", orchestratorModule+"="+absOrch)
@@ -211,7 +208,7 @@ func (o *Orchestrator) Scaffold(targetDir, orchestratorRoot string) error {
 		if tidyErr := retryTidy.Run(); tidyErr != nil {
 			return fmt.Errorf("mage verification: %w (tidy fallback: %v)", err, tidyErr)
 		}
-		if err := verifyMage(targetDir); err != nil {
+		if err := build.VerifyMage(targetDir); err != nil {
 			return fmt.Errorf("mage verification (after local replace): %w", err)
 		}
 	}
@@ -230,7 +227,7 @@ func (o *Orchestrator) Uninstall(targetDir string) error {
 
 	// Remove magefiles/orchestrator.go.
 	orchGo := filepath.Join(targetDir, dirMagefiles, "orchestrator.go")
-	if err := removeIfExists(orchGo); err != nil {
+	if err := build.RemoveIfExists(orchGo); err != nil {
 		return fmt.Errorf("removing orchestrator.go: %w", err)
 	}
 
@@ -256,7 +253,7 @@ func (o *Orchestrator) Uninstall(targetDir string) error {
 
 	// Remove configuration.yaml.
 	cfgPath := filepath.Join(targetDir, DefaultConfigFile)
-	if err := removeIfExists(cfgPath); err != nil {
+	if err := build.RemoveIfExists(cfgPath); err != nil {
 		return fmt.Errorf("removing configuration.yaml: %w", err)
 	}
 
@@ -286,161 +283,53 @@ func (o *Orchestrator) Uninstall(targetDir string) error {
 
 // removeIfExists removes path if it exists, logging the action.
 func removeIfExists(path string) error {
-	if _, err := os.Stat(path); os.IsNotExist(err) {
-		return nil
-	}
-	logf("uninstall: removing %s", path)
-	return os.Remove(path)
+	return build.RemoveIfExists(path)
 }
 
 // clearMageGoFiles removes all .go files from mageDir, preserving
 // go.mod, go.sum, and non-Go files. If mageDir does not exist, this
 // is a no-op.
 func clearMageGoFiles(mageDir string) error {
-	entries, err := os.ReadDir(mageDir)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".go") {
-			continue
-		}
-		path := filepath.Join(mageDir, e.Name())
-		logf("scaffold: removing existing %s", path)
-		if err := os.Remove(path); err != nil {
-			return fmt.Errorf("removing %s: %w", path, err)
-		}
-	}
-	return nil
+	return build.ClearMageGoFiles(mageDir)
 }
 
 // copyFile copies src to dst, creating parent directories as needed.
 func copyFile(src, dst string) error {
-	data, err := os.ReadFile(src)
-	if err != nil {
-		return err
-	}
-	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
-		return err
-	}
-	return os.WriteFile(dst, data, 0o644)
+	return build.CopyFile(src, dst)
 }
 
 // detectModulePath reads go.mod in the target directory and extracts
 // the module path from the first "module" directive.
 func detectModulePath(targetDir string) (string, error) {
-	modPath := filepath.Join(targetDir, "go.mod")
-	f, err := os.Open(modPath)
-	if err != nil {
-		return "", fmt.Errorf("opening go.mod: %w", err)
-	}
-	defer f.Close()
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if strings.HasPrefix(line, "module ") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "module")), nil
-		}
-	}
-	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("reading go.mod: %w", err)
-	}
-	return "", fmt.Errorf("no module directive in %s", modPath)
+	return build.DetectModulePath(targetDir)
 }
 
 // detectMainPackage scans cmd/ for directories containing main.go.
-// Returns the module-relative import path of the first main package
-// found, or empty string if none exist.
 func detectMainPackage(targetDir, modulePath string) string {
-	cmdDir := filepath.Join(targetDir, "cmd")
-	entries, err := os.ReadDir(cmdDir)
-	if err != nil {
-		return ""
-	}
-	for _, e := range entries {
-		if !e.IsDir() {
-			continue
-		}
-		mainGo := filepath.Join(cmdDir, e.Name(), "main.go")
-		if _, err := os.Stat(mainGo); err == nil {
-			return modulePath + "/cmd/" + e.Name()
-		}
-	}
-	// Check for main.go directly in cmd/.
-	if _, err := os.Stat(filepath.Join(cmdDir, "main.go")); err == nil {
-		return modulePath + "/cmd"
-	}
-	return ""
+	return build.DetectMainPackage(targetDir, modulePath)
 }
 
 // detectSourceDirs returns existing Go source directories in the target.
 func detectSourceDirs(targetDir string) []string {
-	candidates := []string{"cmd/", "pkg/", "internal/", "tests/"}
-	var found []string
-	for _, d := range candidates {
-		if _, err := os.Stat(filepath.Join(targetDir, d)); err == nil {
-			found = append(found, d)
-		}
-	}
-	return found
+	return build.DetectSourceDirs(targetDir)
 }
 
 // detectBinaryName extracts a binary name from the module path by
 // using its last path component.
 func detectBinaryName(modulePath string) string {
-	parts := strings.Split(modulePath, "/")
-	if len(parts) == 0 {
-		return "app"
-	}
-	return parts[len(parts)-1]
+	return build.DetectBinaryName(modulePath)
 }
 
-// scaffoldSeedTemplate creates a version.go.tmpl in the magefiles directory
-// and returns the destination path (relative to repo root) and the template
-// source path (relative to repo root) for use in seed_files configuration.
+// scaffoldSeedTemplate creates a version.go.tmpl in the magefiles directory.
 func scaffoldSeedTemplate(targetDir, modulePath, mainPkg string) (destPath, tmplPath string, err error) {
-	// Derive the relative directory for the main package.
-	// e.g. modulePath="github.com/org/repo", mainPkg="github.com/org/repo/cmd/app"
-	// → relDir="cmd/app"
-	relDir := strings.TrimPrefix(mainPkg, modulePath+"/")
-	if relDir == mainPkg {
-		// mainPkg equals modulePath — main is at repo root.
-		relDir = "."
-	}
-
-	destPath = filepath.Join(relDir, "version.go")
-	tmplPath = filepath.Join(dirMagefiles, "version.go.tmpl")
-
-	tmplContent := `// Copyright (c) 2026 Petar Djukic. All rights reserved.
-// SPDX-License-Identifier: MIT
-
-package main
-
-// Version is set during the generation process.
-const Version = "{{.Version}}"
-`
-	absPath := filepath.Join(targetDir, tmplPath)
-	if err := os.MkdirAll(filepath.Dir(absPath), 0o755); err != nil {
-		return "", "", err
-	}
-	if err := os.WriteFile(absPath, []byte(tmplContent), 0o644); err != nil {
-		return "", "", err
-	}
-	return destPath, tmplPath, nil
+	return build.ScaffoldSeedTemplate(targetDir, modulePath, mainPkg, dirMagefiles)
 }
 
 // writeScaffoldConfig marshals cfg as YAML and writes it to path.
 func writeScaffoldConfig(path string, cfg Config) error {
-	data, err := yaml.Marshal(&cfg)
-	if err != nil {
-		return fmt.Errorf("marshalling config: %w", err)
-	}
-	header := "# Orchestrator configuration — generated by scaffold.\n# See docs/ARCHITECTURE.yaml for field descriptions.\n\n"
-	return os.WriteFile(path, append([]byte(header), data...), 0o644)
+	return build.WriteScaffoldConfig(path, func() ([]byte, error) {
+		return yaml.Marshal(&cfg)
+	})
 }
 
 // clearGenerationBranch reads configuration.yaml in repoDir, clears the
@@ -470,207 +359,38 @@ func clearGenerationBranch(repoDir string) error {
 }
 
 // scaffoldMageGoMod ensures magefiles/go.mod exists with the orchestrator
-// dependency. If a published version of the orchestrator module is available
-// on the Go module proxy, it is required directly. Otherwise the function
-// falls back to a local replace directive pointing at orchestratorRoot.
+// dependency.
 func scaffoldMageGoMod(mageDir, rootModule, orchestratorRoot string) error {
-	goMod := filepath.Join(mageDir, "go.mod")
-
-	// Create magefiles/go.mod if it does not exist.
-	if _, err := os.Stat(goMod); os.IsNotExist(err) {
-		mageModule := rootModule + "/magefiles"
-		logf("scaffold: creating %s (module %s)", goMod, mageModule)
-		initCmd := exec.Command(binGo, "mod", "init", mageModule)
-		initCmd.Dir = mageDir
-		if err := initCmd.Run(); err != nil {
-			return fmt.Errorf("go mod init: %w", err)
-		}
-	}
-
-	// Prefer a published version over a local replace directive.
-	// A local replace bakes a machine-specific absolute path into the
-	// target repo, which is meaningless to other machines and fails
-	// inside containers.
-	usedPublished := false
-	if version := latestPublishedVersion(orchestratorModule); version != "" {
-		logf("scaffold: trying published %s@%s", orchestratorModule, version)
-
-		// Drop any stale replace directive from a previous scaffold.
-		dropCmd := exec.Command(binGo, "mod", "edit",
-			"-dropreplace", orchestratorModule)
-		dropCmd.Dir = mageDir
-		_ = dropCmd.Run() // ignore error if no replace exists
-
-		requireCmd := exec.Command(binGo, "mod", "edit",
-			"-require", orchestratorModule+"@"+version)
-		requireCmd.Dir = mageDir
-		if err := requireCmd.Run(); err != nil {
-			return fmt.Errorf("go mod edit -require: %w", err)
-		}
-
-		// Verify the published version is usable (module path may have
-		// changed across tags — the proxy will reject mismatches).
-		tidyCmd := exec.Command(binGo, "mod", "tidy")
-		tidyCmd.Dir = mageDir
-		if err := tidyCmd.Run(); err != nil {
-			logf("scaffold: published %s@%s unusable (%v); falling back to local replace", orchestratorModule, version, err)
-		} else {
-			usedPublished = true
-		}
-	}
-
-	if !usedPublished {
-		logf("scaffold: using local replace for %s", orchestratorModule)
-		replaceCmd := exec.Command(binGo, "mod", "edit",
-			"-replace", orchestratorModule+"="+orchestratorRoot)
-		replaceCmd.Dir = mageDir
-		if err := replaceCmd.Run(); err != nil {
-			return fmt.Errorf("go mod edit -replace: %w", err)
-		}
-
-		tidyCmd := exec.Command(binGo, "mod", "tidy")
-		tidyCmd.Dir = mageDir
-		tidyCmd.Stdout = os.Stdout
-		tidyCmd.Stderr = os.Stderr
-		if err := tidyCmd.Run(); err != nil {
-			return fmt.Errorf("go mod tidy: %w", err)
-		}
-	}
-
-	return nil
+	return build.ScaffoldMageGoMod(mageDir, rootModule, orchestratorRoot)
 }
 
 // latestPublishedVersion queries the Go module proxy for the latest
-// published version of module. Returns empty string if no versions
-// are available or the proxy cannot be reached.
+// published version of module.
 func latestPublishedVersion(module string) string {
-	tmpDir, err := os.MkdirTemp("", "version-check-*")
-	if err != nil {
-		return ""
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			logf("scaffold: warning: removing temp dir: %v", err)
-		}
-	}()
-
-	initCmd := exec.Command(binGo, "mod", "init", "temp")
-	initCmd.Dir = tmpDir
-	if err := initCmd.Run(); err != nil {
-		return ""
-	}
-
-	cmd := exec.Command(binGo, "list", "-m", "-versions", module)
-	cmd.Dir = tmpDir
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	// Output format: "module v0.1.0 v0.2.0 v0.3.0"
-	parts := strings.Fields(strings.TrimSpace(string(out)))
-	if len(parts) < 2 {
-		return ""
-	}
-	return parts[len(parts)-1]
+	return build.LatestPublishedVersion(module)
 }
 
-// verifyMage runs mage -l in the target directory to confirm the
-// orchestrator template is correctly wired.
+// verifyMage runs mage -l in the target directory.
 func verifyMage(targetDir string) error {
-	magePath, err := findMage()
-	if err != nil {
-		return err
-	}
-	cmd := exec.Command(magePath, "-l")
-	cmd.Dir = targetDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	return cmd.Run()
+	return build.VerifyMage(targetDir)
 }
 
-// findMage locates the mage binary. It checks PATH first, then falls
-// back to $(go env GOPATH)/bin/mage for installations via go install.
+// findMage locates the mage binary.
 func findMage() (string, error) {
-	if p, err := exec.LookPath(binMage); err == nil {
-		return p, nil
-	}
-	out, err := exec.Command(binGo, "env", "GOPATH").Output()
-	if err != nil {
-		return "", fmt.Errorf("mage not found on PATH and cannot determine GOPATH: %w", err)
-	}
-	gopath := strings.TrimSpace(string(out))
-	candidate := filepath.Join(gopath, "bin", binMage)
-	if _, err := os.Stat(candidate); err != nil {
-		return "", fmt.Errorf("mage not found on PATH or at %s", candidate)
-	}
-	return candidate, nil
+	return build.FindMage()
 }
 
 // goModDownloadResult holds the fields we need from go mod download -json.
-type goModDownloadResult struct {
-	Dir string `json:"Dir"`
-}
+type goModDownloadResult = build.GoModDownloadResult
 
-// goModDownload fetches a Go module at the specified version using the
-// Go module proxy and returns the path to the cached source directory.
-// The cache directory is read-only; callers must copy before modifying.
+// goModDownload fetches a Go module at the specified version.
 func goModDownload(module, version string) (string, error) {
-	// go mod download requires a module context; create a temporary one.
-	tmpDir, err := os.MkdirTemp("", "gomod-dl-*")
-	if err != nil {
-		return "", fmt.Errorf("creating temp dir: %w", err)
-	}
-	defer func() {
-		if err := os.RemoveAll(tmpDir); err != nil {
-			logf("scaffold: warning: removing temp dir: %v", err)
-		}
-	}()
-
-	initCmd := exec.Command(binGo, "mod", "init", "temp")
-	initCmd.Dir = tmpDir
-	if err := initCmd.Run(); err != nil {
-		return "", fmt.Errorf("go mod init: %w", err)
-	}
-
-	ref := module + "@" + version
-	dlCmd := exec.Command(binGo, "mod", "download", "-json", ref)
-	dlCmd.Dir = tmpDir
-	out, err := dlCmd.Output()
-	if err != nil {
-		return "", fmt.Errorf("go mod download %s: %w", ref, err)
-	}
-
-	var result goModDownloadResult
-	if err := json.Unmarshal(out, &result); err != nil {
-		return "", fmt.Errorf("parsing go mod download output: %w", err)
-	}
-	if result.Dir == "" {
-		return "", fmt.Errorf("go mod download %s: empty Dir in output", ref)
-	}
-	return result.Dir, nil
+	return build.GoModDownload(module, version)
 }
 
-// copyDir recursively copies src to dst, making all files writable.
-// The Go module cache is read-only, so this produces a mutable copy.
+// copyDir recursively copies src to dst.
 func copyDir(src, dst string) error {
-	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		rel, err := filepath.Rel(src, path)
-		if err != nil {
-			return err
-		}
-		target := filepath.Join(dst, rel)
-		if d.IsDir() {
-			return os.MkdirAll(target, 0o755)
-		}
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return err
-		}
-		return os.WriteFile(target, data, 0o644)
-	})
+	return build.CopyDir(src, dst)
 }
 
 // PrepareTestRepo downloads a Go module at the given version, copies it
@@ -680,7 +400,7 @@ func copyDir(src, dst string) error {
 func (o *Orchestrator) PrepareTestRepo(module, version, orchestratorRoot string) (string, error) {
 	logf("prepareTestRepo: downloading %s@%s", module, version)
 
-	cacheDir, err := goModDownload(module, version)
+	cacheDir, err := build.GoModDownload(module, version)
 	if err != nil {
 		return "", fmt.Errorf("downloading module: %w", err)
 	}
@@ -693,7 +413,7 @@ func (o *Orchestrator) PrepareTestRepo(module, version, orchestratorRoot string)
 	repoDir := filepath.Join(workDir, "repo")
 
 	logf("prepareTestRepo: copying to %s", repoDir)
-	if err := copyDir(cacheDir, repoDir); err != nil {
+	if err := build.CopyDir(cacheDir, repoDir); err != nil {
 		os.RemoveAll(workDir)
 		return "", fmt.Errorf("copying module source: %w", err)
 	}


### PR DESCRIPTION
## Summary

Extracts standalone helper functions from build.go, docker.go, and scaffold.go into pkg/orchestrator/internal/build/. Parent files become thin Orchestrator receiver wrappers with go:embed directives and Config-dependent logic staying in the parent.

## Changes

- Created pkg/orchestrator/internal/build/ with build.go, docker.go, scaffold.go and their tests
- Parent build.go, docker.go, scaffold.go reduced to thin wrappers
- Binary paths and logging injected via package-level variables (same pattern as internal/context)
- go:embed directives stay in parent; embedded content passed as parameters

## Test plan

- [x] All 8 packages build clean
- [x] All tests pass (go test ./... -count=1)
- [x] No API changes visible to consumer repos

Closes #1177