### PR TITLE
GH-1178: Extract release/ into internal sub-package

### DIFF
--- a/pkg/orchestrator/internal/release/release.go
+++ b/pkg/orchestrator/internal/release/release.go
@@ -1,0 +1,326 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Package release implements release lifecycle operations: updating roadmap
+// use-case statuses, mutating project release lists in configuration files,
+// and version tagging. The parent orchestrator package provides thin
+// receiver-method wrappers around these functions.
+package release
+
+import (
+	"fmt"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ---------------------------------------------------------------------------
+// Injected dependencies
+// ---------------------------------------------------------------------------
+
+// Logger is a function that formats and emits log messages.
+type Logger func(format string, args ...any)
+
+// Package-level variables set by the parent package at init time.
+var (
+	Log Logger = func(string, ...any) {}
+
+	GitCurrentBranchFn func(dir string) (string, error)
+	GitListTagsFn      func(pattern, dir string) []string
+	GitTagFn           func(tag, dir string) error
+	GitStageAllFn      func(dir string) error
+	GitCommitFn        func(msg, dir string) error
+)
+
+// ---------------------------------------------------------------------------
+// Minimal local types for YAML validation (avoid importing parent types)
+// ---------------------------------------------------------------------------
+
+type roadmapDoc struct {
+	Releases []roadmapRelease `yaml:"releases"`
+}
+
+type roadmapRelease struct {
+	Version  string           `yaml:"version"`
+	UseCases []roadmapUseCase `yaml:"use_cases"`
+}
+
+type roadmapUseCase struct {
+	ID     string `yaml:"id"`
+	Status string `yaml:"status"`
+}
+
+type configProjectReleases struct {
+	Project struct {
+		Releases []string `yaml:"releases"`
+	} `yaml:"project"`
+}
+
+// ---------------------------------------------------------------------------
+// ReleaseUpdate / ReleaseClear
+// ---------------------------------------------------------------------------
+
+// ReleaseUpdate marks a release as complete. It sets all use-case statuses
+// to "implemented" in docs/road-map.yaml and removes the release version
+// from project.releases in the config file.
+func ReleaseUpdate(configFile, version string) error {
+	if err := UpdateRoadmapUCStatuses(version, "implemented"); err != nil {
+		return err
+	}
+	if err := RemoveReleaseFromConfig(configFile, version); err != nil {
+		return err
+	}
+	Log("release:update %s: done", version)
+	return nil
+}
+
+// ReleaseClear reverses ReleaseUpdate. It resets all use-case statuses to
+// "spec_complete" and re-appends the release version to project.releases.
+func ReleaseClear(configFile, version string) error {
+	if err := UpdateRoadmapUCStatuses(version, "spec_complete"); err != nil {
+		return err
+	}
+	if err := AddReleaseToConfig(configFile, version); err != nil {
+		return err
+	}
+	Log("release:clear %s: done", version)
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Roadmap use-case status manipulation
+// ---------------------------------------------------------------------------
+
+// UpdateRoadmapUCStatuses loads docs/road-map.yaml via yaml.v3 node API,
+// finds the release matching version, sets all its use_cases[*].status
+// values to newStatus, and writes the file back.
+func UpdateRoadmapUCStatuses(version, newStatus string) error {
+	const path = "docs/road-map.yaml"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("release update: read %s: %w", path, err)
+	}
+
+	// Validate structure via typed unmarshal before mutation.
+	var doc roadmapDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("release update: parse %s: %w", path, err)
+	}
+	found := false
+	for _, rel := range doc.Releases {
+		if rel.Version == version {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("release update: version %q not found in %s", version, path)
+	}
+
+	// Node round-trip to preserve comments and structure.
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return fmt.Errorf("release update: node parse %s: %w", path, err)
+	}
+
+	if err := SetRoadmapUCStatuses(&root, version, newStatus); err != nil {
+		return fmt.Errorf("release update: mutate %s: %w", path, err)
+	}
+
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return fmt.Errorf("release update: marshal %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return fmt.Errorf("release update: write %s: %w", path, err)
+	}
+	Log("release update: set use-case statuses to %q for release %s in %s", newStatus, version, path)
+	return nil
+}
+
+// SetRoadmapUCStatuses mutates the yaml.Node tree of road-map.yaml, finding
+// the release with the given version and setting all its use_cases[*].status
+// scalar values to newStatus.
+func SetRoadmapUCStatuses(root *yaml.Node, version, newStatus string) error {
+	// Unwrap document node.
+	doc := root
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
+		doc = doc.Content[0]
+	}
+	// doc should be a mapping node for the roadmap document.
+	releases := MappingValue(doc, "releases")
+	if releases == nil || releases.Kind != yaml.SequenceNode {
+		return fmt.Errorf("releases key not found or not a sequence")
+	}
+	for _, relNode := range releases.Content {
+		versionNode := MappingValue(relNode, "version")
+		if versionNode == nil || versionNode.Value != version {
+			continue
+		}
+		ucSeq := MappingValue(relNode, "use_cases")
+		if ucSeq == nil || ucSeq.Kind != yaml.SequenceNode {
+			continue
+		}
+		for _, ucNode := range ucSeq.Content {
+			statusNode := MappingValue(ucNode, "status")
+			if statusNode != nil {
+				statusNode.Value = newStatus
+			}
+		}
+		return nil
+	}
+	return fmt.Errorf("version %q not found in releases node tree", version)
+}
+
+// ---------------------------------------------------------------------------
+// Config release list manipulation
+// ---------------------------------------------------------------------------
+
+// RemoveReleaseFromConfig loads configPath, removes version from
+// project.releases, and writes it back via node round-trip.
+func RemoveReleaseFromConfig(configPath, version string) error {
+	return MutateConfigReleases(configPath, version, false)
+}
+
+// AddReleaseToConfig loads configPath, appends version to project.releases
+// if not already present, and writes it back via node round-trip.
+func AddReleaseToConfig(configPath, version string) error {
+	return MutateConfigReleases(configPath, version, true)
+}
+
+// MutateConfigReleases is the shared implementation for RemoveReleaseFromConfig
+// and AddReleaseToConfig. When add is true, version is appended (if absent);
+// when add is false, version is removed.
+func MutateConfigReleases(configPath, version string, add bool) error {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return fmt.Errorf("release config: read %s: %w", configPath, err)
+	}
+
+	// Validate via typed unmarshal.
+	var cfg any
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return fmt.Errorf("release config: parse %s: %w", configPath, err)
+	}
+
+	// Node round-trip.
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return fmt.Errorf("release config: node parse %s: %w", configPath, err)
+	}
+
+	if err := MutateProjectReleasesNode(&root, version, add); err != nil {
+		// project.releases is optional; log and skip rather than hard-fail.
+		Log("release config: project.releases not found in %s, skipping: %v", configPath, err)
+		return nil
+	}
+
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return fmt.Errorf("release config: marshal %s: %w", configPath, err)
+	}
+	if err := os.WriteFile(configPath, out, 0o644); err != nil {
+		return fmt.Errorf("release config: write %s: %w", configPath, err)
+	}
+	action := "removed"
+	if add {
+		action = "added"
+	}
+	Log("release config: %s %q in project.releases in %s", action, version, configPath)
+	return nil
+}
+
+// MutateProjectReleasesNode finds project.releases in the node tree and either
+// removes or appends version. Returns an error if project.releases is absent.
+func MutateProjectReleasesNode(root *yaml.Node, version string, add bool) error {
+	doc := root
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
+		doc = doc.Content[0]
+	}
+	projectNode := MappingValue(doc, "project")
+	if projectNode == nil {
+		return fmt.Errorf("project key not found")
+	}
+	releasesNode := MappingValue(projectNode, "releases")
+	if releasesNode == nil {
+		return fmt.Errorf("project.releases key not found")
+	}
+	if releasesNode.Kind != yaml.SequenceNode {
+		return fmt.Errorf("project.releases is not a sequence")
+	}
+
+	if add {
+		// Append only if not already present.
+		for _, child := range releasesNode.Content {
+			if child.Value == version {
+				return nil // already present
+			}
+		}
+		releasesNode.Content = append(releasesNode.Content, &yaml.Node{
+			Kind:  yaml.ScalarNode,
+			Tag:   "!!str",
+			Value: version,
+		})
+	} else {
+		// Remove all occurrences of version.
+		filtered := releasesNode.Content[:0]
+		for _, child := range releasesNode.Content {
+			if child.Value != version {
+				filtered = append(filtered, child)
+			}
+		}
+		releasesNode.Content = filtered
+	}
+	return nil
+}
+
+// MappingValue returns the value node for the given key in a yaml mapping
+// node, or nil if not found.
+func MappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// ReleaseVersionsFromConfig returns the list of releases in project.releases
+// from the given config file.
+func ReleaseVersionsFromConfig(configPath string) ([]string, error) {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+	var cfg configProjectReleases
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return cfg.Project.Releases, nil
+}
+
+// RoadmapUCStatuses returns a map of UC ID to status for the given release
+// version.
+func RoadmapUCStatuses(roadmapPath, version string) (map[string]string, error) {
+	data, err := os.ReadFile(roadmapPath)
+	if err != nil {
+		return nil, err
+	}
+	var doc roadmapDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, err
+	}
+	for _, rel := range doc.Releases {
+		if rel.Version == version {
+			out := make(map[string]string, len(rel.UseCases))
+			for _, uc := range rel.UseCases {
+				out[uc.ID] = uc.Status
+			}
+			return out, nil
+		}
+	}
+	return nil, fmt.Errorf("version %q not found", version)
+}

--- a/pkg/orchestrator/internal/release/release_test.go
+++ b/pkg/orchestrator/internal/release/release_test.go
@@ -1,0 +1,441 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func writeRoadmapFile(t *testing.T, dir, content string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(dir, "docs"), 0o755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	path := filepath.Join(dir, "docs", "road-map.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write road-map.yaml: %v", err)
+	}
+	return path
+}
+
+func writeConfigFile(t *testing.T, path string, releases []string) {
+	t.Helper()
+	relItems := ""
+	for _, r := range releases {
+		relItems += "\n  - " + r
+	}
+	content := "project:\n  releases:" + relItems + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+}
+
+const sampleRoadmap = `id: rm1
+title: Test Roadmap
+releases:
+  - version: "00.0"
+    name: Release 0
+    status: in_progress
+    use_cases:
+      - id: rel00.0-uc001-format
+        status: spec_complete
+        summary: Format output
+      - id: rel00.0-uc002-build
+        status: spec_complete
+        summary: Build pipeline
+  - version: "01.0"
+    name: Release 1
+    status: pending
+    use_cases:
+      - id: rel01.0-uc001-ext
+        status: spec_complete
+        summary: Extension
+`
+
+// stringsContains reports whether slice contains s.
+func stringsContains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+// cdTemp changes to dir and returns a cleanup func that restores the original
+// working directory. Tests that call os.Chdir must not use t.Parallel().
+func cdTemp(t *testing.T, dir string) func() {
+	t.Helper()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir %s: %v", dir, err)
+	}
+	return func() { os.Chdir(orig) } //nolint:errcheck
+}
+
+// ---------------------------------------------------------------------------
+// UpdateRoadmapUCStatuses
+// ---------------------------------------------------------------------------
+
+func TestUpdateRoadmapUCStatuses_SetImplemented(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRoadmapFile(t, dir, sampleRoadmap)
+	defer cdTemp(t, dir)()
+
+	if err := UpdateRoadmapUCStatuses("00.0", "implemented"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	statuses, err := RoadmapUCStatuses(path, "00.0")
+	if err != nil {
+		t.Fatalf("read statuses: %v", err)
+	}
+	for id, status := range statuses {
+		if status != "implemented" {
+			t.Errorf("UC %s: want implemented, got %q", id, status)
+		}
+	}
+
+	// Release 01.0 must be untouched.
+	other, err := RoadmapUCStatuses(path, "01.0")
+	if err != nil {
+		t.Fatalf("read other release: %v", err)
+	}
+	for id, status := range other {
+		if status != "spec_complete" {
+			t.Errorf("UC %s in 01.0 should be untouched, got %q", id, status)
+		}
+	}
+}
+
+func TestUpdateRoadmapUCStatuses_SetSpecComplete(t *testing.T) {
+	dir := t.TempDir()
+	path := writeRoadmapFile(t, dir, sampleRoadmap)
+	defer cdTemp(t, dir)()
+
+	if err := UpdateRoadmapUCStatuses("00.0", "implemented"); err != nil {
+		t.Fatalf("set implemented: %v", err)
+	}
+	if err := UpdateRoadmapUCStatuses("00.0", "spec_complete"); err != nil {
+		t.Fatalf("set spec_complete: %v", err)
+	}
+
+	statuses, err := RoadmapUCStatuses(path, "00.0")
+	if err != nil {
+		t.Fatalf("read statuses: %v", err)
+	}
+	for id, status := range statuses {
+		if status != "spec_complete" {
+			t.Errorf("UC %s: want spec_complete, got %q", id, status)
+		}
+	}
+}
+
+func TestUpdateRoadmapUCStatuses_VersionNotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeRoadmapFile(t, dir, sampleRoadmap)
+	defer cdTemp(t, dir)()
+
+	if err := UpdateRoadmapUCStatuses("99.9", "implemented"); err == nil {
+		t.Error("expected error for missing version, got nil")
+	}
+}
+
+func TestUpdateRoadmapUCStatuses_MissingFile(t *testing.T) {
+	dir := t.TempDir()
+	defer cdTemp(t, dir)()
+
+	if err := UpdateRoadmapUCStatuses("00.0", "implemented"); err == nil {
+		t.Error("expected error for missing road-map.yaml, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RemoveReleaseFromConfig / AddReleaseToConfig
+// ---------------------------------------------------------------------------
+
+func TestRemoveReleaseFromConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "configuration.yaml")
+	writeConfigFile(t, cfgPath, []string{"00.0", "01.0", "02.0"})
+
+	if err := RemoveReleaseFromConfig(cfgPath, "01.0"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	versions, err := ReleaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if stringsContains(versions, "01.0") {
+		t.Errorf("01.0 should have been removed, versions: %v", versions)
+	}
+	if !stringsContains(versions, "00.0") || !stringsContains(versions, "02.0") {
+		t.Errorf("other versions should remain, got: %v", versions)
+	}
+}
+
+func TestAddReleaseToConfig(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "configuration.yaml")
+	writeConfigFile(t, cfgPath, []string{"00.0", "02.0"})
+
+	if err := AddReleaseToConfig(cfgPath, "01.0"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	versions, err := ReleaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !stringsContains(versions, "01.0") {
+		t.Errorf("01.0 should have been added, versions: %v", versions)
+	}
+}
+
+func TestAddReleaseToConfig_Idempotent(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "configuration.yaml")
+	writeConfigFile(t, cfgPath, []string{"00.0", "01.0"})
+
+	if err := AddReleaseToConfig(cfgPath, "01.0"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	versions, err := ReleaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	count := 0
+	for _, v := range versions {
+		if v == "01.0" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 occurrence of 01.0, got %d in %v", count, versions)
+	}
+}
+
+func TestMutateConfigReleases_MissingFile(t *testing.T) {
+	t.Parallel()
+	err := MutateConfigReleases(filepath.Join(t.TempDir(), "nonexistent.yaml"), "01.0", true)
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestMutateConfigReleases_InvalidYAML(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "bad.yaml")
+	os.WriteFile(path, []byte("{{{not yaml"), 0o644)
+	err := MutateConfigReleases(path, "01.0", true)
+	if err == nil {
+		t.Error("expected error for invalid YAML, got nil")
+	}
+}
+
+func TestMutateConfigReleases_NoProjectReleases(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	os.WriteFile(path, []byte("project:\n  module_path: foo\n"), 0o644)
+	// Should log and skip, not error.
+	err := MutateConfigReleases(path, "01.0", true)
+	if err != nil {
+		t.Errorf("expected nil (skip) when project.releases absent, got: %v", err)
+	}
+}
+
+func TestMutateProjectReleasesNode_NoProjectKey(t *testing.T) {
+	t.Parallel()
+	var root yaml.Node
+	yaml.Unmarshal([]byte("other: value\n"), &root)
+	err := MutateProjectReleasesNode(&root, "01.0", true)
+	if err == nil {
+		t.Error("expected error for missing project key")
+	}
+}
+
+func TestMutateProjectReleasesNode_ReleasesNotSequence(t *testing.T) {
+	t.Parallel()
+	var root yaml.Node
+	yaml.Unmarshal([]byte("project:\n  releases: not-a-list\n"), &root)
+	err := MutateProjectReleasesNode(&root, "01.0", true)
+	if err == nil {
+		t.Error("expected error when project.releases is not a sequence")
+	}
+}
+
+func TestReleaseVersionsFromConfig_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := ReleaseVersionsFromConfig(filepath.Join(t.TempDir(), "missing.yaml"))
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestReleaseVersionsFromConfig_InvalidYAML(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "bad.yaml")
+	os.WriteFile(path, []byte("{{{"), 0o644)
+	_, err := ReleaseVersionsFromConfig(path)
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}
+
+func TestRoadmapUCStatuses_MissingFile(t *testing.T) {
+	t.Parallel()
+	_, err := RoadmapUCStatuses(filepath.Join(t.TempDir(), "missing.yaml"), "01.0")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestRoadmapUCStatuses_VersionNotFound(t *testing.T) {
+	t.Parallel()
+	path := filepath.Join(t.TempDir(), "roadmap.yaml")
+	os.WriteFile(path, []byte(sampleRoadmap), 0o644)
+	_, err := RoadmapUCStatuses(path, "99.9")
+	if err == nil {
+		t.Error("expected error for unknown version")
+	}
+}
+
+func TestRemoveReleaseFromConfig_NotPresent(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "configuration.yaml")
+	writeConfigFile(t, cfgPath, []string{"00.0", "01.0"})
+
+	if err := RemoveReleaseFromConfig(cfgPath, "99.9"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	versions, err := ReleaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if len(versions) != 2 {
+		t.Errorf("expected 2 versions unchanged, got %v", versions)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ReleaseUpdate / ReleaseClear round-trip
+// ---------------------------------------------------------------------------
+
+func TestReleaseUpdate_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	rmPath := writeRoadmapFile(t, dir, sampleRoadmap)
+	cfgPath := filepath.Join(dir, "configuration.yaml")
+	writeConfigFile(t, cfgPath, []string{"00.0", "01.0"})
+	defer cdTemp(t, dir)()
+
+	if err := ReleaseUpdate(cfgPath, "00.0"); err != nil {
+		t.Fatalf("ReleaseUpdate: %v", err)
+	}
+
+	statuses, err := RoadmapUCStatuses(rmPath, "00.0")
+	if err != nil {
+		t.Fatalf("read statuses: %v", err)
+	}
+	for id, s := range statuses {
+		if s != "implemented" {
+			t.Errorf("UC %s: want implemented, got %q", id, s)
+		}
+	}
+
+	versions, err := ReleaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if stringsContains(versions, "00.0") {
+		t.Errorf("00.0 should have been removed from releases, got %v", versions)
+	}
+
+	// Clear restores spec_complete and re-adds the version.
+	if err := ReleaseClear(cfgPath, "00.0"); err != nil {
+		t.Fatalf("ReleaseClear: %v", err)
+	}
+
+	statuses, err = RoadmapUCStatuses(rmPath, "00.0")
+	if err != nil {
+		t.Fatalf("read statuses after clear: %v", err)
+	}
+	for id, s := range statuses {
+		if s != "spec_complete" {
+			t.Errorf("UC %s after clear: want spec_complete, got %q", id, s)
+		}
+	}
+
+	versions, err = ReleaseVersionsFromConfig(cfgPath)
+	if err != nil {
+		t.Fatalf("read config after clear: %v", err)
+	}
+	if !stringsContains(versions, "00.0") {
+		t.Errorf("00.0 should have been re-added to releases, got %v", versions)
+	}
+}
+
+func TestReleaseUpdate_VersionNotFound(t *testing.T) {
+	dir := t.TempDir()
+	writeRoadmapFile(t, dir, sampleRoadmap)
+	cfgPath := filepath.Join(dir, "configuration.yaml")
+	writeConfigFile(t, cfgPath, []string{"00.0"})
+	defer cdTemp(t, dir)()
+
+	if err := ReleaseUpdate(cfgPath, "99.9"); err == nil {
+		t.Error("expected error for missing version, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MappingValue
+// ---------------------------------------------------------------------------
+
+func TestMappingValue(t *testing.T) {
+	t.Parallel()
+
+	raw := `key: value
+nested:
+  inner: 42
+`
+	var root yaml.Node
+	if err := yaml.Unmarshal([]byte(raw), &root); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	doc := root.Content[0] // unwrap document node
+
+	v := MappingValue(doc, "key")
+	if v == nil || v.Value != "value" {
+		t.Errorf("key: got %v, want scalar 'value'", v)
+	}
+
+	n := MappingValue(doc, "nested")
+	if n == nil {
+		t.Fatal("nested: got nil")
+	}
+	inner := MappingValue(n, "inner")
+	if inner == nil || inner.Value != "42" {
+		t.Errorf("inner: got %v, want scalar '42'", inner)
+	}
+
+	if MappingValue(doc, "missing") != nil {
+		t.Error("missing key: expected nil")
+	}
+	if MappingValue(nil, "key") != nil {
+		t.Error("nil node: expected nil")
+	}
+}

--- a/pkg/orchestrator/internal/release/release_testmain_test.go
+++ b/pkg/orchestrator/internal/release/release_testmain_test.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package release
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestMain(m *testing.M) {
+	// Wire up git helper functions for tests. These mirror the real
+	// implementations in the parent orchestrator package (commands.go).
+	GitCurrentBranchFn = func(dir string) (string, error) {
+		cmd := exec.Command("git", "rev-parse", "--abbrev-ref", "HEAD")
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		out, err := cmd.Output()
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(out)), nil
+	}
+	GitListTagsFn = func(pattern, dir string) []string {
+		cmd := exec.Command("git", "tag", "--list", pattern)
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		out, _ := cmd.Output()
+		var tags []string
+		for _, line := range strings.Split(string(out), "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				tags = append(tags, line)
+			}
+		}
+		return tags
+	}
+	GitTagFn = func(tag, dir string) error {
+		cmd := exec.Command("git", "tag", tag)
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		return cmd.Run()
+	}
+	GitStageAllFn = func(dir string) error {
+		cmd := exec.Command("git", "add", "-A")
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		return cmd.Run()
+	}
+	GitCommitFn = func(msg, dir string) error {
+		cmd := exec.Command("git", "commit", "--no-verify", "-m", msg)
+		if dir != "" {
+			cmd.Dir = dir
+		}
+		return cmd.Run()
+	}
+
+	os.Exit(m.Run())
+}

--- a/pkg/orchestrator/internal/release/tag.go
+++ b/pkg/orchestrator/internal/release/tag.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package release
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+// TagParams holds the configuration needed by the Tag function.
+type TagParams struct {
+	BaseBranch   string
+	DocTagPrefix string
+	VersionFile  string
+	BuildImageFn func() error
+}
+
+// Tag creates a documentation-only release tag (v0.YYYYMMDD.N) for the current
+// state of the repository, builds the container image with that tag, and tags
+// the image as :latest. The revision number increments for each tag created on
+// the same date. Optionally updates the version file if configured.
+func Tag(p TagParams) error {
+	// Ensure we're on the configured base branch for doc tags.
+	current, err := GitCurrentBranchFn(".")
+	if err != nil {
+		return fmt.Errorf("getting current branch: %w", err)
+	}
+	if current != p.BaseBranch {
+		return fmt.Errorf("tag must be run from %s branch (currently on %s)", p.BaseBranch, current)
+	}
+
+	// Get today's date in YYYYMMDD format.
+	today := time.Now().Format("20060102")
+
+	// Find the next revision for today.
+	revision := NextDocRevision(p.DocTagPrefix, today)
+
+	// Create the tag name.
+	tag := fmt.Sprintf("%s%s.%d", p.DocTagPrefix, today, revision)
+
+	Log("tag: creating documentation release %s", tag)
+
+	// Create the git tag.
+	if err := GitTagFn(tag, "."); err != nil {
+		return fmt.Errorf("creating tag %s: %w", tag, err)
+	}
+
+	// Update the version constant in the version file if configured.
+	if p.VersionFile != "" {
+		Log("tag: writing version %s to %s", tag, p.VersionFile)
+		if err := WriteVersionConst(p.VersionFile, tag); err != nil {
+			return fmt.Errorf("tag %s created but version file update failed: %w", tag, err)
+		}
+		_ = GitStageAllFn(".") // best-effort; commit below handles empty index
+		if err := GitCommitFn(fmt.Sprintf("Set version to %s", tag), "."); err != nil {
+			Log("tag: version commit warning: %v", err)
+		}
+	}
+
+	// Build the container image with the new tag.
+	Log("tag: building container image")
+	if err := p.BuildImageFn(); err != nil {
+		return fmt.Errorf("building image: %w", err)
+	}
+
+	Log("tag: done — created %s and built container image", tag)
+	return nil
+}
+
+// NextDocRevision returns the next revision number for <prefix>DATE.* tags.
+// Returns 0 if no tags exist for the given date, otherwise returns the
+// highest existing revision + 1.
+func NextDocRevision(prefix, date string) int {
+	pattern := fmt.Sprintf("%s%s.*", prefix, date)
+	tags := GitListTagsFn(pattern, ".")
+	if len(tags) == 0 {
+		return 0
+	}
+
+	// Extract revision numbers from tags like v0.20260219.0, v0.20260219.1, etc.
+	// Find the highest revision.
+	revPattern := regexp.MustCompile(`^` + regexp.QuoteMeta(prefix) + regexp.QuoteMeta(date) + `\.(\d+)$`)
+	maxRev := -1
+	for _, t := range tags {
+		matches := revPattern.FindStringSubmatch(t)
+		if len(matches) == 2 {
+			rev, err := strconv.Atoi(matches[1])
+			if err == nil && rev > maxRev {
+				maxRev = rev
+			}
+		}
+	}
+
+	if maxRev == -1 {
+		return 0
+	}
+	return maxRev + 1
+}

--- a/pkg/orchestrator/internal/release/tag_test.go
+++ b/pkg/orchestrator/internal/release/tag_test.go
@@ -1,0 +1,185 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package release
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// setupTagRepo creates a temp git repo with an initial commit and the given
+// tags, then chdirs into it. Returns the original directory; the caller is
+// responsible for restoring via t.Cleanup.
+func setupTagRepo(t *testing.T, tags []string) string {
+	t.Helper()
+	dir, err := os.MkdirTemp("", "tag-test-*")
+	if err != nil {
+		t.Fatalf("MkdirTemp: %v", err)
+	}
+	t.Cleanup(func() { os.RemoveAll(dir) })
+
+	runIn := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	runIn("git", "init")
+	runIn("git", "config", "user.email", "test@test.local")
+	runIn("git", "config", "user.name", "Test")
+	runIn("git", "config", "commit.gpgsign", "false")
+	runIn("git", "commit", "--allow-empty", "-m", "initial")
+	for _, tag := range tags {
+		runIn("git", "tag", tag)
+	}
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(origDir) })
+	return origDir
+}
+
+func TestNextDocRevision_DefaultPrefix(t *testing.T) {
+	// With no matching tags in the repo for a far-future date, revision is 0.
+	rev := NextDocRevision("v0.", "29991231")
+	if rev != 0 {
+		t.Errorf("NextDocRevision(\"v0.\", \"29991231\") = %d, want 0", rev)
+	}
+}
+
+func TestNextDocRevision_CustomPrefix(t *testing.T) {
+	rev := NextDocRevision("myproj.", "29991231")
+	if rev != 0 {
+		t.Errorf("NextDocRevision(\"myproj.\", \"29991231\") = %d, want 0", rev)
+	}
+}
+
+// --- NextDocRevision edge cases ---
+
+func TestNextDocRevision_SameDate_Increments(t *testing.T) {
+	setupTagRepo(t, []string{"v0.29991231.0"})
+	rev := NextDocRevision("v0.", "29991231")
+	if rev != 1 {
+		t.Errorf("NextDocRevision with existing .0 tag: got %d, want 1", rev)
+	}
+}
+
+func TestNextDocRevision_SameDate_MultipleRevisions(t *testing.T) {
+	setupTagRepo(t, []string{"v0.29991231.0", "v0.29991231.3", "v0.29991231.1"})
+	rev := NextDocRevision("v0.", "29991231")
+	if rev != 4 {
+		t.Errorf("NextDocRevision with .0/.1/.3 tags: got %d, want 4", rev)
+	}
+}
+
+func TestNextDocRevision_DifferentDate_ReturnsZero(t *testing.T) {
+	setupTagRepo(t, []string{"v0.29991230.0", "v0.29991230.5"})
+	rev := NextDocRevision("v0.", "29991231")
+	if rev != 0 {
+		t.Errorf("NextDocRevision with tags for different date: got %d, want 0", rev)
+	}
+}
+
+func TestNextDocRevision_MalformedRevision_ReturnsZero(t *testing.T) {
+	setupTagRepo(t, []string{"v0.29991231.xyz"})
+	rev := NextDocRevision("v0.", "29991231")
+	if rev != 0 {
+		t.Errorf("NextDocRevision with malformed tag revision: got %d, want 0", rev)
+	}
+}
+
+func TestNextDocRevision_CustomPrefix_Increments(t *testing.T) {
+	setupTagRepo(t, []string{"docs.29991231.0", "docs.29991231.2"})
+	rev := NextDocRevision("docs.", "29991231")
+	if rev != 3 {
+		t.Errorf("NextDocRevision with custom prefix: got %d, want 3", rev)
+	}
+}
+
+func TestTag_WrongBranch(t *testing.T) {
+	// Override GitCurrentBranchFn to return a known branch.
+	origFn := GitCurrentBranchFn
+	GitCurrentBranchFn = func(dir string) (string, error) {
+		return "feature-branch", nil
+	}
+	defer func() { GitCurrentBranchFn = origFn }()
+
+	err := Tag(TagParams{
+		BaseBranch:   "release",
+		DocTagPrefix: "v0.",
+		BuildImageFn: func() error { return nil },
+	})
+	if err == nil {
+		t.Fatal("Tag() expected error for wrong branch, got nil")
+	}
+	if !strings.Contains(err.Error(), "release") {
+		t.Errorf("Tag() error = %q, want it to mention the expected branch name", err.Error())
+	}
+}
+
+func TestTag_CreatesGitTag(t *testing.T) {
+	setupTagRepo(t, nil)
+
+	current, err := GitCurrentBranchFn(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	buildCalled := false
+	err = Tag(TagParams{
+		BaseBranch:   current,
+		DocTagPrefix: "v0.",
+		BuildImageFn: func() error {
+			buildCalled = true
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Tag() unexpected error: %v", err)
+	}
+	if !buildCalled {
+		t.Error("expected BuildImageFn to be called")
+	}
+
+	// Verify the git tag was created.
+	tags := GitListTagsFn("v0.*", ".")
+	if len(tags) == 0 {
+		t.Error("expected at least one v0.* tag after Tag()")
+	}
+}
+
+func TestTag_VersionFileWriteError(t *testing.T) {
+	setupTagRepo(t, nil)
+
+	current, err := GitCurrentBranchFn(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = Tag(TagParams{
+		BaseBranch:   current,
+		DocTagPrefix: "v0.",
+		VersionFile:  "/dev/null/impossible/version.go", // will fail
+		BuildImageFn: func() error { return nil },
+	})
+
+	if err == nil {
+		t.Fatal("expected error for invalid version file path")
+	}
+	if !strings.Contains(err.Error(), "version file") {
+		t.Errorf("error = %q, want it to mention version file", err.Error())
+	}
+	if !strings.Contains(err.Error(), "tag") {
+		t.Errorf("error = %q, want it to mention the tag was created", err.Error())
+	}
+}

--- a/pkg/orchestrator/internal/release/version.go
+++ b/pkg/orchestrator/internal/release/version.go
@@ -1,0 +1,50 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package release
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+)
+
+// VersionConstRe matches a Go const declaration like:
+//
+//	const Version = "v1.20260212.0"
+//
+// It captures the quoted value.
+var VersionConstRe = regexp.MustCompile(`(?m)^const\s+Version\s*=\s*"([^"]*)"`)
+
+// ReadVersionConst reads the Version constant from a Go source file.
+// Returns "" if the file does not exist or has no Version constant.
+func ReadVersionConst(filePath string) string {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return ""
+	}
+	m := VersionConstRe.FindSubmatch(data)
+	if m == nil {
+		return ""
+	}
+	return string(m[1])
+}
+
+// WriteVersionConst updates the Version constant in a Go source file.
+// The file must already exist and contain a `const Version = "..."` line.
+func WriteVersionConst(filePath, version string) error {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return fmt.Errorf("reading version file: %w", err)
+	}
+
+	if !VersionConstRe.Match(data) {
+		return fmt.Errorf("no Version constant found in %s", filePath)
+	}
+
+	updated := VersionConstRe.ReplaceAll(data, []byte(fmt.Sprintf(`const Version = "%s"`, version)))
+	if err := os.WriteFile(filePath, updated, 0o644); err != nil {
+		return fmt.Errorf("writing version file: %w", err)
+	}
+	return nil
+}

--- a/pkg/orchestrator/internal/release/version_test.go
+++ b/pkg/orchestrator/internal/release/version_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package release
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadVersionConst_ValidFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "version.go")
+	os.WriteFile(path, []byte(`package main
+
+const Version = "v0.20260225.1"
+`), 0o644)
+
+	got := ReadVersionConst(path)
+	if got != "v0.20260225.1" {
+		t.Errorf("ReadVersionConst() = %q, want %q", got, "v0.20260225.1")
+	}
+}
+
+func TestReadVersionConst_MissingFile(t *testing.T) {
+	t.Parallel()
+	got := ReadVersionConst("/nonexistent/version.go")
+	if got != "" {
+		t.Errorf("ReadVersionConst() = %q, want empty string for missing file", got)
+	}
+}
+
+func TestReadVersionConst_NoVersionConst(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "version.go")
+	os.WriteFile(path, []byte(`package main
+
+const AppName = "myapp"
+`), 0o644)
+
+	got := ReadVersionConst(path)
+	if got != "" {
+		t.Errorf("ReadVersionConst() = %q, want empty string when no Version const", got)
+	}
+}
+
+func TestWriteVersionConst_ValidReplacement(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "version.go")
+	os.WriteFile(path, []byte(`package main
+
+const Version = "v0.20260225.0"
+`), 0o644)
+
+	err := WriteVersionConst(path, "v0.20260226.1")
+	if err != nil {
+		t.Fatalf("WriteVersionConst: %v", err)
+	}
+
+	got := ReadVersionConst(path)
+	if got != "v0.20260226.1" {
+		t.Errorf("after write, ReadVersionConst() = %q, want %q", got, "v0.20260226.1")
+	}
+}
+
+func TestWriteVersionConst_MissingFile(t *testing.T) {
+	t.Parallel()
+	err := WriteVersionConst("/nonexistent/version.go", "v1.0.0")
+	if err == nil {
+		t.Error("expected error for missing file, got nil")
+	}
+}
+
+func TestWriteVersionConst_NoVersionConst(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "version.go")
+	os.WriteFile(path, []byte(`package main
+
+const AppName = "myapp"
+`), 0o644)
+
+	err := WriteVersionConst(path, "v1.0.0")
+	if err == nil {
+		t.Error("expected error when no Version const, got nil")
+	}
+}

--- a/pkg/orchestrator/release.go
+++ b/pkg/orchestrator/release.go
@@ -4,11 +4,24 @@
 package orchestrator
 
 import (
-	"fmt"
-	"os"
+	rel "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/release"
 
 	"gopkg.in/yaml.v3"
 )
+
+// ---------------------------------------------------------------------------
+// Dependency injection: wire the parent package's logf and git helper
+// functions into the internal/release package at init time.
+// ---------------------------------------------------------------------------
+
+func init() {
+	rel.Log = logf
+	rel.GitCurrentBranchFn = gitCurrentBranch
+	rel.GitListTagsFn = gitListTags
+	rel.GitTagFn = gitTag
+	rel.GitStageAllFn = gitStageAll
+	rel.GitCommitFn = gitCommit
+}
 
 // ReleaseUpdate marks a release as complete in the project files. It sets all
 // use-case statuses to "implemented" for the named release in
@@ -19,14 +32,7 @@ import (
 // Returns an error if the release version is not found in road-map.yaml, or
 // if either file fails schema validation.
 func (o *Orchestrator) ReleaseUpdate(version string) error {
-	if err := updateRoadmapUCStatuses(version, "implemented"); err != nil {
-		return err
-	}
-	if err := removeReleaseFromConfig(DefaultConfigFile, version); err != nil {
-		return err
-	}
-	logf("release:update %s: done", version)
-	return nil
+	return rel.ReleaseUpdate(DefaultConfigFile, version)
 }
 
 // ReleaseClear reverses ReleaseUpdate. It resets all use-case statuses to
@@ -36,243 +42,50 @@ func (o *Orchestrator) ReleaseUpdate(version string) error {
 // Returns an error if the release version is not found in road-map.yaml, or
 // if either file fails schema validation.
 func (o *Orchestrator) ReleaseClear(version string) error {
-	if err := updateRoadmapUCStatuses(version, "spec_complete"); err != nil {
-		return err
-	}
-	if err := addReleaseToConfig(DefaultConfigFile, version); err != nil {
-		return err
-	}
-	logf("release:clear %s: done", version)
-	return nil
+	return rel.ReleaseClear(DefaultConfigFile, version)
 }
 
-// updateRoadmapUCStatuses loads docs/road-map.yaml via yaml.v3 node API,
-// finds the release matching version, sets all its use_cases[*].status
-// values to newStatus, and writes the file back.
+// updateRoadmapUCStatuses delegates to the internal/release package.
 func updateRoadmapUCStatuses(version, newStatus string) error {
-	const path = "docs/road-map.yaml"
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("release update: read %s: %w", path, err)
-	}
-
-	// Validate structure via typed unmarshal before mutation.
-	var doc RoadmapDoc
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return fmt.Errorf("release update: parse %s: %w", path, err)
-	}
-	found := false
-	for _, rel := range doc.Releases {
-		if rel.Version == version {
-			found = true
-			break
-		}
-	}
-	if !found {
-		return fmt.Errorf("release update: version %q not found in %s", version, path)
-	}
-
-	// Node round-trip to preserve comments and structure.
-	var root yaml.Node
-	if err := yaml.Unmarshal(data, &root); err != nil {
-		return fmt.Errorf("release update: node parse %s: %w", path, err)
-	}
-
-	if err := setRoadmapUCStatuses(&root, version, newStatus); err != nil {
-		return fmt.Errorf("release update: mutate %s: %w", path, err)
-	}
-
-	out, err := yaml.Marshal(&root)
-	if err != nil {
-		return fmt.Errorf("release update: marshal %s: %w", path, err)
-	}
-	if err := os.WriteFile(path, out, 0o644); err != nil {
-		return fmt.Errorf("release update: write %s: %w", path, err)
-	}
-	logf("release update: set use-case statuses to %q for release %s in %s", newStatus, version, path)
-	return nil
+	return rel.UpdateRoadmapUCStatuses(version, newStatus)
 }
 
-// setRoadmapUCStatuses mutates the yaml.Node tree of road-map.yaml, finding
-// the release with the given version and setting all its use_cases[*].status
-// scalar values to newStatus.
+// setRoadmapUCStatuses delegates to the internal/release package.
 func setRoadmapUCStatuses(root *yaml.Node, version, newStatus string) error {
-	// Unwrap document node.
-	doc := root
-	if doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
-		doc = doc.Content[0]
-	}
-	// doc should be a mapping node for the roadmap document.
-	releases := mappingValue(doc, "releases")
-	if releases == nil || releases.Kind != yaml.SequenceNode {
-		return fmt.Errorf("releases key not found or not a sequence")
-	}
-	for _, relNode := range releases.Content {
-		versionNode := mappingValue(relNode, "version")
-		if versionNode == nil || versionNode.Value != version {
-			continue
-		}
-		ucSeq := mappingValue(relNode, "use_cases")
-		if ucSeq == nil || ucSeq.Kind != yaml.SequenceNode {
-			continue
-		}
-		for _, ucNode := range ucSeq.Content {
-			statusNode := mappingValue(ucNode, "status")
-			if statusNode != nil {
-				statusNode.Value = newStatus
-			}
-		}
-		return nil
-	}
-	return fmt.Errorf("version %q not found in releases node tree", version)
+	return rel.SetRoadmapUCStatuses(root, version, newStatus)
 }
 
-// removeReleaseFromConfig loads configPath, removes version from
-// project.releases, and writes it back via node round-trip.
+// removeReleaseFromConfig delegates to the internal/release package.
 func removeReleaseFromConfig(configPath, version string) error {
-	return mutateConfigReleases(configPath, version, false)
+	return rel.RemoveReleaseFromConfig(configPath, version)
 }
 
-// addReleaseToConfig loads configPath, appends version to project.releases
-// if not already present, and writes it back via node round-trip.
+// addReleaseToConfig delegates to the internal/release package.
 func addReleaseToConfig(configPath, version string) error {
-	return mutateConfigReleases(configPath, version, true)
+	return rel.AddReleaseToConfig(configPath, version)
 }
 
-// mutateConfigReleases is the shared implementation for removeReleaseFromConfig
-// and addReleaseToConfig. When add is true, version is appended (if absent);
-// when add is false, version is removed.
+// mutateConfigReleases delegates to the internal/release package.
 func mutateConfigReleases(configPath, version string, add bool) error {
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return fmt.Errorf("release config: read %s: %w", configPath, err)
-	}
-
-	// Validate via typed unmarshal.
-	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return fmt.Errorf("release config: parse %s: %w", configPath, err)
-	}
-
-	// Node round-trip.
-	var root yaml.Node
-	if err := yaml.Unmarshal(data, &root); err != nil {
-		return fmt.Errorf("release config: node parse %s: %w", configPath, err)
-	}
-
-	if err := mutateProjectReleasesNode(&root, version, add); err != nil {
-		// project.releases is optional; log and skip rather than hard-fail.
-		logf("release config: project.releases not found in %s, skipping: %v", configPath, err)
-		return nil
-	}
-
-	out, err := yaml.Marshal(&root)
-	if err != nil {
-		return fmt.Errorf("release config: marshal %s: %w", configPath, err)
-	}
-	if err := os.WriteFile(configPath, out, 0o644); err != nil {
-		return fmt.Errorf("release config: write %s: %w", configPath, err)
-	}
-	action := "removed"
-	if add {
-		action = "added"
-	}
-	logf("release config: %s %q in project.releases in %s", action, version, configPath)
-	return nil
+	return rel.MutateConfigReleases(configPath, version, add)
 }
 
-// mutateProjectReleasesNode finds project.releases in the node tree and either
-// removes or appends version. Returns an error if project.releases is absent.
+// mutateProjectReleasesNode delegates to the internal/release package.
 func mutateProjectReleasesNode(root *yaml.Node, version string, add bool) error {
-	doc := root
-	if doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
-		doc = doc.Content[0]
-	}
-	projectNode := mappingValue(doc, "project")
-	if projectNode == nil {
-		return fmt.Errorf("project key not found")
-	}
-	releasesNode := mappingValue(projectNode, "releases")
-	if releasesNode == nil {
-		return fmt.Errorf("project.releases key not found")
-	}
-	if releasesNode.Kind != yaml.SequenceNode {
-		return fmt.Errorf("project.releases is not a sequence")
-	}
-
-	if add {
-		// Append only if not already present.
-		for _, child := range releasesNode.Content {
-			if child.Value == version {
-				return nil // already present
-			}
-		}
-		releasesNode.Content = append(releasesNode.Content, &yaml.Node{
-			Kind:  yaml.ScalarNode,
-			Tag:   "!!str",
-			Value: version,
-		})
-	} else {
-		// Remove all occurrences of version.
-		filtered := releasesNode.Content[:0]
-		for _, child := range releasesNode.Content {
-			if child.Value != version {
-				filtered = append(filtered, child)
-			}
-		}
-		releasesNode.Content = filtered
-	}
-	return nil
+	return rel.MutateProjectReleasesNode(root, version, add)
 }
 
-// mappingValue returns the value node for the given key in a yaml mapping
-// node, or nil if not found.
+// mappingValue delegates to the internal/release package.
 func mappingValue(node *yaml.Node, key string) *yaml.Node {
-	if node == nil || node.Kind != yaml.MappingNode {
-		return nil
-	}
-	for i := 0; i+1 < len(node.Content); i += 2 {
-		if node.Content[i].Value == key {
-			return node.Content[i+1]
-		}
-	}
-	return nil
+	return rel.MappingValue(node, key)
 }
 
-// releaseVersionsFromConfig returns the list of releases in project.releases
-// from the given config file. Used in tests.
+// releaseVersionsFromConfig delegates to the internal/release package.
 func releaseVersionsFromConfig(configPath string) ([]string, error) {
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		return nil, err
-	}
-	var cfg Config
-	if err := yaml.Unmarshal(data, &cfg); err != nil {
-		return nil, err
-	}
-	return cfg.Project.Releases, nil
+	return rel.ReleaseVersionsFromConfig(configPath)
 }
 
-// roadmapUCStatuses returns a map of UC ID → status for the given release
-// version. Used in tests.
+// roadmapUCStatuses delegates to the internal/release package.
 func roadmapUCStatuses(roadmapPath, version string) (map[string]string, error) {
-	data, err := os.ReadFile(roadmapPath)
-	if err != nil {
-		return nil, err
-	}
-	var doc RoadmapDoc
-	if err := yaml.Unmarshal(data, &doc); err != nil {
-		return nil, err
-	}
-	for _, rel := range doc.Releases {
-		if rel.Version == version {
-			out := make(map[string]string, len(rel.UseCases))
-			for _, uc := range rel.UseCases {
-				out[uc.ID] = uc.Status
-			}
-			return out, nil
-		}
-	}
-	return nil, fmt.Errorf("version %q not found", version)
+	return rel.RoadmapUCStatuses(roadmapPath, version)
 }
-

--- a/pkg/orchestrator/tag.go
+++ b/pkg/orchestrator/tag.go
@@ -4,10 +4,7 @@
 package orchestrator
 
 import (
-	"fmt"
-	"regexp"
-	"strconv"
-	"time"
+	rel "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/release"
 )
 
 // Tag creates a documentation-only release tag (v0.YYYYMMDD.N) for the current
@@ -21,79 +18,15 @@ import (
 //
 // Exposed as a mage target (e.g., mage tag).
 func (o *Orchestrator) Tag() error {
-	// Ensure we're on the configured base branch for doc tags.
-	current, err := gitCurrentBranch(".")
-	if err != nil {
-		return fmt.Errorf("getting current branch: %w", err)
-	}
-	if current != o.cfg.Cobbler.BaseBranch {
-		return fmt.Errorf("tag must be run from %s branch (currently on %s)", o.cfg.Cobbler.BaseBranch, current)
-	}
-
-	// Get today's date in YYYYMMDD format.
-	today := time.Now().Format("20060102")
-
-	// Find the next revision for today.
-	revision := nextDocRevision(o.cfg.Cobbler.DocTagPrefix, today)
-
-	// Create the tag name.
-	tag := fmt.Sprintf("%s%s.%d", o.cfg.Cobbler.DocTagPrefix, today, revision)
-
-	logf("tag: creating documentation release %s", tag)
-
-	// Create the git tag.
-	if err := gitTag(tag, "."); err != nil {
-		return fmt.Errorf("creating tag %s: %w", tag, err)
-	}
-
-	// Update the version constant in the version file if configured.
-	if o.cfg.Project.VersionFile != "" {
-		logf("tag: writing version %s to %s", tag, o.cfg.Project.VersionFile)
-		if err := writeVersionConst(o.cfg.Project.VersionFile, tag); err != nil {
-			return fmt.Errorf("tag %s created but version file update failed: %w", tag, err)
-		}
-		_ = gitStageAll(".") // best-effort; commit below handles empty index
-		if err := gitCommit(fmt.Sprintf("Set version to %s", tag), "."); err != nil {
-			logf("tag: version commit warning: %v", err)
-		}
-	}
-
-	// Build the container image with the new tag.
-	logf("tag: building container image")
-	if err := o.BuildImage(); err != nil {
-		return fmt.Errorf("building image: %w", err)
-	}
-
-	logf("tag: done — created %s and built container image", tag)
-	return nil
+	return rel.Tag(rel.TagParams{
+		BaseBranch:   o.cfg.Cobbler.BaseBranch,
+		DocTagPrefix: o.cfg.Cobbler.DocTagPrefix,
+		VersionFile:  o.cfg.Project.VersionFile,
+		BuildImageFn: o.BuildImage,
+	})
 }
 
-// nextDocRevision returns the next revision number for <prefix>DATE.* tags.
-// Returns 0 if no tags exist for the given date, otherwise returns the
-// highest existing revision + 1.
+// nextDocRevision delegates to the internal/release package.
 func nextDocRevision(prefix, date string) int {
-	pattern := fmt.Sprintf("%s%s.*", prefix, date)
-	tags := gitListTags(pattern, ".")
-	if len(tags) == 0 {
-		return 0
-	}
-
-	// Extract revision numbers from tags like v0.20260219.0, v0.20260219.1, etc.
-	// Find the highest revision.
-	revPattern := regexp.MustCompile(`^` + regexp.QuoteMeta(prefix) + regexp.QuoteMeta(date) + `\.(\d+)$`)
-	maxRev := -1
-	for _, t := range tags {
-		matches := revPattern.FindStringSubmatch(t)
-		if len(matches) == 2 {
-			rev, err := strconv.Atoi(matches[1])
-			if err == nil && rev > maxRev {
-				maxRev = rev
-			}
-		}
-	}
-
-	if maxRev == -1 {
-		return 0
-	}
-	return maxRev + 1
+	return rel.NextDocRevision(prefix, date)
 }

--- a/pkg/orchestrator/version.go
+++ b/pkg/orchestrator/version.go
@@ -4,47 +4,18 @@
 package orchestrator
 
 import (
-	"fmt"
-	"os"
-	"regexp"
+	rel "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/release"
 )
 
-// versionConstRe matches a Go const declaration like:
-//
-//	const Version = "v1.20260212.0"
-//
-// It captures the quoted value.
-var versionConstRe = regexp.MustCompile(`(?m)^const\s+Version\s*=\s*"([^"]*)"`)
+// versionConstRe is kept as a package-level reference for backward compatibility.
+var versionConstRe = rel.VersionConstRe
 
-// readVersionConst reads the Version constant from a Go source file.
-// Returns "" if the file does not exist or has no Version constant.
+// readVersionConst delegates to the internal/release package.
 func readVersionConst(filePath string) string {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return ""
-	}
-	m := versionConstRe.FindSubmatch(data)
-	if m == nil {
-		return ""
-	}
-	return string(m[1])
+	return rel.ReadVersionConst(filePath)
 }
 
-// writeVersionConst updates the Version constant in a Go source file.
-// The file must already exist and contain a `const Version = "..."` line.
+// writeVersionConst delegates to the internal/release package.
 func writeVersionConst(filePath, version string) error {
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return fmt.Errorf("reading version file: %w", err)
-	}
-
-	if !versionConstRe.Match(data) {
-		return fmt.Errorf("no Version constant found in %s", filePath)
-	}
-
-	updated := versionConstRe.ReplaceAll(data, []byte(fmt.Sprintf(`const Version = "%s"`, version)))
-	if err := os.WriteFile(filePath, updated, 0o644); err != nil {
-		return fmt.Errorf("writing version file: %w", err)
-	}
-	return nil
+	return rel.WriteVersionConst(filePath, version)
 }


### PR DESCRIPTION
## Summary

Extracts release lifecycle, tagging, and version file management into pkg/orchestrator/internal/release/. Parent files become thin wrappers with git helpers and logging injected via package-level variables.

## Changes

- Created pkg/orchestrator/internal/release/ with release.go, tag.go, version.go and their tests
- Parent release.go, tag.go, version.go reduced to thin wrappers
- Minimal local types (roadmapDoc, configProjectReleases) avoid circular imports
- TagParams struct replaces Orchestrator receiver for Tag()

## Test plan

- [x] All 9 packages build clean
- [x] All tests pass (go test ./... -count=1)
- [x] No API changes visible to consumer repos

Closes #1178