### PR TITLE
GH-1180: Extract generate/ into internal sub-package

### DIFF
--- a/pkg/orchestrator/build.go
+++ b/pkg/orchestrator/build.go
@@ -82,11 +82,11 @@ func (o *Orchestrator) DumpStitchPrompt() error {
 		return fmt.Errorf("getting working directory: %w", err)
 	}
 	prompt, err := o.buildStitchPrompt(stitchTask{
-		worktreeDir: cwd,
-		id:          "EXAMPLE-001",
-		title:       "Example task",
-		description: "Placeholder task description for prompt preview.",
-		issueType:   "task",
+		WorktreeDir: cwd,
+		ID:          "EXAMPLE-001",
+		Title:       "Example task",
+		Description: "Placeholder task description for prompt preview.",
+		IssueType:   "task",
 	})
 	if err != nil {
 		return fmt.Errorf("building stitch prompt: %w", err)

--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -6,14 +6,292 @@ package orchestrator
 import (
 	"bytes"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
-	"maps"
 	"slices"
 	"strings"
 	"text/template"
 	"time"
+
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/generate"
 )
+
+// ---------------------------------------------------------------------------
+// Dependency injection: wire the parent package's logf and binary paths
+// into the internal/generate package at init time.
+// ---------------------------------------------------------------------------
+
+func init() {
+	generate.Log = logf
+	generate.BinGit = binGit
+}
+
+// ---------------------------------------------------------------------------
+// Type aliases for backward compatibility
+// ---------------------------------------------------------------------------
+
+// validationResult holds the outcome of measure output validation.
+type validationResult = generate.ValidationResult
+
+// issueDescription is the subset of fields parsed from an issue description.
+type issueDescription = generate.IssueDescription
+
+// issueDescFile holds a file path from an issue description.
+type issueDescFile = generate.IssueDescFile
+
+// issueDescItem holds an ID+text pair from an issue description.
+type issueDescItem = generate.IssueDescItem
+
+// stitchTask holds the state for a single stitch work item.
+type stitchTask = generate.StitchTask
+
+// ---------------------------------------------------------------------------
+// Sentinel errors
+// ---------------------------------------------------------------------------
+
+// errTaskReset is returned by doOneTask when a task fails but the stitch
+// loop should continue to the next task.
+var errTaskReset = generate.ErrTaskReset
+
+// ---------------------------------------------------------------------------
+// Constants re-exported from internal/generate.
+// ---------------------------------------------------------------------------
+
+// baseBranchFile is the name of the file that records which branch a
+// generation was started from, stored inside the cobbler directory.
+const baseBranchFile = generate.BaseBranchFile
+
+// tagSuffixes lists the lifecycle tag suffixes in order.
+var tagSuffixes = generate.TagSuffixes
+
+// prdRefPattern matches PRD requirement references in task requirement text.
+var prdRefPattern = generate.PRDRefPattern
+
+// ---------------------------------------------------------------------------
+// gitDeps builds the GitDeps struct for the generate package.
+// ---------------------------------------------------------------------------
+
+func genGitDeps() generate.GitDeps {
+	return generate.GitDeps{
+		Checkout:      gitCheckout,
+		CurrentBranch: gitCurrentBranch,
+		StageAll:      gitStageAll,
+		UnstageAll:    gitUnstageAll,
+		Commit:        gitCommit,
+		HasChanges:    gitHasChanges,
+		Stash:         gitStash,
+	}
+}
+
+// stitchGitDeps builds the StitchGitDeps struct for stitch operations.
+func stitchGitDeps() generate.StitchGitDeps {
+	return generate.StitchGitDeps{
+		BranchExists:      gitBranchExists,
+		CreateBranch:      gitCreateBranch,
+		DeleteBranch:      gitDeleteBranch,
+		ForceDeleteBranch: gitForceDeleteBranch,
+		ListBranches:      gitListBranches,
+		WorktreeAdd:       gitWorktreeAdd,
+		WorktreeRemove:    gitWorktreeRemove,
+		WorktreePrune:     gitWorktreePrune,
+		Checkout:          gitCheckout,
+		CurrentBranch:     gitCurrentBranch,
+		MergeCmd:          gitMergeCmd,
+		RevParseHEAD:      gitRevParseHEAD,
+	}
+}
+
+// stitchIssueDeps builds the StitchIssueDeps struct for stitch operations.
+func stitchIssueDeps(repo, generation string) generate.StitchIssueDeps {
+	return generate.StitchIssueDeps{
+		ListOpenCobblerIssues: func(r, g string) ([]generate.StitchIssue, error) {
+			issues, err := listOpenCobblerIssues(r, g)
+			if err != nil {
+				return nil, err
+			}
+			result := make([]generate.StitchIssue, len(issues))
+			for i, iss := range issues {
+				labels := make([]string, len(iss.Labels))
+				copy(labels, iss.Labels)
+				result[i] = generate.StitchIssue{
+					Number:      iss.Number,
+					Title:       iss.Title,
+					Description: iss.Description,
+					State:       iss.State,
+					Labels:      labels,
+				}
+			}
+			return result, nil
+		},
+		PickReadyIssue: func(r, g string) (generate.StitchIssue, error) {
+			iss, err := pickReadyIssue(r, g)
+			if err != nil {
+				return generate.StitchIssue{}, err
+			}
+			return generate.StitchIssue{
+				Number:      iss.Number,
+				Title:       iss.Title,
+				Description: iss.Description,
+				State:       iss.State,
+				Labels:      iss.Labels,
+			}, nil
+		},
+		RemoveInProgressLabel: func(r string, num int) error {
+			return removeInProgressLabel(r, num)
+		},
+		HasLabel: func(iss generate.StitchIssue, label string) bool {
+			for _, l := range iss.Labels {
+				if l == label {
+					return true
+				}
+			}
+			return false
+		},
+		LabelInProgress: cobblerLabelInProgress,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Function delegates — unexported wrappers that preserve the original
+// call signatures used throughout the parent package.
+// ---------------------------------------------------------------------------
+
+func resolveStopTarget(callerBranch, genBranch, recordedBase string) string {
+	return generate.ResolveStopTarget(callerBranch, genBranch, recordedBase)
+}
+
+func generationName(tag string) string {
+	return generate.GenerationName(tag)
+}
+
+func saveAndSwitchBranch(target string) error {
+	return generate.SaveAndSwitchBranch(target, genGitDeps())
+}
+
+func ensureOnBranch(branch string) error {
+	return generate.EnsureOnBranch(branch, genGitDeps())
+}
+
+func removeEmptyDirs(root string) {
+	generate.RemoveEmptyDirs(root)
+}
+
+func appendToGitignore(dir, entry string) error {
+	return generate.AppendToGitignore(dir, entry)
+}
+
+func truncateSHA(sha string) string {
+	return generate.TruncateSHA(sha)
+}
+
+func measureReleasesConstraint(releases []string, release string) string {
+	return generate.MeasureReleasesConstraint(releases, release)
+}
+
+func filterImplementedReleases(releases []string) []string {
+	return generate.FilterImplementedReleases(releases)
+}
+
+func filterImplementedRelease(release string) string {
+	return generate.FilterImplementedRelease(release)
+}
+
+func validateMeasureOutput(issues []proposedIssue, maxReqs int, subItemCounts map[string]map[string]int) validationResult {
+	// Convert proposedIssue (from internal/github) to generate.ProposedIssue.
+	genIssues := make([]generate.ProposedIssue, len(issues))
+	for i, iss := range issues {
+		genIssues[i] = generate.ProposedIssue{
+			Index:       iss.Index,
+			Title:       iss.Title,
+			Description: iss.Description,
+			Dependency:  iss.Dependency,
+		}
+	}
+	return generate.ValidateMeasureOutput(genIssues, maxReqs, subItemCounts)
+}
+
+func expandedRequirementCount(reqs []issueDescItem, subItemCounts map[string]map[string]int) int {
+	return generate.ExpandedRequirementCount(reqs, subItemCounts)
+}
+
+func loadPRDSubItemCounts() map[string]map[string]int {
+	return generate.LoadPRDSubItemCounts()
+}
+
+func warnOversizedGroups(maxReqs int) {
+	generate.WarnOversizedGroups(maxReqs)
+}
+
+func appendMeasureLog(cobblerDir string, newIssues []proposedIssue) {
+	// Convert proposedIssue to generate.ProposedIssue.
+	genIssues := make([]generate.ProposedIssue, len(newIssues))
+	for i, iss := range newIssues {
+		genIssues[i] = generate.ProposedIssue{
+			Index:       iss.Index,
+			Title:       iss.Title,
+			Description: iss.Description,
+			Dependency:  iss.Dependency,
+		}
+	}
+	generate.AppendMeasureLog(cobblerDir, genIssues)
+}
+
+func taskBranchName(baseBranch, issueID string) string {
+	return generate.TaskBranchName(baseBranch, issueID)
+}
+
+func taskBranchPattern(baseBranch string) string {
+	return generate.TaskBranchPattern(baseBranch)
+}
+
+func parseRequiredReading(description string) []string {
+	return generate.ParseRequiredReading(description)
+}
+
+func scopeSourceDirs(configDirs []string, description string) []string {
+	return generate.ScopeSourceDirs(configDirs, description)
+}
+
+func validateIssueDescription(desc string) error {
+	return generate.ValidateIssueDescription(desc)
+}
+
+func recoverStaleBranches(baseBranch, worktreeBase, repo string) bool {
+	return generate.RecoverStaleBranches(baseBranch, worktreeBase, repo, stitchGitDeps(), stitchIssueDeps(repo, ""))
+}
+
+func resetOrphanedIssues(baseBranch, repo, generation string) bool {
+	return generate.ResetOrphanedIssues(baseBranch, repo, generation, stitchGitDeps(), stitchIssueDeps(repo, generation))
+}
+
+func pickTask(baseBranch, worktreeBase, repo, generation string) (stitchTask, error) {
+	return generate.PickTask(baseBranch, worktreeBase, repo, generation, stitchIssueDeps(repo, generation))
+}
+
+func createWorktree(task stitchTask) error {
+	return generate.CreateWorktree(task, stitchGitDeps())
+}
+
+func commitWorktreeChanges(task stitchTask) error {
+	return generate.CommitWorktreeChanges(task)
+}
+
+func cleanGoBinaries(dir string) {
+	generate.CleanGoBinaries(dir)
+}
+
+func mergeBranch(branchName, baseBranch, repoRoot string) error {
+	return generate.MergeBranch(branchName, baseBranch, repoRoot, stitchGitDeps())
+}
+
+func cleanupWorktree(task stitchTask) bool {
+	return generate.CleanupWorktree(task, stitchGitDeps())
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator receiver methods
+// ---------------------------------------------------------------------------
 
 // GeneratorRun executes N cycles of Measure + Stitch within the current generation.
 // If cycles > 0 it overrides configuration.yaml's generation.cycles for this run only.
@@ -340,10 +618,6 @@ func (o *Orchestrator) GeneratorStart() error {
 	return nil
 }
 
-// baseBranchFile is the name of the file that records which branch a
-// generation was started from, stored inside the cobbler directory.
-const baseBranchFile = "base-branch"
-
 // writeBaseBranch writes the base branch name to .cobbler/base-branch.
 func (o *Orchestrator) writeBaseBranch(branch string) error {
 	dir := o.cfg.Cobbler.Dir
@@ -366,20 +640,6 @@ func (o *Orchestrator) readBaseBranch() string {
 		return "main"
 	}
 	return branch
-}
-
-// resolveStopTarget returns the branch that generator:stop should merge into.
-// callerBranch is the branch checked out when generator:stop was invoked.
-// genBranch is the generation branch being stopped. recordedBase is the branch
-// written by generator:start. When the caller is on a branch other than the
-// generation branch and other than the recorded base, that caller branch is
-// returned so that generator:stop merges into an explicit feature branch rather
-// than always forcing a merge into the recorded base (GH-523).
-func resolveStopTarget(callerBranch, genBranch, recordedBase string) string {
-	if callerBranch != genBranch && callerBranch != recordedBase {
-		return callerBranch
-	}
-	return recordedBase
 }
 
 // GeneratorStop completes a generation trail and merges it into the base branch.
@@ -420,10 +680,6 @@ func (o *Orchestrator) GeneratorStop() error {
 	logf("generator:stop: beginning")
 
 	// Capture the caller's branch before switching to the generation branch.
-	// If the caller is on a feature branch (e.g. gh-168-...) rather than
-	// the recorded base branch, prefer it as the merge target so that
-	// generator:stop respects the PR workflow described in the close-out
-	// procedure (GH-523).
 	callerBranch, err := gitCurrentBranch(".")
 	if err != nil {
 		return fmt.Errorf("getting current branch: %w", err)
@@ -456,16 +712,14 @@ func (o *Orchestrator) GeneratorStop() error {
 		return err
 	}
 
-	// Close any open cobbler-gen issues for this generation so they do not
-	// accumulate as orphans after the branch is deleted.
+	// Close any open cobbler-gen issues for this generation.
 	if ghRepo, err := detectGitHubRepo(".", o.cfg); err == nil && ghRepo != "" {
 		if err := closeGenerationIssues(ghRepo, branch); err != nil {
 			logf("generator:stop: close issues warning: %v", err)
 		}
 	}
 
-	// Reset all implemented releases back to spec_complete so the repo is
-	// ready for the next generation run (GH-1021).
+	// Reset all implemented releases back to spec_complete (GH-1021).
 	if err := o.resetImplementedReleases(); err != nil {
 		logf("generator:stop: reset releases warning: %v", err)
 	}
@@ -479,8 +733,6 @@ func (o *Orchestrator) GeneratorStop() error {
 // mergeGeneration resets Go sources, commits the clean state, merges the
 // generation branch into the base branch, tags the result, resets the base
 // branch to specs-only, and deletes the generation branch.
-// When preserve_sources is true the pre-merge source reset and the
-// post-tag cleanGoSources call are both skipped (prd002 R10.2).
 func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 	if o.cfg.Generation.PreserveSources {
 		logf("generator:stop: preserve_sources=true, skipping pre-merge Go source reset on %s", baseBranch)
@@ -508,8 +760,7 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 		return fmt.Errorf("merging %s: %w", branch, err)
 	}
 
-	// Restore Go files from earlier generations so the v1 tag captures a
-	// complete snapshot (prd002 R5.9). Runs before tagging.
+	// Restore Go files from earlier generations.
 	startTag := branch + "-start"
 	if err := o.restoreFromStartTag(startTag); err != nil {
 		logf("generator:stop: restore warning: %v", err)
@@ -521,10 +772,7 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 		return fmt.Errorf("tagging merge: %w", err)
 	}
 
-	// Reset base branch to specs-only (prd002 R5.10, R5.11).
-	// Version tagging is handled separately by mage tag (Tag() in tag.go).
-	// Use cleanGoSources (not resetGoSources) to avoid re-seeding files like version.go.
-	// Skip when preserve_sources is true — library repos keep their Go source (prd002 R10.2).
+	// Reset base branch to specs-only.
 	if o.cfg.Generation.PreserveSources {
 		logf("generator:stop: preserve_sources=true, skipping post-tag source reset on %s", baseBranch)
 	} else {
@@ -574,9 +822,7 @@ func (o *Orchestrator) resetImplementedReleases() error {
 }
 
 // restoreFromStartTag restores Go source files that existed on main at the
-// given start tag but are missing after the merge. This preserves code from
-// earlier generations that would otherwise be lost during the reset+merge
-// cycle. See prd002-generation-lifecycle R5.8.
+// given start tag but are missing after the merge.
 func (o *Orchestrator) restoreFromStartTag(startTag string) error {
 	startFiles, err := gitLsTreeFiles(startTag, ".")
 	if err != nil {
@@ -585,15 +831,12 @@ func (o *Orchestrator) restoreFromStartTag(startTag string) error {
 
 	var restored []string
 	for _, path := range startFiles {
-		// Only restore Go source files outside magefiles/.
 		if !strings.HasSuffix(path, ".go") {
 			continue
 		}
 		if strings.HasPrefix(path, o.cfg.Project.MagefilesDir+"/") {
 			continue
 		}
-
-		// Skip files that already exist on disk.
 		if _, err := os.Stat(path); err == nil {
 			continue
 		}
@@ -633,27 +876,13 @@ func (o *Orchestrator) restoreFromStartTag(startTag string) error {
 
 // listGenerationBranches returns all generation-* branch names.
 func (o *Orchestrator) listGenerationBranches() []string {
-	return gitListBranches(o.cfg.Generation.Prefix + "*", ".")
-}
-
-// tagSuffixes lists the lifecycle tag suffixes in order.
-var tagSuffixes = []string{"-start", "-finished", "-merged", "-abandoned"}
-
-// generationName strips the lifecycle suffix from a tag to recover
-// the generation name.
-func generationName(tag string) string {
-	for _, suffix := range tagSuffixes {
-		if cut, ok := strings.CutSuffix(tag, suffix); ok {
-			return cut
-		}
-	}
-	return tag
+	return gitListBranches(o.cfg.Generation.Prefix+"*", ".")
 }
 
 // cleanupUnmergedTags renames tags for generations that were never
 // merged into a single -abandoned tag.
 func (o *Orchestrator) cleanupUnmergedTags() {
-	tags := gitListTags(o.cfg.Generation.Prefix + "*", ".")
+	tags := gitListTags(o.cfg.Generation.Prefix+"*", ".")
 	if len(tags) == 0 {
 		return
 	}
@@ -706,55 +935,10 @@ func (o *Orchestrator) resolveBranch(explicit string) (string, error) {
 	}
 }
 
-// saveAndSwitchBranch commits or stashes uncommitted changes on the
-// current branch, then checks out the target branch. It tries a WIP
-// commit first; if that fails and the tree is still dirty, it stashes
-// changes so the checkout can succeed.
-func saveAndSwitchBranch(target string) error {
-	current, err := gitCurrentBranch(".")
-	if err != nil {
-		return err
-	}
-	if current == target {
-		return nil
-	}
-
-	if err := gitStageAll("."); err != nil {
-		return fmt.Errorf("staging changes: %w", err)
-	}
-
-	msg := fmt.Sprintf("WIP: save state before switching to %s", target)
-	if err := gitCommit(msg, "."); err != nil {
-		// Commit failed (e.g. nothing to commit). Unstage and fall
-		// back to stash if the tree is still dirty.
-		_ = gitUnstageAll(".") // best-effort; unstage before stash fallback
-		if gitHasChanges(".") {
-			logf("saveAndSwitchBranch: commit failed, stashing dirty tree")
-			_ = gitStash(msg, ".") // best-effort; switching branch is the priority
-		}
-	}
-
-	logf("saveAndSwitchBranch: %s -> %s", current, target)
-	return gitCheckout(target, ".")
-}
-
-// ensureOnBranch switches to the given branch if not already on it.
-func ensureOnBranch(branch string) error {
-	current, err := gitCurrentBranch(".")
-	if err != nil {
-		return err
-	}
-	if current == branch {
-		return nil
-	}
-	logf("ensureOnBranch: switching from %s to %s", current, branch)
-	return gitCheckout(branch, ".")
-}
-
 // GeneratorList shows active branches and past generations.
 func (o *Orchestrator) GeneratorList() error {
 	branches := o.listGenerationBranches()
-	tags := gitListTags(o.cfg.Generation.Prefix + "*", ".")
+	tags := gitListTags(o.cfg.Generation.Prefix+"*", ".")
 	current, _ := gitCurrentBranch(".")
 
 	nameSet := make(map[string]bool)
@@ -814,7 +998,6 @@ func (o *Orchestrator) GeneratorList() error {
 }
 
 // GeneratorSwitch commits current work and checks out another generation branch.
-// Uses Config.GenerationBranch as the target.
 func (o *Orchestrator) GeneratorSwitch() error {
 	target := o.cfg.Generation.Branch
 	baseBranch := o.cfg.Cobbler.BaseBranch
@@ -872,8 +1055,6 @@ func (o *Orchestrator) GeneratorReset() error {
 				logf("generator:reset: close issues warning for %s: %v", gb, err)
 			}
 		}
-		// Close issues created on the base branch (handles repos where measure ran on the
-		// base branch, such as test repos that run cobbler:measure without a generation branch).
 		if err := closeGenerationIssues(ghRepo, baseBranch); err != nil {
 			logf("generator:reset: close issues warning for %s: %v", baseBranch, err)
 		}
@@ -940,7 +1121,6 @@ func (o *Orchestrator) resetGoSources(version string) error {
 
 // cleanGoSources removes all Go files, empty source directories, and the
 // binary directory without re-seeding files or reinitializing the module.
-// Used for the specs-only reset after v1 tags are created.
 func (o *Orchestrator) cleanGoSources() {
 	o.deleteGoFiles(".")
 	for _, dir := range o.cfg.Project.GoSourceDirs {
@@ -1015,29 +1195,6 @@ func (o *Orchestrator) deleteGoFiles(root string) {
 	})
 }
 
-// removeEmptyDirs removes empty directories under the given root.
-func removeEmptyDirs(root string) {
-	if _, err := os.Stat(root); os.IsNotExist(err) {
-		return
-	}
-	var dirs []string
-	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
-		if err != nil {
-			return nil
-		}
-		if d.IsDir() {
-			dirs = append(dirs, path)
-		}
-		return nil
-	})
-	for i := len(dirs) - 1; i >= 0; i-- {
-		entries, err := os.ReadDir(dirs[i])
-		if err == nil && len(entries) == 0 {
-			_ = os.Remove(dirs[i]) // best-effort empty dir cleanup
-		}
-	}
-}
-
 // cleanupDirs removes all directories listed in Config.CleanupDirs.
 func (o *Orchestrator) cleanupDirs() {
 	for _, dir := range o.cfg.Generation.CleanupDirs {
@@ -1047,7 +1204,6 @@ func (o *Orchestrator) cleanupDirs() {
 }
 
 // GeneratorInit writes a default configuration.yaml if one does not exist.
-// Exposed as mage generator:init.
 func GeneratorInit() error {
 	logf("generator:init: writing %s", DefaultConfigFile)
 	if err := WriteDefaultConfig(DefaultConfigFile); err != nil {
@@ -1068,36 +1224,4 @@ func (o *Orchestrator) FullReset() error {
 		return err
 	}
 	return o.GeneratorReset()
-}
-
-// appendToGitignore adds entry to the .gitignore file in dir if not already
-// present. Creates the file if it does not exist. Used by GeneratorStart to
-// ensure build artifacts (bin/) are not committed to the generation branch
-// regardless of where they are produced (GH-469).
-func appendToGitignore(dir, entry string) error {
-	path := filepath.Join(dir, ".gitignore")
-
-	data, err := os.ReadFile(path)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("reading .gitignore: %w", err)
-	}
-
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.TrimSpace(line) == entry {
-			return nil // already present
-		}
-	}
-
-	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		return fmt.Errorf("opening .gitignore: %w", err)
-	}
-	defer f.Close()
-
-	prefix := ""
-	if len(data) > 0 && data[len(data)-1] != '\n' {
-		prefix = "\n"
-	}
-	_, err = fmt.Fprintf(f, "%s%s\n", prefix, entry)
-	return err
 }

--- a/pkg/orchestrator/internal/generate/generator.go
+++ b/pkg/orchestrator/internal/generate/generator.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Package generate implements the generation lifecycle: start, run, resume,
+// stop, switch, reset, and list operations. The parent orchestrator package
+// provides thin receiver-method wrappers around these functions.
+package generate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Injected dependencies
+// ---------------------------------------------------------------------------
+
+// Logger is a function that formats and emits log messages.
+type Logger func(format string, args ...any)
+
+// Package-level variables set by the parent package at init time.
+var (
+	Log Logger = func(string, ...any) {}
+
+	BinGit string
+)
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// BaseBranchFile is the name of the file that records which branch a
+// generation was started from, stored inside the cobbler directory.
+const BaseBranchFile = "base-branch"
+
+// TagSuffixes lists the lifecycle tag suffixes in order.
+var TagSuffixes = []string{"-start", "-finished", "-merged", "-abandoned"}
+
+// ---------------------------------------------------------------------------
+// Pure functions
+// ---------------------------------------------------------------------------
+
+// ResolveStopTarget returns the branch that generator:stop should merge into.
+// callerBranch is the branch checked out when generator:stop was invoked.
+// genBranch is the generation branch being stopped. recordedBase is the branch
+// written by generator:start. When the caller is on a branch other than the
+// generation branch and other than the recorded base, that caller branch is
+// returned so that generator:stop merges into an explicit feature branch rather
+// than always forcing a merge into the recorded base (GH-523).
+func ResolveStopTarget(callerBranch, genBranch, recordedBase string) string {
+	if callerBranch != genBranch && callerBranch != recordedBase {
+		return callerBranch
+	}
+	return recordedBase
+}
+
+// GenerationName strips the lifecycle suffix from a tag to recover
+// the generation name.
+func GenerationName(tag string) string {
+	for _, suffix := range TagSuffixes {
+		if cut, ok := strings.CutSuffix(tag, suffix); ok {
+			return cut
+		}
+	}
+	return tag
+}
+
+// ---------------------------------------------------------------------------
+// Git branch helpers
+// ---------------------------------------------------------------------------
+
+// SaveAndSwitchBranch commits or stashes uncommitted changes on the
+// current branch, then checks out the target branch. It tries a WIP
+// commit first; if that fails and the tree is still dirty, it stashes
+// changes so the checkout can succeed.
+//
+// The caller must provide git helper functions via the deps struct.
+func SaveAndSwitchBranch(target string, deps GitDeps) error {
+	current, err := deps.CurrentBranch(".")
+	if err != nil {
+		return err
+	}
+	if current == target {
+		return nil
+	}
+
+	if err := deps.StageAll("."); err != nil {
+		return fmt.Errorf("staging changes: %w", err)
+	}
+
+	msg := fmt.Sprintf("WIP: save state before switching to %s", target)
+	if err := deps.Commit(msg, "."); err != nil {
+		// Commit failed (e.g. nothing to commit). Unstage and fall
+		// back to stash if the tree is still dirty.
+		_ = deps.UnstageAll(".") // best-effort; unstage before stash fallback
+		if deps.HasChanges(".") {
+			Log("saveAndSwitchBranch: commit failed, stashing dirty tree")
+			_ = deps.Stash(msg, ".") // best-effort; switching branch is the priority
+		}
+	}
+
+	Log("saveAndSwitchBranch: %s -> %s", current, target)
+	return deps.Checkout(target, ".")
+}
+
+// EnsureOnBranch switches to the given branch if not already on it.
+func EnsureOnBranch(branch string, deps GitDeps) error {
+	current, err := deps.CurrentBranch(".")
+	if err != nil {
+		return err
+	}
+	if current == branch {
+		return nil
+	}
+	Log("ensureOnBranch: switching from %s to %s", current, branch)
+	return deps.Checkout(branch, ".")
+}
+
+// ---------------------------------------------------------------------------
+// File system helpers
+// ---------------------------------------------------------------------------
+
+// RemoveEmptyDirs removes empty directories under the given root.
+func RemoveEmptyDirs(root string) {
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return
+	}
+	var dirs []string
+	_ = filepath.WalkDir(root, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			dirs = append(dirs, path)
+		}
+		return nil
+	})
+	for i := len(dirs) - 1; i >= 0; i-- {
+		entries, err := os.ReadDir(dirs[i])
+		if err == nil && len(entries) == 0 {
+			_ = os.Remove(dirs[i]) // best-effort empty dir cleanup
+		}
+	}
+}
+
+// AppendToGitignore adds entry to the .gitignore file in dir if not already
+// present. Creates the file if it does not exist. Used by GeneratorStart to
+// ensure build artifacts (bin/) are not committed to the generation branch
+// regardless of where they are produced (GH-469).
+func AppendToGitignore(dir, entry string) error {
+	path := filepath.Join(dir, ".gitignore")
+
+	data, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("reading .gitignore: %w", err)
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.TrimSpace(line) == entry {
+			return nil // already present
+		}
+	}
+
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("opening .gitignore: %w", err)
+	}
+	defer f.Close()
+
+	prefix := ""
+	if len(data) > 0 && data[len(data)-1] != '\n' {
+		prefix = "\n"
+	}
+	_, err = fmt.Fprintf(f, "%s%s\n", prefix, entry)
+	return err
+}
+
+// ---------------------------------------------------------------------------
+// GitDeps provides git operations needed by the generate package.
+// ---------------------------------------------------------------------------
+
+// GitDeps holds the git helper functions injected by the parent package.
+type GitDeps struct {
+	Checkout      func(branch, dir string) error
+	CurrentBranch func(dir string) (string, error)
+	StageAll      func(dir string) error
+	UnstageAll    func(dir string) error
+	Commit        func(msg, dir string) error
+	HasChanges    func(dir string) bool
+	Stash         func(msg, dir string) error
+}

--- a/pkg/orchestrator/internal/generate/measure.go
+++ b/pkg/orchestrator/internal/generate/measure.go
@@ -1,0 +1,418 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package generate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// IssueDescription is the subset of fields parsed from an issue description
+// YAML for advisory validation.
+type IssueDescription struct {
+	DeliverableType    string          `yaml:"deliverable_type"`
+	Files              []IssueDescFile `yaml:"files"`
+	Requirements       []IssueDescItem `yaml:"requirements"`
+	AcceptanceCriteria []IssueDescItem `yaml:"acceptance_criteria"`
+	DesignDecisions    []IssueDescItem `yaml:"design_decisions"`
+}
+
+// IssueDescFile holds a file path from an issue description.
+type IssueDescFile struct {
+	Path string `yaml:"path"`
+}
+
+// IssueDescItem holds an ID+text pair from an issue description.
+type IssueDescItem struct {
+	ID   string `yaml:"id"`
+	Text string `yaml:"text"`
+}
+
+// ValidationResult holds the outcome of measure output validation.
+type ValidationResult struct {
+	Warnings []string // advisory issues (logged but do not block import)
+	Errors   []string // blocking issues (cause rejection in enforcing mode)
+}
+
+// HasErrors returns true if the validation found blocking issues.
+func (v ValidationResult) HasErrors() bool {
+	return len(v.Errors) > 0
+}
+
+// ProposedIssue is the minimal interface needed by validation and logging.
+// The parent package aliases this to the internal/github ProposedIssue.
+type ProposedIssue struct {
+	Index       int    `yaml:"index" json:"index"`
+	Title       string `yaml:"title" json:"title"`
+	Description string `yaml:"description" json:"description"`
+	Dependency  int    `yaml:"dependency" json:"dependency"`
+}
+
+// ---------------------------------------------------------------------------
+// Pure functions
+// ---------------------------------------------------------------------------
+
+// TruncateSHA returns the first 8 characters of a SHA, or the full
+// string if shorter.
+func TruncateSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}
+
+// MeasureReleasesConstraint returns a hard constraint string to append to the
+// measure prompt when a release scope is configured. Returns "" when no scope
+// is set. Releases (list) takes precedence over Release (single string).
+func MeasureReleasesConstraint(releases []string, release string) string {
+	if len(releases) > 0 {
+		return fmt.Sprintf(
+			"\n\nRelease scope: You MUST only propose tasks for use cases in releases [%s]. Do not propose tasks for any other release.",
+			strings.Join(releases, ", "),
+		)
+	}
+	if release != "" {
+		return fmt.Sprintf(
+			"\n\nRelease scope: You MUST only propose tasks for use cases in release %q or earlier. Do not propose tasks for later releases.",
+			release,
+		)
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// PRD reference pattern
+// ---------------------------------------------------------------------------
+
+// PRDRefPattern matches PRD requirement references in task requirement text.
+// Examples: "prd003 R2", "prd004-ts R1.3", "prd001-orchestrator-core R5".
+// Group 1 = PRD stem (e.g., "prd003" or "prd004-ts").
+// Group 2 = requirement group number (e.g., "2" from "R2").
+// Group 3 = optional sub-item number (e.g., "3" from "R1.3"); empty for groups.
+var PRDRefPattern = regexp.MustCompile(`(prd\d+[-\w]*)\s+R(\d+)(?:\.(\d+))?`)
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+// ValidateMeasureOutput checks proposed issues against P9 granularity ranges
+// and P7 file naming conventions. Returns structured warnings and errors.
+// All issues are logged regardless of enforcing mode. maxReqs is the
+// operator-configured requirement cap (0 = unlimited). subItemCounts maps
+// PRD stems to group IDs to sub-item counts; when a task requirement
+// references a PRD group, the expanded sub-item count is used instead of 1.
+// Expanded-count violations are logged as warnings (best-effort), not errors.
+func ValidateMeasureOutput(issues []ProposedIssue, maxReqs int, subItemCounts map[string]map[string]int) ValidationResult {
+	var result ValidationResult
+	for _, issue := range issues {
+		var desc IssueDescription
+		if err := yaml.Unmarshal([]byte(issue.Description), &desc); err != nil {
+			msg := fmt.Sprintf("[%d] %q: could not parse description: %v", issue.Index, issue.Title, err)
+			Log("validateMeasureOutput: %s", msg)
+			result.Warnings = append(result.Warnings, msg)
+			continue
+		}
+
+		rCount := len(desc.Requirements)
+		acCount := len(desc.AcceptanceCriteria)
+		dCount := len(desc.DesignDecisions)
+
+		// Compute expanded requirement count by resolving PRD group
+		// references to their sub-item counts (GH-122).
+		expandedCount := ExpandedRequirementCount(desc.Requirements, subItemCounts)
+
+		// Enforce max_requirements_per_task on the expanded sub-item count,
+		// not the top-level group count (GH-535). A requirement referencing
+		// "prd003 R2" where R2 has 10 sub-items counts as 10, not 1.
+		if maxReqs > 0 && expandedCount > maxReqs {
+			msg := fmt.Sprintf("[%d] %q: expanded sub-item count is %d, max is %d", issue.Index, issue.Title, expandedCount, maxReqs)
+			Log("validateMeasureOutput: %s", msg)
+			result.Errors = append(result.Errors, msg)
+		}
+
+		if desc.DeliverableType == "code" {
+			if rCount < 5 || rCount > 8 {
+				msg := fmt.Sprintf("[%d] %q: requirement count %d outside P9 range 5-8", issue.Index, issue.Title, rCount)
+				Log("validateMeasureOutput: %s", msg)
+				result.Errors = append(result.Errors, msg)
+			}
+			if acCount < 5 || acCount > 8 {
+				msg := fmt.Sprintf("[%d] %q: acceptance criteria count %d outside P9 range 5-8", issue.Index, issue.Title, acCount)
+				Log("validateMeasureOutput: %s", msg)
+				result.Errors = append(result.Errors, msg)
+			}
+			if dCount < 3 || dCount > 5 {
+				msg := fmt.Sprintf("[%d] %q: design decision count %d outside P9 range 3-5", issue.Index, issue.Title, dCount)
+				Log("validateMeasureOutput: %s", msg)
+				result.Errors = append(result.Errors, msg)
+			}
+		} else if desc.DeliverableType == "documentation" {
+			if rCount < 2 || rCount > 4 {
+				msg := fmt.Sprintf("[%d] %q: requirement count %d outside P9 doc range 2-4", issue.Index, issue.Title, rCount)
+				Log("validateMeasureOutput: %s", msg)
+				result.Errors = append(result.Errors, msg)
+			}
+			if acCount < 3 || acCount > 5 {
+				msg := fmt.Sprintf("[%d] %q: acceptance criteria count %d outside P9 doc range 3-5", issue.Index, issue.Title, acCount)
+				Log("validateMeasureOutput: %s", msg)
+				result.Errors = append(result.Errors, msg)
+			}
+		}
+
+		// Check for P7 violation: file named after its package.
+		for _, f := range desc.Files {
+			parts := strings.Split(f.Path, "/")
+			if len(parts) >= 2 {
+				dir := parts[len(parts)-2]
+				file := parts[len(parts)-1]
+				if file == dir+".go" || file == dir+"_test.go" {
+					msg := fmt.Sprintf("[%d] %q: file %s matches package name (P7 violation)", issue.Index, issue.Title, f.Path)
+					Log("validateMeasureOutput: %s", msg)
+					result.Errors = append(result.Errors, msg)
+				}
+			}
+		}
+	}
+	return result
+}
+
+// ExpandedRequirementCount computes the effective requirement count by
+// parsing PRD group references from each requirement's text and expanding
+// groups to their sub-item counts. A requirement referencing "prd003 R2"
+// where R2 has 4 sub-items counts as 4, not 1. Requirements without a
+// recognized PRD reference or referencing a specific sub-item (R1.3)
+// count as 1.
+func ExpandedRequirementCount(reqs []IssueDescItem, subItemCounts map[string]map[string]int) int {
+	if len(subItemCounts) == 0 {
+		return len(reqs)
+	}
+	total := 0
+	for _, req := range reqs {
+		matches := PRDRefPattern.FindStringSubmatch(req.Text)
+		if matches == nil {
+			total++
+			continue
+		}
+		prdStem := matches[1]
+		groupNum := matches[2]
+		subItem := matches[3]
+
+		// Specific sub-item reference (e.g., R1.3) counts as 1.
+		if subItem != "" {
+			total++
+			continue
+		}
+
+		// Group reference (e.g., R2). Look up sub-item count.
+		groupKey := "R" + groupNum
+		if groups, ok := subItemCounts[prdStem]; ok {
+			if count, found := groups[groupKey]; found {
+				total += count
+				continue
+			}
+		}
+		// PRD or group not found — count as 1.
+		total++
+	}
+	return total
+}
+
+// ---------------------------------------------------------------------------
+// PRD loading and warnings
+// ---------------------------------------------------------------------------
+
+// PRDDoc is the minimal PRD structure needed for sub-item counting.
+type PRDDoc struct {
+	Requirements map[string]PRDRequirementGroup `yaml:"requirements"`
+}
+
+// PRDRequirementGroup represents a single requirement group with sub-items.
+type PRDRequirementGroup struct {
+	Items []any `yaml:"items"`
+}
+
+// LoadPRDSubItemCounts loads all PRDs from the standard path and returns a
+// map of PRD stem -> group key -> sub-item count. A group with no sub-items
+// maps to 1. The stem is the filename without path and extension (e.g.,
+// "prd003-cobbler-workflows"); an additional entry keyed by the short prefix
+// (e.g., "prd003") is added for fuzzy matching.
+func LoadPRDSubItemCounts() map[string]map[string]int {
+	paths, _ := filepath.Glob("docs/specs/product-requirements/prd*.yaml")
+	counts := make(map[string]map[string]int, len(paths)*2)
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var prd PRDDoc
+		if err := yaml.Unmarshal(data, &prd); err != nil {
+			continue
+		}
+		stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		groupCounts := make(map[string]int, len(prd.Requirements))
+		for key, group := range prd.Requirements {
+			if len(group.Items) > 0 {
+				groupCounts[key] = len(group.Items)
+			} else {
+				groupCounts[key] = 1
+			}
+		}
+		counts[stem] = groupCounts
+		// Add short prefix entry (e.g., "prd003") for fuzzy matching.
+		if idx := strings.IndexByte(stem, '-'); idx > 0 {
+			short := stem[:idx]
+			if _, exists := counts[short]; !exists {
+				counts[short] = groupCounts
+			}
+		}
+	}
+	return counts
+}
+
+// WarnOversizedGroups loads PRDs and logs a warning for each requirement
+// group whose sub-item count exceeds maxReqs. This is advisory and runs
+// before the measure prompt is built so operators can restructure PRDs.
+func WarnOversizedGroups(maxReqs int) {
+	paths, _ := filepath.Glob("docs/specs/product-requirements/prd*.yaml")
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var prd PRDDoc
+		if err := yaml.Unmarshal(data, &prd); err != nil {
+			continue
+		}
+		stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
+		keys := make([]string, 0, len(prd.Requirements))
+		for k := range prd.Requirements {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			group := prd.Requirements[key]
+			if len(group.Items) > maxReqs {
+				Log("warning: %s %s has %d sub-items (max_requirements_per_task=%d); consider splitting this requirement group",
+					stem, key, len(group.Items), maxReqs)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Measure log persistence
+// ---------------------------------------------------------------------------
+
+// AppendMeasureLog merges newIssues into the persistent measure.yaml list.
+// measure.yaml is a single growing YAML list of all issues proposed across runs.
+func AppendMeasureLog(cobblerDir string, newIssues []ProposedIssue) {
+	logPath := filepath.Join(cobblerDir, "measure.yaml")
+
+	var existing []ProposedIssue
+	if data, err := os.ReadFile(logPath); err == nil {
+		if err := yaml.Unmarshal(data, &existing); err != nil {
+			Log("appendMeasureLog: could not parse existing list, starting fresh: %v", err)
+			existing = nil
+		}
+	}
+
+	combined := append(existing, newIssues...)
+	out, err := yaml.Marshal(combined)
+	if err != nil {
+		Log("appendMeasureLog: marshal failed: %v", err)
+		return
+	}
+	if err := os.WriteFile(logPath, out, 0o644); err != nil {
+		Log("appendMeasureLog: write failed: %v", err)
+		return
+	}
+	Log("appendMeasureLog: %d total issues in %s", len(combined), logPath)
+}
+
+// ---------------------------------------------------------------------------
+// Release filtering
+// ---------------------------------------------------------------------------
+
+// RoadmapDoc is the minimal road-map structure needed for release filtering.
+type RoadmapDoc struct {
+	Releases []RoadmapRelease `yaml:"releases"`
+}
+
+// RoadmapRelease represents a single release in road-map.yaml.
+type RoadmapRelease struct {
+	Version string `yaml:"version"`
+	Status  string `yaml:"status"`
+}
+
+// UCStatusDone returns true when the status string indicates a completed
+// use case or release ("implemented", "done", or "closed").
+func UCStatusDone(status string) bool {
+	s := strings.ToLower(status)
+	return s == "implemented" || s == "done" || s == "closed"
+}
+
+// FilterImplementedReleases returns a copy of releases with any entry whose
+// road-map status is "implemented" or "done" removed. Releases not found in
+// road-map.yaml are kept (unknown status is not treated as implemented).
+// Returns nil when all releases are filtered out.
+func FilterImplementedReleases(releases []string) []string {
+	if len(releases) == 0 {
+		return releases
+	}
+	data, err := os.ReadFile("docs/road-map.yaml")
+	if err != nil {
+		return releases
+	}
+	var rm RoadmapDoc
+	if err := yaml.Unmarshal(data, &rm); err != nil {
+		return releases
+	}
+	status := make(map[string]string, len(rm.Releases))
+	for _, rel := range rm.Releases {
+		status[rel.Version] = rel.Status
+	}
+	var out []string
+	for _, r := range releases {
+		if UCStatusDone(status[r]) {
+			Log("filterImplementedReleases: dropping implemented release %s from constraint", r)
+			continue
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// FilterImplementedRelease returns the release string unchanged unless the
+// road-map marks that release as implemented/done, in which case "" is
+// returned so no legacy single-release constraint is emitted.
+func FilterImplementedRelease(release string) string {
+	if release == "" {
+		return ""
+	}
+	data, err := os.ReadFile("docs/road-map.yaml")
+	if err != nil {
+		return release
+	}
+	var rm RoadmapDoc
+	if err := yaml.Unmarshal(data, &rm); err != nil {
+		return release
+	}
+	for _, rel := range rm.Releases {
+		if rel.Version == release && UCStatusDone(rel.Status) {
+			Log("filterImplementedRelease: dropping implemented release %s from constraint", release)
+			return ""
+		}
+	}
+	return release
+}

--- a/pkg/orchestrator/internal/generate/stitch.go
+++ b/pkg/orchestrator/internal/generate/stitch.go
@@ -1,0 +1,460 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package generate
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ErrTaskReset is returned by DoOneTask when a task fails but the stitch
+// loop should continue to the next task (e.g., Claude failure, worktree
+// commit failure, merge failure). The task has been reset to open.
+var ErrTaskReset = errors.New("task reset to open")
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// StitchTask holds the state for a single stitch work item.
+type StitchTask struct {
+	ID          string // cobbler_index as string — used for branch/worktree naming
+	Title       string
+	Description string
+	IssueType   string
+	BranchName  string
+	WorktreeDir string
+	GhNumber    int    // GitHub issue number — used for closing/labelling
+	Generation  string // generation label value
+	Repo        string // GitHub owner/repo
+}
+
+// ---------------------------------------------------------------------------
+// Branch naming
+// ---------------------------------------------------------------------------
+
+// TaskBranchName returns the git branch name for a stitch task.
+// Uses "task/<base>-<id>" instead of "<base>/task/<id>" to avoid
+// ref conflicts when the base branch is "main".
+func TaskBranchName(baseBranch, issueID string) string {
+	return "task/" + baseBranch + "-" + issueID
+}
+
+// TaskBranchPattern returns the glob pattern for listing task branches.
+func TaskBranchPattern(baseBranch string) string {
+	return "task/" + baseBranch + "-*"
+}
+
+// ---------------------------------------------------------------------------
+// Issue description parsing & validation
+// ---------------------------------------------------------------------------
+
+// ParseRequiredReading extracts the required_reading list from a YAML task
+// description. Handles both the canonical string format ("- path (reason)")
+// and the map format ("- path: foo.go") that Claude sometimes emits.
+// Returns nil if the field is absent or unparseable.
+func ParseRequiredReading(description string) []string {
+	if description == "" {
+		return nil
+	}
+
+	// Try []string first (canonical format: "- path/to/file.go (reason)").
+	var stringParsed struct {
+		RequiredReading []string `yaml:"required_reading"`
+	}
+	if err := yaml.Unmarshal([]byte(description), &stringParsed); err == nil {
+		return stringParsed.RequiredReading
+	}
+
+	// Fall back to []map format when Claude emits structured entries
+	// like {path: "foo.go", reason: "..."}.
+	var mapParsed struct {
+		RequiredReading []map[string]string `yaml:"required_reading"`
+	}
+	if err := yaml.Unmarshal([]byte(description), &mapParsed); err != nil {
+		Log("parseRequiredReading: YAML parse error: %v", err)
+		return nil
+	}
+	var result []string
+	for _, entry := range mapParsed.RequiredReading {
+		if p := entry["path"]; p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
+}
+
+// ScopeSourceDirs narrows GoSourceDirs based on the task description's files
+// field (GH-1005). For each configured dir, if the task's files reference a
+// sub-directory two levels deep (e.g. "cmd/cat/main.go" under "cmd/"), only
+// that sub-directory is included instead of the whole tree. Directories where
+// all task files sit directly inside (e.g. "pkg/orchestrator/foo.go" under
+// "pkg/") are kept as-is. Returns nil when no scoping is possible.
+func ScopeSourceDirs(configDirs []string, description string) []string {
+	if description == "" || len(configDirs) == 0 {
+		return nil
+	}
+	var parsed struct {
+		Files []string `yaml:"files"`
+	}
+	if err := yaml.Unmarshal([]byte(description), &parsed); err != nil || len(parsed.Files) == 0 {
+		return nil
+	}
+
+	// Extract two-level prefixes from task files: "cmd/cat/main.go" → "cmd/cat".
+	subDirs := make(map[string]bool)
+	for _, f := range parsed.Files {
+		f = strings.TrimPrefix(f, "./")
+		parts := strings.SplitN(f, "/", 3)
+		if len(parts) == 3 {
+			subDirs[parts[0]+"/"+parts[1]] = true
+		}
+	}
+
+	changed := false
+	scoped := make([]string, 0, len(configDirs))
+	for _, dir := range configDirs {
+		clean := strings.TrimRight(strings.TrimPrefix(dir, "./"), "/")
+		// Collect sub-directories of this config dir referenced by the task.
+		var matches []string
+		for sd := range subDirs {
+			if strings.HasPrefix(sd, clean+"/") {
+				matches = append(matches, sd)
+			}
+		}
+		if len(matches) > 0 {
+			sort.Strings(matches)
+			scoped = append(scoped, matches...)
+			changed = true
+		} else {
+			scoped = append(scoped, dir)
+		}
+	}
+
+	if !changed {
+		return nil
+	}
+	return scoped
+}
+
+// ValidateIssueDescription checks that a description parses as valid YAML
+// and contains the required top-level keys defined by the issue-format
+// constitution. Returns an error describing what is missing; callers
+// should log a warning but not block on validation failures.
+func ValidateIssueDescription(desc string) error {
+	if desc == "" {
+		return fmt.Errorf("empty description")
+	}
+
+	var parsed map[string]any
+	if err := yaml.Unmarshal([]byte(desc), &parsed); err != nil {
+		return fmt.Errorf("not valid YAML: %w", err)
+	}
+
+	required := []string{"deliverable_type", "required_reading", "files", "requirements", "acceptance_criteria"}
+	var missing []string
+	for _, key := range required {
+		if _, ok := parsed[key]; !ok {
+			missing = append(missing, key)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("missing required fields: %s", strings.Join(missing, ", "))
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Stitch git helpers (standalone functions using DI)
+// ---------------------------------------------------------------------------
+
+// StitchGitDeps holds git helper functions needed by stitch operations.
+type StitchGitDeps struct {
+	BranchExists      func(name, dir string) bool
+	CreateBranch      func(name, dir string) error
+	DeleteBranch      func(name, dir string) error
+	ForceDeleteBranch func(name, dir string) error
+	ListBranches      func(pattern, dir string) []string
+	WorktreeAdd       func(worktreeDir, branch, dir string) *exec.Cmd
+	WorktreeRemove    func(worktreeDir, dir string) error
+	WorktreePrune     func(dir string) error
+	Checkout          func(branch, dir string) error
+	CurrentBranch     func(dir string) (string, error)
+	MergeCmd          func(branch, dir string) *exec.Cmd
+	RevParseHEAD      func(dir string) (string, error)
+}
+
+// StitchIssueDeps holds GitHub issue helper functions needed by stitch.
+type StitchIssueDeps struct {
+	ListOpenCobblerIssues  func(repo, generation string) ([]StitchIssue, error)
+	PickReadyIssue         func(repo, generation string) (StitchIssue, error)
+	RemoveInProgressLabel  func(repo string, number int) error
+	HasLabel               func(issue StitchIssue, label string) bool
+	LabelInProgress        string
+}
+
+// StitchIssue is the minimal issue representation needed by stitch operations.
+type StitchIssue struct {
+	Number      int
+	Title       string
+	Description string
+	State       string
+	Labels      []string
+}
+
+// RecoverStaleBranches removes leftover task branches and worktrees,
+// removing the in-progress label from their issues. Returns true if any were recovered.
+func RecoverStaleBranches(baseBranch, worktreeBase, repo string, gitDeps StitchGitDeps, issueDeps StitchIssueDeps) bool {
+	branches := gitDeps.ListBranches(TaskBranchPattern(baseBranch), ".")
+	if len(branches) == 0 {
+		Log("recoverStaleBranches: no stale branches found")
+		return false
+	}
+
+	Log("recoverStaleBranches: found %d stale branch(es): %v", len(branches), branches)
+	for _, branch := range branches {
+		Log("recoverStaleBranches: recovering %s", branch)
+
+		issueID := strings.TrimPrefix(branch, "task/"+baseBranch+"-")
+		worktreeDir := filepath.Join(worktreeBase, issueID)
+
+		if _, err := os.Stat(worktreeDir); err == nil {
+			Log("recoverStaleBranches: removing worktree %s", worktreeDir)
+			if err := gitDeps.WorktreeRemove(worktreeDir, "."); err != nil {
+				Log("recoverStaleBranches: worktree remove warning: %v", err)
+			}
+		} else {
+			Log("recoverStaleBranches: no worktree at %s", worktreeDir)
+		}
+
+		Log("recoverStaleBranches: deleting branch %s", branch)
+		if err := gitDeps.ForceDeleteBranch(branch, "."); err != nil {
+			Log("recoverStaleBranches: branch delete warning: %v", err)
+		}
+
+		if issueID != "" {
+			var num int
+			if _, err := fmt.Sscanf(issueID, "%d", &num); err == nil && num > 0 {
+				Log("recoverStaleBranches: removing in-progress label from issue #%d", num)
+				if err := issueDeps.RemoveInProgressLabel(repo, num); err != nil {
+					Log("recoverStaleBranches: label removal warning: %v", err)
+				}
+			}
+		}
+	}
+	return true
+}
+
+// ResetOrphanedIssues finds in_progress GitHub issues with no corresponding
+// task branch and removes their in-progress label. Returns true if any were reset.
+func ResetOrphanedIssues(baseBranch, repo, generation string, gitDeps StitchGitDeps, issueDeps StitchIssueDeps) bool {
+	issues, err := issueDeps.ListOpenCobblerIssues(repo, generation)
+	if err != nil {
+		Log("resetOrphanedIssues: list issues failed: %v", err)
+		return false
+	}
+
+	recovered := false
+	for _, iss := range issues {
+		if !issueDeps.HasLabel(iss, issueDeps.LabelInProgress) {
+			continue
+		}
+		id := fmt.Sprintf("%d", iss.Number)
+		taskBranch := TaskBranchName(baseBranch, id)
+		if !gitDeps.BranchExists(taskBranch, ".") {
+			recovered = true
+			Log("resetOrphanedIssues: orphaned issue #%d (no branch %s), removing in-progress label", iss.Number, taskBranch)
+			if err := issueDeps.RemoveInProgressLabel(repo, iss.Number); err != nil {
+				Log("resetOrphanedIssues: label removal warning for #%d: %v", iss.Number, err)
+			}
+		} else {
+			Log("resetOrphanedIssues: issue #%d has branch %s, skipping", iss.Number, taskBranch)
+		}
+	}
+	return recovered
+}
+
+// PickTask selects the next ready task from GitHub Issues.
+func PickTask(baseBranch, worktreeBase, repo, generation string, issueDeps StitchIssueDeps) (StitchTask, error) {
+	Log("pickTask: calling pickReadyIssue repo=%s generation=%s", repo, generation)
+	iss, err := issueDeps.PickReadyIssue(repo, generation)
+	if err != nil {
+		Log("pickTask: no tasks available: %v", err)
+		return StitchTask{}, fmt.Errorf("no tasks available")
+	}
+
+	id := fmt.Sprintf("%d", iss.Number)
+	task := StitchTask{
+		ID:          id,
+		Title:       iss.Title,
+		Description: iss.Description,
+		IssueType:   "task",
+		BranchName:  TaskBranchName(baseBranch, id),
+		WorktreeDir: filepath.Join(worktreeBase, id),
+		GhNumber:    iss.Number,
+		Generation:  generation,
+		Repo:        repo,
+	}
+
+	// Validate the issue description as YAML with required fields.
+	if err := ValidateIssueDescription(task.Description); err != nil {
+		Log("pickTask: description validation warning: %v", err)
+	}
+
+	Log("pickTask: picked #%d id=%s branch=%s worktree=%s", iss.Number, task.ID, task.BranchName, task.WorktreeDir)
+	Log("pickTask: title=%q", task.Title)
+	Log("pickTask: descriptionLen=%d", len(task.Description))
+	return task, nil
+}
+
+// CreateWorktree creates a git worktree for the given task.
+func CreateWorktree(task StitchTask, gitDeps StitchGitDeps) error {
+	Log("createWorktree: dir=%s branch=%s", task.WorktreeDir, task.BranchName)
+
+	if err := os.MkdirAll(filepath.Dir(task.WorktreeDir), 0o755); err != nil {
+		return fmt.Errorf("creating worktree parent directory: %w", err)
+	}
+
+	if !gitDeps.BranchExists(task.BranchName, ".") {
+		Log("createWorktree: branch %s does not exist, creating", task.BranchName)
+		if err := gitDeps.CreateBranch(task.BranchName, "."); err != nil {
+			Log("createWorktree: gitCreateBranch failed: %v", err)
+			return fmt.Errorf("creating branch %s: %w", task.BranchName, err)
+		}
+		Log("createWorktree: branch %s created", task.BranchName)
+	} else {
+		Log("createWorktree: branch %s already exists", task.BranchName)
+	}
+
+	Log("createWorktree: adding worktree")
+	cmd := gitDeps.WorktreeAdd(task.WorktreeDir, task.BranchName, ".")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		Log("createWorktree: worktree add failed: %v", err)
+		return fmt.Errorf("adding worktree: %w", err)
+	}
+
+	Log("createWorktree: worktree ready at %s on branch %s", task.WorktreeDir, task.BranchName)
+	return nil
+}
+
+// CleanGoBinaries removes untracked executable files with no extension from
+// dir before staging. Go binaries produced by `go build ./cmd/<name>/` land
+// in the working directory as extensionless executables; this prevents them
+// from being committed to the generation branch (GH-456).
+func CleanGoBinaries(dir string) {
+	cmd := exec.Command(BinGit, "ls-files", "--others", "--exclude-standard")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		Log("cleanGoBinaries: git ls-files: %v", err)
+		return
+	}
+
+	removed := 0
+	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if name == "" || filepath.Ext(name) != "" {
+			continue // skip empty lines and files with extensions
+		}
+		path := filepath.Join(dir, name)
+		info, err := os.Stat(path)
+		if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
+			continue // skip missing, directories, and non-executables
+		}
+		if err := os.Remove(path); err != nil {
+			Log("cleanGoBinaries: remove %s: %v", name, err)
+		} else {
+			Log("cleanGoBinaries: removed binary %s", name)
+			removed++
+		}
+	}
+	Log("cleanGoBinaries: removed %d binary file(s)", removed)
+}
+
+// CommitWorktreeChanges stages and commits all changes Claude made in the
+// worktree. Claude does not run git commands; the orchestrator handles git
+// externally. Returns nil if there are no changes to commit.
+func CommitWorktreeChanges(task StitchTask) error {
+	Log("commitWorktreeChanges: staging changes in %s", task.WorktreeDir)
+
+	// Remove compiled Go binaries before staging so they are not committed.
+	CleanGoBinaries(task.WorktreeDir)
+
+	addCmd := exec.Command(BinGit, "add", "-A")
+	addCmd.Dir = task.WorktreeDir
+	if out, err := addCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git add -A: %w\n%s", err, out)
+	}
+
+	// Check if there are staged changes to commit.
+	diffCmd := exec.Command(BinGit, "diff", "--cached", "--quiet")
+	diffCmd.Dir = task.WorktreeDir
+	if diffCmd.Run() == nil {
+		Log("commitWorktreeChanges: no changes to commit for %s", task.ID)
+		return nil
+	}
+
+	msg := fmt.Sprintf("Task %s: %s", task.ID, task.Title)
+	Log("commitWorktreeChanges: committing %q", msg)
+	commitCmd := exec.Command(BinGit, "commit", "--no-verify", "-m", msg)
+	commitCmd.Dir = task.WorktreeDir
+	if out, err := commitCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git commit: %w\n%s", err, out)
+	}
+
+	Log("commitWorktreeChanges: committed in worktree for %s", task.ID)
+	return nil
+}
+
+// MergeBranch merges the task branch into the base branch.
+func MergeBranch(branchName, baseBranch, repoRoot string, gitDeps StitchGitDeps) error {
+	Log("mergeBranch: %s into %s (repoRoot=%s)", branchName, baseBranch, repoRoot)
+
+	Log("mergeBranch: checking out %s", baseBranch)
+	if err := gitDeps.Checkout(baseBranch, "."); err != nil {
+		Log("mergeBranch: checkout failed: %v", err)
+		return fmt.Errorf("checking out %s: %w", baseBranch, err)
+	}
+	Log("mergeBranch: checked out %s", baseBranch)
+
+	Log("mergeBranch: merging %s", branchName)
+	cmd := gitDeps.MergeCmd(branchName, ".")
+	cmd.Dir = repoRoot
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		Log("mergeBranch: merge failed: %v", err)
+		return fmt.Errorf("merging %s: %w", branchName, err)
+	}
+
+	Log("mergeBranch: merge successful")
+	return nil
+}
+
+// CleanupWorktree removes the worktree and its branch. Returns true if the
+// worktree was removed successfully, false if removal failed (branch is left
+// intact to avoid orphaning the worktree).
+func CleanupWorktree(task StitchTask, gitDeps StitchGitDeps) bool {
+	Log("cleanupWorktree: removing worktree %s", task.WorktreeDir)
+	if err := gitDeps.WorktreeRemove(task.WorktreeDir, "."); err != nil {
+		Log("cleanupWorktree: worktree remove failed, skipping branch delete: %v", err)
+		return false
+	}
+
+	Log("cleanupWorktree: deleting branch %s", task.BranchName)
+	if err := gitDeps.DeleteBranch(task.BranchName, "."); err != nil {
+		Log("cleanupWorktree: branch delete warning: %v", err)
+	}
+
+	Log("cleanupWorktree: done for task %s", task.ID)
+	return true
+}

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -8,8 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
-	"sort"
 	"strings"
 	"time"
 
@@ -115,16 +113,12 @@ func (o *Orchestrator) RunMeasure() error {
 	o.RunPreCycleAnalysis()
 
 	// Warn about PRD requirement groups whose sub-item count exceeds
-	// max_requirements_per_task. This is advisory — measure continues
-	// regardless so the operator can restructure PRDs later.
+	// max_requirements_per_task.
 	if o.cfg.Cobbler.MaxRequirementsPerTask > 0 {
 		warnOversizedGroups(o.cfg.Cobbler.MaxRequirementsPerTask)
 	}
 
 	// Route target-repo defects to the target repo (prd003 R11).
-	// Schema errors and constitution drift are bugs in the target project's
-	// files; filing them as GitHub issues prevents Claude from proposing them
-	// as measure tasks, which would fail validation and block the cycle.
 	if analysis := loadAnalysisDoc(o.cfg.Cobbler.Dir); analysis != nil && len(analysis.Defects) > 0 {
 		if targetRepo := resolveTargetRepo(o.cfg); targetRepo != "" {
 			logf("measure: filing %d defect(s) as bug issues in %s", len(analysis.Defects), targetRepo)
@@ -155,8 +149,6 @@ func (o *Orchestrator) RunMeasure() error {
 	logf("locBefore prod=%d test=%d", locBefore.Production, locBefore.Test)
 
 	// Iterative measure: call Claude once per issue with limit=1.
-	// Between calls, import the result into GitHub Issues and refresh the issue list
-	// so subsequent calls see existing issues and avoid duplicates.
 	totalIssues := o.cfg.Cobbler.MaxMeasureIssues
 	var allCreatedIDs []string
 	var totalTokens ClaudeResult
@@ -165,8 +157,7 @@ func (o *Orchestrator) RunMeasure() error {
 	for i := 0; i < totalIssues; i++ {
 		logf("--- iteration %d/%d ---", i+1, totalIssues)
 
-		// Refresh existing issues from GitHub before each call (except the first,
-		// where we already have them).
+		// Refresh existing issues from GitHub before each call (except the first).
 		if i > 0 {
 			refreshed, refreshErr := listActiveIssuesContext(repo, generation)
 			if refreshErr != nil {
@@ -177,10 +168,6 @@ func (o *Orchestrator) RunMeasure() error {
 		}
 
 		// Create a placeholder issue so users can see measure is running Claude.
-		// The placeholder has no cobbler labels and is invisible to stitch and to
-		// the measure context prompt. It is closed after the iteration regardless
-		// of outcome (GH-568). The defer below closes it on any early-return path
-		// (e.g. Claude failure) so it never stays open as an orphan (GH-747).
 		placeholderNum, placeholderErr := createMeasuringPlaceholder(repo, generation, i+1)
 		if placeholderErr != nil {
 			logf("measure: warning: createMeasuringPlaceholder: %v", placeholderErr)
@@ -321,14 +308,10 @@ func (o *Orchestrator) RunMeasure() error {
 		}
 
 		// Close the placeholder only when it was not upgraded in-place (GH-578).
-		// An upgraded placeholder became the task issue; closing it destroys the task.
-		// Mark placeholderResolved so the defer registered above is a no-op (GH-747).
 		placeholderResolved = true
 		if placeholderNum > 0 && !placeholderUpgraded {
 			closeMeasuringPlaceholder(repo, placeholderNum)
 		}
-
-		// Record invocation metrics on each created issue.
 
 		allCreatedIDs = append(allCreatedIDs, createdIDs...)
 
@@ -342,15 +325,6 @@ func (o *Orchestrator) RunMeasure() error {
 	logf("completed %d iteration(s), %d issue(s) created in %s",
 		totalIssues, len(allCreatedIDs), time.Since(measureStart).Round(time.Second))
 	return nil
-}
-
-// truncateSHA returns the first 8 characters of a SHA, or the full
-// string if shorter.
-func truncateSHA(sha string) string {
-	if len(sha) > 8 {
-		return sha[:8]
-	}
-	return sha
 }
 
 func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limit int, validationErrors ...string) (string, error) {
@@ -374,8 +348,6 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 	}
 
 	// Apply CobblerConfig measure source settings to phaseCtx (GH-565).
-	// Config values are overridden only when the phaseCtx file has not
-	// already set the field (file-level wins over config-level).
 	if phaseCtx == nil {
 		phaseCtx = &PhaseContext{}
 	}
@@ -387,14 +359,10 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 		phaseCtx.SourcePatterns = o.cfg.Cobbler.MeasureSourcePatterns
 		logf("buildMeasurePrompt: measure_source_patterns set from config")
 	}
-	// Apply test exclusion setting (GH-616). Default true; file-level wins
-	// when already set to true by the phaseCtx file.
 	if o.cfg.Cobbler.effectiveMeasureExcludeTests() && !phaseCtx.ExcludeTests {
 		phaseCtx.ExcludeTests = true
 		logf("buildMeasurePrompt: measure_exclude_tests=true, _test.go files will be excluded")
 	}
-	// Wire source summarization mode (GH-617, prd003 R12). Config wins when
-	// the phaseCtx file has not already set the mode (file-level wins).
 	if o.cfg.Cobbler.MeasureSourceMode != "" && phaseCtx.SourceMode == "" {
 		phaseCtx.SourceMode = o.cfg.Cobbler.MeasureSourceMode
 		logf("buildMeasurePrompt: measure_source_mode=%q from config", phaseCtx.SourceMode)
@@ -440,9 +408,7 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 		"max_requirements": fmt.Sprintf("%d", o.cfg.Cobbler.MaxRequirementsPerTask),
 	}
 
-	// Inject package_contracts when source mode is "headers" or "custom"
-	// and any PRD declares a package_contract. The contracts give the
-	// measure agent structured API context alongside (or instead of) source.
+	// Inject package_contracts when source mode is "headers" or "custom".
 	var measureContracts []OODPackageContractRef
 	sourceMode := phaseCtx.SourceMode
 	if sourceMode == "headers" || sourceMode == "custom" {
@@ -467,12 +433,7 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 		PackageContracts:        measureContracts,
 	}
 
-	// Enforce releases scope: the roadmap is not filtered by release, so
-	// without an explicit constraint the agent may propose tasks from adjacent
-	// releases after exhausting the configured ones.
-	// Filter out releases already marked as implemented in road-map.yaml so a
-	// stale releases config value does not direct Claude to re-implement work
-	// that is already done (GH-847).
+	// Enforce releases scope.
 	activeReleases := filterImplementedReleases(o.cfg.Project.Releases)
 	activeRelease := filterImplementedRelease(o.cfg.Project.Release)
 	doc.Constraints += measureReleasesConstraint(activeReleases, activeRelease)
@@ -487,86 +448,14 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 	return string(out), nil
 }
 
-// measureReleasesConstraint returns a hard constraint string to append to the
-// measure prompt when a release scope is configured. Returns "" when no scope
-// is set. Releases (list) takes precedence over Release (single string).
-func measureReleasesConstraint(releases []string, release string) string {
-	if len(releases) > 0 {
-		return fmt.Sprintf(
-			"\n\nRelease scope: You MUST only propose tasks for use cases in releases [%s]. Do not propose tasks for any other release.",
-			strings.Join(releases, ", "),
-		)
-	}
-	if release != "" {
-		return fmt.Sprintf(
-			"\n\nRelease scope: You MUST only propose tasks for use cases in release %q or earlier. Do not propose tasks for later releases.",
-			release,
-		)
-	}
-	return ""
-}
-
-// filterImplementedReleases returns a copy of releases with any entry whose
-// road-map status is "implemented" or "done" removed. Releases not found in
-// road-map.yaml are kept (unknown status is not treated as implemented).
-// Returns nil when all releases are filtered out.
-func filterImplementedReleases(releases []string) []string {
-	if len(releases) == 0 {
-		return releases
-	}
-	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
-	if rm == nil {
-		return releases
-	}
-	status := make(map[string]string, len(rm.Releases))
-	for _, rel := range rm.Releases {
-		status[rel.Version] = rel.Status
-	}
-	var out []string
-	for _, r := range releases {
-		if ucStatusDone(status[r]) {
-			logf("filterImplementedReleases: dropping implemented release %s from constraint", r)
-			continue
-		}
-		out = append(out, r)
-	}
-	return out
-}
-
-// filterImplementedRelease returns the release string unchanged unless the
-// road-map marks that release as implemented/done, in which case "" is
-// returned so no legacy single-release constraint is emitted.
-func filterImplementedRelease(release string) string {
-	if release == "" {
-		return ""
-	}
-	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
-	if rm == nil {
-		return release
-	}
-	for _, rel := range rm.Releases {
-		if rel.Version == release && ucStatusDone(rel.Status) {
-			logf("filterImplementedRelease: dropping implemented release %s from constraint", release)
-			return ""
-		}
-	}
-	return release
-}
-
 // proposedIssue is aliased from internal/github in issues_gh.go.
 
-// importIssues imports proposed issues from a YAML file into GitHub. It returns
-// the created issue IDs, any validation error strings (for retry feedback), and
-// a non-nil error when validation fails in enforcing mode. ph is the measuring
-// placeholder issue number; when ph > 0 and exactly one issue is proposed, the
-// placeholder is upgraded in-place instead of creating a new issue (GH-578).
+// importIssues imports proposed issues from a YAML file into GitHub.
 func (o *Orchestrator) importIssues(yamlFile, repo, generation string, ph int) ([]string, []string, error) {
 	return o.importIssuesImpl(yamlFile, repo, generation, false, ph)
 }
 
-// importIssuesForce imports issues bypassing enforcing validation. Used when
-// retries are exhausted to accept the last result with warnings (R5). ph is
-// the placeholder number passed through to importIssuesImpl (GH-578).
+// importIssuesForce imports issues bypassing enforcing validation.
 func (o *Orchestrator) importIssuesForce(yamlFile, repo, generation string, ph int) ([]string, error) {
 	ids, _, err := o.importIssuesImpl(yamlFile, repo, generation, true, ph)
 	return ids, err
@@ -591,8 +480,7 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 		logf("importIssues: [%d] title=%q dep=%d", i, issue.Title, issue.Dependency)
 	}
 
-	// Validate proposed issues against P9/P7 rules. Load PRD sub-item
-	// counts so the validator can expand group references (GH-122).
+	// Validate proposed issues against P9/P7 rules.
 	subItemCounts := loadPRDSubItemCounts()
 	vr := validateMeasureOutput(issues, o.cfg.Cobbler.MaxRequirementsPerTask, subItemCounts)
 	if len(vr.Warnings) > 0 {
@@ -605,8 +493,6 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 
 	// Deduplicate: fetch existing issues for this generation and skip any
 	// proposed issue whose normalized title matches a closed one (GH-1026).
-	// Only dedup when the generation has open issues — indicates an active run.
-	// If all issues are closed, this is likely a fresh start on the same branch.
 	closedTitles := make(map[string]int) // normalized title → issue number
 	if existing, err := listAllCobblerIssues(repo, generation); err == nil {
 		hasOpen := false
@@ -635,9 +521,7 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 	}
 	issues = filtered
 
-	// Create all issues on GitHub. When a placeholder number is given and exactly
-	// one issue is proposed, upgrade the placeholder in-place instead of creating
-	// a new issue, eliminating the two-issue dance (GH-578).
+	// Create all issues on GitHub.
 	var ids []string
 	upgraded := false
 	if ph > 0 && len(issues) == 1 {
@@ -674,227 +558,8 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 	return ids, nil, nil
 }
 
-// issueDescription is the subset of fields parsed from an issue description
-// YAML for advisory validation.
-type issueDescription struct {
-	DeliverableType    string              `yaml:"deliverable_type"`
-	Files              []issueDescFile     `yaml:"files"`
-	Requirements       []issueDescItem     `yaml:"requirements"`
-	AcceptanceCriteria []issueDescItem     `yaml:"acceptance_criteria"`
-	DesignDecisions    []issueDescItem     `yaml:"design_decisions"`
-}
-
-type issueDescFile struct {
-	Path string `yaml:"path"`
-}
-
-type issueDescItem struct {
-	ID   string `yaml:"id"`
-	Text string `yaml:"text"`
-}
-
-// validationResult holds the outcome of measure output validation.
-type validationResult struct {
-	Warnings []string // advisory issues (logged but do not block import)
-	Errors   []string // blocking issues (cause rejection in enforcing mode)
-}
-
-// HasErrors returns true if the validation found blocking issues.
-func (v validationResult) HasErrors() bool {
-	return len(v.Errors) > 0
-}
-
-// validateMeasureOutput checks proposed issues against P9 granularity ranges
-// and P7 file naming conventions. Returns structured warnings and errors.
-// All issues are logged regardless of enforcing mode. maxReqs is the
-// operator-configured requirement cap (0 = unlimited). subItemCounts maps
-// PRD stems to group IDs to sub-item counts; when a task requirement
-// references a PRD group, the expanded sub-item count is used instead of 1.
-// Expanded-count violations are logged as warnings (best-effort), not errors.
-func validateMeasureOutput(issues []proposedIssue, maxReqs int, subItemCounts map[string]map[string]int) validationResult {
-	var result validationResult
-	for _, issue := range issues {
-		var desc issueDescription
-		if err := yaml.Unmarshal([]byte(issue.Description), &desc); err != nil {
-			msg := fmt.Sprintf("[%d] %q: could not parse description: %v", issue.Index, issue.Title, err)
-			logf("validateMeasureOutput: %s", msg)
-			result.Warnings = append(result.Warnings, msg)
-			continue
-		}
-
-		rCount := len(desc.Requirements)
-		acCount := len(desc.AcceptanceCriteria)
-		dCount := len(desc.DesignDecisions)
-
-		// Compute expanded requirement count by resolving PRD group
-		// references to their sub-item counts (GH-122).
-		expandedCount := expandedRequirementCount(desc.Requirements, subItemCounts)
-
-		// Enforce max_requirements_per_task on the expanded sub-item count,
-		// not the top-level group count (GH-535). A requirement referencing
-		// "prd003 R2" where R2 has 10 sub-items counts as 10, not 1.
-		if maxReqs > 0 && expandedCount > maxReqs {
-			msg := fmt.Sprintf("[%d] %q: expanded sub-item count is %d, max is %d", issue.Index, issue.Title, expandedCount, maxReqs)
-			logf("validateMeasureOutput: %s", msg)
-			result.Errors = append(result.Errors, msg)
-		}
-
-		if desc.DeliverableType == "code" {
-			if rCount < 5 || rCount > 8 {
-				msg := fmt.Sprintf("[%d] %q: requirement count %d outside P9 range 5-8", issue.Index, issue.Title, rCount)
-				logf("validateMeasureOutput: %s", msg)
-				result.Errors = append(result.Errors, msg)
-			}
-			if acCount < 5 || acCount > 8 {
-				msg := fmt.Sprintf("[%d] %q: acceptance criteria count %d outside P9 range 5-8", issue.Index, issue.Title, acCount)
-				logf("validateMeasureOutput: %s", msg)
-				result.Errors = append(result.Errors, msg)
-			}
-			if dCount < 3 || dCount > 5 {
-				msg := fmt.Sprintf("[%d] %q: design decision count %d outside P9 range 3-5", issue.Index, issue.Title, dCount)
-				logf("validateMeasureOutput: %s", msg)
-				result.Errors = append(result.Errors, msg)
-			}
-		} else if desc.DeliverableType == "documentation" {
-			if rCount < 2 || rCount > 4 {
-				msg := fmt.Sprintf("[%d] %q: requirement count %d outside P9 doc range 2-4", issue.Index, issue.Title, rCount)
-				logf("validateMeasureOutput: %s", msg)
-				result.Errors = append(result.Errors, msg)
-			}
-			if acCount < 3 || acCount > 5 {
-				msg := fmt.Sprintf("[%d] %q: acceptance criteria count %d outside P9 doc range 3-5", issue.Index, issue.Title, acCount)
-				logf("validateMeasureOutput: %s", msg)
-				result.Errors = append(result.Errors, msg)
-			}
-		}
-
-		// Check for P7 violation: file named after its package.
-		for _, f := range desc.Files {
-			parts := strings.Split(f.Path, "/")
-			if len(parts) >= 2 {
-				dir := parts[len(parts)-2]
-				file := parts[len(parts)-1]
-				if file == dir+".go" || file == dir+"_test.go" {
-					msg := fmt.Sprintf("[%d] %q: file %s matches package name (P7 violation)", issue.Index, issue.Title, f.Path)
-					logf("validateMeasureOutput: %s", msg)
-					result.Errors = append(result.Errors, msg)
-				}
-			}
-		}
-	}
-	return result
-}
-
-// prdRefPattern matches PRD requirement references in task requirement text.
-// Examples: "prd003 R2", "prd004-ts R1.3", "prd001-orchestrator-core R5".
-// Group 1 = PRD stem (e.g., "prd003" or "prd004-ts").
-// Group 2 = requirement group number (e.g., "2" from "R2").
-// Group 3 = optional sub-item number (e.g., "3" from "R1.3"); empty for groups.
-var prdRefPattern = regexp.MustCompile(`(prd\d+[-\w]*)\s+R(\d+)(?:\.(\d+))?`)
-
-// loadPRDSubItemCounts loads all PRDs from the standard path and returns a
-// map of PRD stem -> group key -> sub-item count. A group with no sub-items
-// maps to 1. The stem is the filename without path and extension (e.g.,
-// "prd003-cobbler-workflows"); an additional entry keyed by the short prefix
-// (e.g., "prd003") is added for fuzzy matching.
-func loadPRDSubItemCounts() map[string]map[string]int {
-	paths, _ := filepath.Glob("docs/specs/product-requirements/prd*.yaml")
-	counts := make(map[string]map[string]int, len(paths)*2)
-	for _, path := range paths {
-		prd := loadYAML[PRDDoc](path)
-		if prd == nil {
-			continue
-		}
-		stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
-		groupCounts := make(map[string]int, len(prd.Requirements))
-		for key, group := range prd.Requirements {
-			if len(group.Items) > 0 {
-				groupCounts[key] = len(group.Items)
-			} else {
-				groupCounts[key] = 1
-			}
-		}
-		counts[stem] = groupCounts
-		// Add short prefix entry (e.g., "prd003") for fuzzy matching.
-		if idx := strings.IndexByte(stem, '-'); idx > 0 {
-			short := stem[:idx]
-			if _, exists := counts[short]; !exists {
-				counts[short] = groupCounts
-			}
-		}
-	}
-	return counts
-}
-
-// expandedRequirementCount computes the effective requirement count by
-// parsing PRD group references from each requirement's text and expanding
-// groups to their sub-item counts. A requirement referencing "prd003 R2"
-// where R2 has 4 sub-items counts as 4, not 1. Requirements without a
-// recognized PRD reference or referencing a specific sub-item (R1.3)
-// count as 1.
-func expandedRequirementCount(reqs []issueDescItem, subItemCounts map[string]map[string]int) int {
-	if len(subItemCounts) == 0 {
-		return len(reqs)
-	}
-	total := 0
-	for _, req := range reqs {
-		matches := prdRefPattern.FindStringSubmatch(req.Text)
-		if matches == nil {
-			total++
-			continue
-		}
-		prdStem := matches[1]
-		groupNum := matches[2]
-		subItem := matches[3]
-
-		// Specific sub-item reference (e.g., R1.3) counts as 1.
-		if subItem != "" {
-			total++
-			continue
-		}
-
-		// Group reference (e.g., R2). Look up sub-item count.
-		groupKey := "R" + groupNum
-		if groups, ok := subItemCounts[prdStem]; ok {
-			if count, found := groups[groupKey]; found {
-				total += count
-				continue
-			}
-		}
-		// PRD or group not found — count as 1.
-		total++
-	}
-	return total
-}
-
-// warnOversizedGroups loads PRDs and logs a warning for each requirement
-// group whose sub-item count exceeds maxReqs. This is advisory and runs
-// before the measure prompt is built so operators can restructure PRDs.
-func warnOversizedGroups(maxReqs int) {
-	paths, _ := filepath.Glob("docs/specs/product-requirements/prd*.yaml")
-	for _, path := range paths {
-		prd := loadYAML[PRDDoc](path)
-		if prd == nil {
-			continue
-		}
-		stem := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
-		keys := make([]string, 0, len(prd.Requirements))
-		for k := range prd.Requirements {
-			keys = append(keys, k)
-		}
-		sort.Strings(keys)
-		for _, key := range keys {
-			group := prd.Requirements[key]
-			if len(group.Items) > maxReqs {
-				logf("warning: %s %s has %d sub-items (max_requirements_per_task=%d); consider splitting this requirement group",
-					stem, key, len(group.Items), maxReqs)
-			}
-		}
-	}
-}
-
 // saveHistory persists measure artifacts (log, issues YAML) to the configured
-// history directory. The prompt is saved separately before runClaude.
+// history directory.
 func (o *Orchestrator) saveHistory(ts string, rawOutput []byte, issuesFile string) {
 	o.saveHistoryLog(ts, "measure", rawOutput)
 
@@ -908,30 +573,4 @@ func (o *Orchestrator) saveHistory(ts string, rawOutput []byte, issuesFile strin
 			logf("saveHistory: write issues: %v", err)
 		}
 	}
-}
-
-// appendMeasureLog merges newIssues into the persistent measure.yaml list.
-// measure.yaml is a single growing YAML list of all issues proposed across runs.
-func appendMeasureLog(cobblerDir string, newIssues []proposedIssue) {
-	logPath := filepath.Join(cobblerDir, "measure.yaml")
-
-	var existing []proposedIssue
-	if data, err := os.ReadFile(logPath); err == nil {
-		if err := yaml.Unmarshal(data, &existing); err != nil {
-			logf("appendMeasureLog: could not parse existing list, starting fresh: %v", err)
-			existing = nil
-		}
-	}
-
-	combined := append(existing, newIssues...)
-	out, err := yaml.Marshal(combined)
-	if err != nil {
-		logf("appendMeasureLog: marshal failed: %v", err)
-		return
-	}
-	if err := os.WriteFile(logPath, out, 0o644); err != nil {
-		logf("appendMeasureLog: write failed: %v", err)
-		return
-	}
-	logf("appendMeasureLog: %d total issues in %s", len(combined), logPath)
 }

--- a/pkg/orchestrator/prompt_test.go
+++ b/pkg/orchestrator/prompt_test.go
@@ -276,11 +276,11 @@ func TestMeasurePromptSourceCodeOverProseConstraint(t *testing.T) {
 func TestStitchPromptIsValidYAML(t *testing.T) {
 	o := New(Config{})
 	task := stitchTask{
-		id:          "test-001",
-		title:       "Test task",
-		issueType:   "task",
-		description: "A test description.",
-		worktreeDir: "/tmp",
+		ID:          "test-001",
+		Title:       "Test task",
+		IssueType:   "task",
+		Description: "A test description.",
+		WorktreeDir: "/tmp",
 	}
 
 	prompt, err := o.buildStitchPrompt(task)
@@ -297,11 +297,11 @@ func TestStitchPromptIsValidYAML(t *testing.T) {
 func TestStitchPromptIncludesExecutionConstitution(t *testing.T) {
 	o := New(Config{})
 	task := stitchTask{
-		id:          "test-001",
-		title:       "Test task",
-		issueType:   "task",
-		description: "A test description.",
-		worktreeDir: "/tmp",
+		ID:          "test-001",
+		Title:       "Test task",
+		IssueType:   "task",
+		Description: "A test description.",
+		WorktreeDir: "/tmp",
 	}
 
 	prompt, err := o.buildStitchPrompt(task)
@@ -320,11 +320,11 @@ func TestStitchPromptIncludesExecutionConstitution(t *testing.T) {
 func TestStitchPromptIncludesTaskContext(t *testing.T) {
 	o := New(Config{})
 	task := stitchTask{
-		id:          "task-123",
-		title:       "Implement feature X",
-		issueType:   "task",
-		description: "Detailed requirements here.",
-		worktreeDir: "/tmp",
+		ID:          "task-123",
+		Title:       "Implement feature X",
+		IssueType:   "task",
+		Description: "Detailed requirements here.",
+		WorktreeDir: "/tmp",
 	}
 
 	prompt, err := o.buildStitchPrompt(task)
@@ -346,11 +346,11 @@ func TestStitchPromptIncludesTaskContext(t *testing.T) {
 func TestStitchPromptIncludesGoStyleConstitution(t *testing.T) {
 	o := New(Config{})
 	task := stitchTask{
-		id:          "test-001",
-		title:       "Test task",
-		issueType:   "task",
-		description: "A test description.",
-		worktreeDir: "/tmp",
+		ID:          "test-001",
+		Title:       "Test task",
+		IssueType:   "task",
+		Description: "A test description.",
+		WorktreeDir: "/tmp",
 	}
 
 	prompt, err := o.buildStitchPrompt(task)
@@ -490,9 +490,9 @@ shared_protocols:
 
 	o := New(Config{})
 	task := stitchTask{
-		id:        "test-ood",
-		title:     "Implement ls",
-		issueType: "code",
+		ID:        "test-ood",
+		Title:     "Implement ls",
+		IssueType: "code",
 	}
 	out, err := o.buildStitchPrompt(task)
 	if err != nil {
@@ -522,7 +522,7 @@ package_contract:
 `), 0o644)
 
 	o := New(Config{})
-	task := stitchTask{id: "t1", title: "impl", issueType: "code"}
+	task := stitchTask{ID: "t1", Title: "impl", IssueType: "code"}
 	out, err := o.buildStitchPrompt(task)
 	if err != nil {
 		t.Fatalf("buildStitchPrompt: %v", err)

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -8,19 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"sort"
 	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
-
-// errTaskReset is returned by doOneTask when a task fails but the stitch
-// loop should continue to the next task (e.g., Claude failure, worktree
-// commit failure, merge failure). The task has been reset to open.
-var errTaskReset = errors.New("task reset to open")
 
 //go:embed prompts/stitch.yaml
 var defaultStitchPrompt string
@@ -39,9 +32,6 @@ func (o *Orchestrator) Stitch() error {
 }
 
 // RunStitch runs the stitch workflow using Config settings.
-// It processes up to MaxStitchIssuesPerCycle tasks and returns the count
-// of tasks completed. The caller (RunCycles) uses this to track the
-// total across all cycles against MaxStitchIssues.
 func (o *Orchestrator) RunStitch() (int, error) {
 	return o.RunStitchN(o.cfg.Cobbler.MaxStitchIssuesPerCycle)
 }
@@ -121,8 +111,6 @@ func (o *Orchestrator) RunStitchN(limit int) (int, error) {
 
 	totalTasks := 0
 	// failedTaskIDs tracks tasks that returned errTaskReset in this cycle.
-	// A task whose in-progress label is removed is re-eligible immediately,
-	// so without this set the stitch loop retries the same task indefinitely.
 	failedTaskIDs := map[string]struct{}{}
 	for {
 		if limit > 0 && totalTasks >= limit {
@@ -137,55 +125,30 @@ func (o *Orchestrator) RunStitchN(limit int) (int, error) {
 			break
 		}
 
-		// If this task already failed in the current cycle, stop. It was
-		// reset to open and will be retried in the next measure+stitch cycle.
-		if _, alreadyFailed := failedTaskIDs[task.id]; alreadyFailed {
-			logf("task %s already failed this cycle, stopping stitch", task.id)
+		// If this task already failed in the current cycle, stop.
+		if _, alreadyFailed := failedTaskIDs[task.ID]; alreadyFailed {
+			logf("task %s already failed this cycle, stopping stitch", task.ID)
 			break
 		}
 
 		taskStart := time.Now()
-		logf("executing task %d: id=%s title=%q", totalTasks+1, task.id, task.title)
+		logf("executing task %d: id=%s title=%q", totalTasks+1, task.ID, task.Title)
 		if err := o.doOneTask(task, baseBranch, repoRoot); err != nil {
 			if errors.Is(err, errTaskReset) {
-				logf("task %s was reset after %s, continuing", task.id, time.Since(taskStart).Round(time.Second))
-				failedTaskIDs[task.id] = struct{}{}
+				logf("task %s was reset after %s, continuing", task.ID, time.Since(taskStart).Round(time.Second))
+				failedTaskIDs[task.ID] = struct{}{}
 				continue
 			}
-			logf("task %s failed after %s: %v", task.id, time.Since(taskStart).Round(time.Second), err)
-			return totalTasks, fmt.Errorf("executing task %s: %w", task.id, err)
+			logf("task %s failed after %s: %v", task.ID, time.Since(taskStart).Round(time.Second), err)
+			return totalTasks, fmt.Errorf("executing task %s: %w", task.ID, err)
 		}
-		logf("task %s completed in %s", task.id, time.Since(taskStart).Round(time.Second))
+		logf("task %s completed in %s", task.ID, time.Since(taskStart).Round(time.Second))
 
 		totalTasks++
 	}
 
 	logf("completed %d task(s) in %s", totalTasks, time.Since(stitchStart).Round(time.Second))
 	return totalTasks, nil
-}
-
-// taskBranchName returns the git branch name for a stitch task.
-// Uses "task/<base>-<id>" instead of "<base>/task/<id>" to avoid
-// ref conflicts when the base branch is "main".
-func taskBranchName(baseBranch, issueID string) string {
-	return "task/" + baseBranch + "-" + issueID
-}
-
-// taskBranchPattern returns the glob pattern for listing task branches.
-func taskBranchPattern(baseBranch string) string {
-	return "task/" + baseBranch + "-*"
-}
-
-type stitchTask struct {
-	id          string // cobbler_index as string — used for branch/worktree naming
-	title       string
-	description string
-	issueType   string
-	branchName  string
-	worktreeDir string
-	ghNumber    int    // GitHub issue number — used for closing/labelling
-	generation  string // generation label value
-	repo        string // GitHub owner/repo
 }
 
 // recoverStaleTasks cleans up task branches and orphaned in_progress issues
@@ -211,234 +174,14 @@ func (o *Orchestrator) recoverStaleTasks(baseBranch, worktreeBase, repo, generat
 	return nil
 }
 
-// recoverStaleBranches removes leftover task branches and worktrees,
-// removing the in-progress label from their issues. Returns true if any were recovered.
-func recoverStaleBranches(baseBranch, worktreeBase, repo string) bool {
-	branches := gitListBranches(taskBranchPattern(baseBranch), ".")
-	if len(branches) == 0 {
-		logf("recoverStaleBranches: no stale branches found")
-		return false
-	}
-
-	logf("recoverStaleBranches: found %d stale branch(es): %v", len(branches), branches)
-	for _, branch := range branches {
-		logf("recoverStaleBranches: recovering %s", branch)
-
-		issueID := strings.TrimPrefix(branch, "task/"+baseBranch+"-")
-		worktreeDir := filepath.Join(worktreeBase, issueID)
-
-		if _, err := os.Stat(worktreeDir); err == nil {
-			logf("recoverStaleBranches: removing worktree %s", worktreeDir)
-			if err := gitWorktreeRemove(worktreeDir, "."); err != nil {
-				logf("recoverStaleBranches: worktree remove warning: %v", err)
-			}
-		} else {
-			logf("recoverStaleBranches: no worktree at %s", worktreeDir)
-		}
-
-		logf("recoverStaleBranches: deleting branch %s", branch)
-		if err := gitForceDeleteBranch(branch, "."); err != nil {
-			logf("recoverStaleBranches: branch delete warning: %v", err)
-		}
-
-		if issueID != "" {
-			var num int
-			if _, err := fmt.Sscanf(issueID, "%d", &num); err == nil && num > 0 {
-				logf("recoverStaleBranches: removing in-progress label from issue #%d", num)
-				if err := removeInProgressLabel(repo, num); err != nil {
-					logf("recoverStaleBranches: label removal warning: %v", err)
-				}
-			}
-		}
-	}
-	return true
-}
-
-// resetOrphanedIssues finds in_progress GitHub issues with no corresponding
-// task branch and removes their in-progress label. Returns true if any were reset.
-func resetOrphanedIssues(baseBranch, repo, generation string) bool {
-	issues, err := listOpenCobblerIssues(repo, generation)
-	if err != nil {
-		logf("resetOrphanedIssues: list issues failed: %v", err)
-		return false
-	}
-
-	recovered := false
-	for _, iss := range issues {
-		if !hasLabel(iss, cobblerLabelInProgress) {
-			continue
-		}
-		id := fmt.Sprintf("%d", iss.Number)
-		taskBranch := taskBranchName(baseBranch, id)
-		if !gitBranchExists(taskBranch, ".") {
-			recovered = true
-			logf("resetOrphanedIssues: orphaned issue #%d (no branch %s), removing in-progress label", iss.Number, taskBranch)
-			if err := removeInProgressLabel(repo, iss.Number); err != nil {
-				logf("resetOrphanedIssues: label removal warning for #%d: %v", iss.Number, err)
-			}
-		} else {
-			logf("resetOrphanedIssues: issue #%d has branch %s, skipping", iss.Number, taskBranch)
-		}
-	}
-	return recovered
-}
-
-func pickTask(baseBranch, worktreeBase, repo, generation string) (stitchTask, error) {
-	logf("pickTask: calling pickReadyIssue repo=%s generation=%s", repo, generation)
-	iss, err := pickReadyIssue(repo, generation)
-	if err != nil {
-		logf("pickTask: no tasks available: %v", err)
-		return stitchTask{}, fmt.Errorf("no tasks available")
-	}
-
-	id := fmt.Sprintf("%d", iss.Number)
-	task := stitchTask{
-		id:          id,
-		title:       iss.Title,
-		description: iss.Description,
-		issueType:   "task",
-		branchName:  taskBranchName(baseBranch, id),
-		worktreeDir: filepath.Join(worktreeBase, id),
-		ghNumber:    iss.Number,
-		generation:  generation,
-		repo:        repo,
-	}
-
-	// Validate the issue description as YAML with required fields.
-	if err := validateIssueDescription(task.description); err != nil {
-		logf("pickTask: description validation warning: %v", err)
-	}
-
-	logf("pickTask: picked #%d id=%s branch=%s worktree=%s", iss.Number, task.id, task.branchName, task.worktreeDir)
-	logf("pickTask: title=%q", task.title)
-	logf("pickTask: descriptionLen=%d", len(task.description))
-	return task, nil
-}
-
-// parseRequiredReading extracts the required_reading list from a YAML task
-// description. Handles both the canonical string format ("- path (reason)")
-// and the map format ("- path: foo.go") that Claude sometimes emits.
-// Returns nil if the field is absent or unparseable.
-func parseRequiredReading(description string) []string {
-	if description == "" {
-		return nil
-	}
-
-	// Try []string first (canonical format: "- path/to/file.go (reason)").
-	var stringParsed struct {
-		RequiredReading []string `yaml:"required_reading"`
-	}
-	if err := yaml.Unmarshal([]byte(description), &stringParsed); err == nil {
-		return stringParsed.RequiredReading
-	}
-
-	// Fall back to []map format when Claude emits structured entries
-	// like {path: "foo.go", reason: "..."}.
-	var mapParsed struct {
-		RequiredReading []map[string]string `yaml:"required_reading"`
-	}
-	if err := yaml.Unmarshal([]byte(description), &mapParsed); err != nil {
-		logf("parseRequiredReading: YAML parse error: %v", err)
-		return nil
-	}
-	var result []string
-	for _, entry := range mapParsed.RequiredReading {
-		if p := entry["path"]; p != "" {
-			result = append(result, p)
-		}
-	}
-	return result
-}
-
-// scopeSourceDirs narrows GoSourceDirs based on the task description's files
-// field (GH-1005). For each configured dir, if the task's files reference a
-// sub-directory two levels deep (e.g. "cmd/cat/main.go" under "cmd/"), only
-// that sub-directory is included instead of the whole tree. Directories where
-// all task files sit directly inside (e.g. "pkg/orchestrator/foo.go" under
-// "pkg/") are kept as-is. Returns nil when no scoping is possible.
-func scopeSourceDirs(configDirs []string, description string) []string {
-	if description == "" || len(configDirs) == 0 {
-		return nil
-	}
-	var parsed struct {
-		Files []string `yaml:"files"`
-	}
-	if err := yaml.Unmarshal([]byte(description), &parsed); err != nil || len(parsed.Files) == 0 {
-		return nil
-	}
-
-	// Extract two-level prefixes from task files: "cmd/cat/main.go" → "cmd/cat".
-	subDirs := make(map[string]bool)
-	for _, f := range parsed.Files {
-		f = strings.TrimPrefix(f, "./")
-		parts := strings.SplitN(f, "/", 3)
-		if len(parts) == 3 {
-			subDirs[parts[0]+"/"+parts[1]] = true
-		}
-	}
-
-	changed := false
-	scoped := make([]string, 0, len(configDirs))
-	for _, dir := range configDirs {
-		clean := strings.TrimRight(strings.TrimPrefix(dir, "./"), "/")
-		// Collect sub-directories of this config dir referenced by the task.
-		var matches []string
-		for sd := range subDirs {
-			if strings.HasPrefix(sd, clean+"/") {
-				matches = append(matches, sd)
-			}
-		}
-		if len(matches) > 0 {
-			sort.Strings(matches)
-			scoped = append(scoped, matches...)
-			changed = true
-		} else {
-			scoped = append(scoped, dir)
-		}
-	}
-
-	if !changed {
-		return nil
-	}
-	return scoped
-}
-
-// validateIssueDescription checks that a description parses as valid YAML
-// and contains the required top-level keys defined by the issue-format
-// constitution. Returns an error describing what is missing; callers
-// should log a warning but not block on validation failures.
-func validateIssueDescription(desc string) error {
-	if desc == "" {
-		return fmt.Errorf("empty description")
-	}
-
-	var parsed map[string]any
-	if err := yaml.Unmarshal([]byte(desc), &parsed); err != nil {
-		return fmt.Errorf("not valid YAML: %w", err)
-	}
-
-	required := []string{"deliverable_type", "required_reading", "files", "requirements", "acceptance_criteria"}
-	var missing []string
-	for _, key := range required {
-		if _, ok := parsed[key]; !ok {
-			missing = append(missing, key)
-		}
-	}
-	if len(missing) > 0 {
-		return fmt.Errorf("missing required fields: %s", strings.Join(missing, ", "))
-	}
-	return nil
-}
-
 func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) error {
 	taskStart := time.Now()
-	logf("doOneTask: starting task %s (%s)", task.id, task.title)
+	logf("doOneTask: starting task %s (%s)", task.ID, task.Title)
 
-	// The cobbler-in-progress label was added by pickReadyIssue; no separate claim step is needed.
-	logf("doOneTask: task #%d claimed via pickReadyIssue label", task.ghNumber)
+	logf("doOneTask: task #%d claimed via pickReadyIssue label", task.GhNumber)
 
 	// Create worktree.
-	logf("doOneTask: creating worktree for %s", task.id)
+	logf("doOneTask: creating worktree for %s", task.ID)
 	wtStart := time.Now()
 	if err := createWorktree(task); err != nil {
 		logf("doOneTask: createWorktree failed after %s: %v", time.Since(wtStart).Round(time.Second), err)
@@ -459,26 +202,26 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	logf("doOneTask: prompt built, length=%d bytes", len(prompt))
 
 	// Post "started" comment so the issue reflects pickup immediately.
-	commentCobblerIssue(task.repo, task.ghNumber, fmt.Sprintf(
-		"Stitch started. Branch: `%s`, prompt: %d bytes.", task.branchName, len(prompt)))
+	commentCobblerIssue(task.Repo, task.GhNumber, fmt.Sprintf(
+		"Stitch started. Branch: `%s`, prompt: %d bytes.", task.BranchName, len(prompt)))
 
-	// Save prompt BEFORE calling Claude so it's on disk even if Claude times out.
+	// Save prompt BEFORE calling Claude.
 	historyTS := time.Now().Format("2006-01-02-15-04-05")
 	o.saveHistoryPrompt(historyTS, "stitch", prompt)
 
-	logf("doOneTask: invoking Claude for task %s", task.id)
+	logf("doOneTask: invoking Claude for task %s", task.ID)
 	claudeStart := time.Now()
-	tokens, claudeErr := o.runClaude(prompt, task.worktreeDir, o.cfg.Silence())
+	tokens, claudeErr := o.runClaude(prompt, task.WorktreeDir, o.cfg.Silence())
 
-	// Save Claude log immediately — even on failure, partial output is valuable.
+	// Save Claude log immediately.
 	o.saveHistoryLog(historyTS, "stitch", tokens.RawOutput)
 
 	if claudeErr != nil {
-		logf("doOneTask: Claude failed for %s after %s: %v", task.id, time.Since(claudeStart).Round(time.Second), claudeErr)
+		logf("doOneTask: Claude failed for %s after %s: %v", task.ID, time.Since(claudeStart).Round(time.Second), claudeErr)
 		o.saveHistoryStats(historyTS, "stitch", HistoryStats{
 			Caller:    "stitch",
-			TaskID:    task.id,
-			TaskTitle: task.title,
+			TaskID:    task.ID,
+			TaskTitle: task.Title,
 			Status:    "failed",
 			Error:     fmt.Sprintf("claude failure: %v", claudeErr),
 			StartedAt: claudeStart.UTC().Format(time.RFC3339),
@@ -491,16 +234,15 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 		o.failTask(task, "Claude failure", taskStart)
 		return errTaskReset
 	}
-	logf("doOneTask: Claude completed for %s in %s", task.id, time.Since(claudeStart).Round(time.Second))
+	logf("doOneTask: Claude completed for %s in %s", task.ID, time.Since(claudeStart).Round(time.Second))
 
-	// Commit Claude's changes in the worktree. Claude does not run git;
-	// the orchestrator manages all git operations externally.
+	// Commit Claude's changes in the worktree.
 	if err := commitWorktreeChanges(task); err != nil {
-		logf("doOneTask: worktree commit failed for %s: %v", task.id, err)
+		logf("doOneTask: worktree commit failed for %s: %v", task.ID, err)
 		o.saveHistoryStats(historyTS, "stitch", HistoryStats{
 			Caller:    "stitch",
-			TaskID:    task.id,
-			TaskTitle: task.title,
+			TaskID:    task.ID,
+			TaskTitle: task.Title,
 			Status:    "failed",
 			Error:     fmt.Sprintf("worktree commit failure: %v", err),
 			StartedAt: claudeStart.UTC().Format(time.RFC3339),
@@ -514,15 +256,11 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 		return errTaskReset
 	}
 
-	// Capture locAfter from the worktree before merging. The worktree starts
-	// from the current generation branch state and includes Claude's additions,
-	// so this gives the correct post-task LOC without waiting for the merge.
-	locAfter := o.captureLOCAt(task.worktreeDir)
+	// Capture locAfter from the worktree before merging.
+	locAfter := o.captureLOCAt(task.WorktreeDir)
 	logf("doOneTask: locAfter prod=%d test=%d", locAfter.Production, locAfter.Test)
 
 	// Append outcome trailers to the worktree commit before merging.
-	// Trailers must be on the pre-merge commit so they travel into the
-	// generation branch history.
 	trailerRec := InvocationRecord{
 		Caller:    "stitch",
 		StartedAt: claudeStart.UTC().Format(time.RFC3339),
@@ -538,8 +276,8 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 		LOCAfter:  locAfter,
 		NumTurns:  tokens.NumTurns,
 	}
-	if err := appendOutcomeTrailers(task.worktreeDir, trailerRec); err != nil {
-		logf("doOneTask: outcome trailer warning for %s: %v", task.id, err)
+	if err := appendOutcomeTrailers(task.WorktreeDir, trailerRec); err != nil {
+		logf("doOneTask: outcome trailer warning for %s: %v", task.ID, err)
 	}
 
 	// Capture pre-merge HEAD for diffstat.
@@ -549,14 +287,14 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	}
 
 	// Merge branch back.
-	logf("doOneTask: merging %s into %s", task.branchName, baseBranch)
+	logf("doOneTask: merging %s into %s", task.BranchName, baseBranch)
 	mergeStart := time.Now()
-	if err := mergeBranch(task.branchName, baseBranch, repoRoot); err != nil {
-		logf("doOneTask: merge failed for %s after %s: %v", task.id, time.Since(mergeStart).Round(time.Second), err)
+	if err := mergeBranch(task.BranchName, baseBranch, repoRoot); err != nil {
+		logf("doOneTask: merge failed for %s after %s: %v", task.ID, time.Since(mergeStart).Round(time.Second), err)
 		o.saveHistoryStats(historyTS, "stitch", HistoryStats{
 			Caller:    "stitch",
-			TaskID:    task.id,
-			TaskTitle: task.title,
+			TaskID:    task.ID,
+			TaskTitle: task.Title,
 			Status:    "failed",
 			Error:     fmt.Sprintf("merge failure: %v", err),
 			StartedAt: claudeStart.UTC().Format(time.RFC3339),
@@ -584,15 +322,15 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	logf("doOneTask: fileChanges=%d entries", len(fileChanges))
 
 	// Cleanup worktree.
-	logf("doOneTask: cleaning up worktree for %s", task.id)
+	logf("doOneTask: cleaning up worktree for %s", task.ID)
 	cleanupWorktree(task)
 
-	// Save stitch stats (log was saved immediately after runClaude).
+	// Save stitch stats.
 	taskDuration := time.Since(taskStart)
 	o.saveHistoryStats(historyTS, "stitch", HistoryStats{
 		Caller:        "stitch",
-		TaskID:        task.id,
-		TaskTitle:     task.title,
+		TaskID:        task.ID,
+		TaskTitle:     task.Title,
 		Status:        "success",
 		StartedAt:     claudeStart.UTC().Format(time.RFC3339),
 		Duration:      taskDuration.Round(time.Second).String(),
@@ -609,10 +347,10 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 
 	// Save stitch report with per-file diffstat.
 	o.saveHistoryReport(historyTS, StitchReport{
-		TaskID:    task.id,
-		TaskTitle: task.title,
+		TaskID:    task.ID,
+		TaskTitle: task.Title,
 		Status:    "success",
-		Branch:    task.branchName,
+		Branch:    task.BranchName,
 		Diff:      historyDiff{Files: diff.FilesChanged, Insertions: diff.Insertions, Deletions: diff.Deletions},
 		Files:     fileChanges,
 		LOCBefore: locBefore,
@@ -630,41 +368,10 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 		Diff:      diffRecord{Files: diff.FilesChanged, Insertions: diff.Insertions, Deletions: diff.Deletions},
 		NumTurns:  tokens.NumTurns,
 	}
-	logf("doOneTask: closing task %s", task.id)
+	logf("doOneTask: closing task %s", task.ID)
 	o.closeStitchTask(task, rec)
 
-	logf("doOneTask: task %s finished in %s", task.id, time.Since(taskStart).Round(time.Second))
-	return nil
-}
-
-func createWorktree(task stitchTask) error {
-	logf("createWorktree: dir=%s branch=%s", task.worktreeDir, task.branchName)
-
-	if err := os.MkdirAll(filepath.Dir(task.worktreeDir), 0o755); err != nil {
-		return fmt.Errorf("creating worktree parent directory: %w", err)
-	}
-
-	if !gitBranchExists(task.branchName, ".") {
-		logf("createWorktree: branch %s does not exist, creating", task.branchName)
-		if err := gitCreateBranch(task.branchName, "."); err != nil {
-			logf("createWorktree: gitCreateBranch failed: %v", err)
-			return fmt.Errorf("creating branch %s: %w", task.branchName, err)
-		}
-		logf("createWorktree: branch %s created", task.branchName)
-	} else {
-		logf("createWorktree: branch %s already exists", task.branchName)
-	}
-
-	logf("createWorktree: adding worktree")
-	cmd := gitWorktreeAdd(task.worktreeDir, task.branchName, ".")
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		logf("createWorktree: worktree add failed: %v", err)
-		return fmt.Errorf("adding worktree: %w", err)
-	}
-
-	logf("createWorktree: worktree ready at %s on branch %s", task.worktreeDir, task.branchName)
+	logf("doOneTask: task %s finished in %s", task.ID, time.Since(taskStart).Round(time.Second))
 	return nil
 }
 
@@ -677,8 +384,7 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 	executionConst := orDefault(o.cfg.Cobbler.ExecutionConstitution, executionConstitution)
 	goStyleConst := orDefault(o.cfg.Cobbler.GoStyleConstitution, goStyleConstitution)
 
-	// Load per-phase context file (prd003 R9.9). Resolved from the
-	// original working directory before chdir to worktree.
+	// Load per-phase context file (prd003 R9.9).
 	stitchCtxPath := filepath.Join(o.cfg.Cobbler.Dir, "stitch_context.yaml")
 	phaseCtx, phaseErr := loadPhaseContext(stitchCtxPath)
 	if phaseErr != nil {
@@ -690,21 +396,19 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 		logf("buildStitchPrompt: no phase context file, using config defaults")
 	}
 
-	// Build project context from the worktree directory so source code
-	// reflects the latest state after prior stitches have been merged.
-	// Scope GoSourceDirs to only directories relevant to this task (GH-1005).
+	// Build project context from the worktree directory.
 	var projectCtx *ProjectContext
-	if task.worktreeDir != "" {
+	if task.WorktreeDir != "" {
 		orig, err := os.Getwd()
 		if err != nil {
 			return "", fmt.Errorf("buildStitchPrompt: getwd: %w", err)
 		}
-		if err := os.Chdir(task.worktreeDir); err != nil {
+		if err := os.Chdir(task.WorktreeDir); err != nil {
 			logf("buildStitchPrompt: chdir to worktree error: %v", err)
 		} else {
 			defer os.Chdir(orig)
 			scopedProject := o.cfg.Project
-			if scoped := scopeSourceDirs(o.cfg.Project.GoSourceDirs, task.description); len(scoped) > 0 {
+			if scoped := scopeSourceDirs(o.cfg.Project.GoSourceDirs, task.Description); len(scoped) > 0 {
 				logf("buildStitchPrompt: scoped go_source_dirs %v -> %v", o.cfg.Project.GoSourceDirs, scoped)
 				scopedProject.GoSourceDirs = scoped
 			}
@@ -718,11 +422,9 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 	}
 	logf("buildStitchPrompt: projectCtx=%v", projectCtx != nil)
 
-	// Selective stitch context (eng05 rec D): filter source files to only
-	// those listed in the task's required_reading. Documentation files are
-	// not filtered; only SourceCode is filtered.
+	// Selective stitch context: filter source files to required_reading.
 	if projectCtx != nil {
-		requiredReading := parseRequiredReading(task.description)
+		requiredReading := parseRequiredReading(task.Description)
 		var sourcePaths []string
 		for _, entry := range requiredReading {
 			clean := stripParenthetical(entry)
@@ -740,19 +442,16 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 				len(projectCtx.SourceCode))
 		}
 
-		// Context budget enforcement: truncate non-required source files
-		// when the serialized context exceeds MaxContextBytes.
+		// Context budget enforcement.
 		applyContextBudget(projectCtx, o.cfg.Cobbler.MaxContextBytes, sourcePaths)
 	}
 
 	taskContext := fmt.Sprintf("Task ID: %s\nType: %s\nTitle: %s",
-		task.id, task.issueType, task.title)
+		task.ID, task.IssueType, task.Title)
 
-	repoFiles := gitLsFiles(task.worktreeDir)
+	repoFiles := gitLsFiles(task.WorktreeDir)
 
-	// Load OOD context: shared_protocols from ARCHITECTURE.yaml and
-	// package_contracts from any PRD that declares them. These give the
-	// agent structured API context for its dependencies.
+	// Load OOD context.
 	oodContracts, oodProtocols := loadOODPromptContext()
 	if len(oodProtocols) > 0 {
 		logf("buildStitchPrompt: injecting %d shared_protocols", len(oodProtocols))
@@ -770,7 +469,7 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 		GoStyleConstitution:   parseYAMLNode(goStyleConst),
 		Task:                  tmpl.Task,
 		Constraints:           tmpl.Constraints,
-		Description:           task.description,
+		Description:           task.Description,
 		SharedProtocols:       oodProtocols,
 		PackageContracts:      oodContracts,
 	}
@@ -784,137 +483,8 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 	return string(out), nil
 }
 
-func mergeBranch(branchName, baseBranch, repoRoot string) error {
-	logf("mergeBranch: %s into %s (repoRoot=%s)", branchName, baseBranch, repoRoot)
-
-	logf("mergeBranch: checking out %s", baseBranch)
-	if err := gitCheckout(baseBranch, "."); err != nil {
-		logf("mergeBranch: checkout failed: %v", err)
-		return fmt.Errorf("checking out %s: %w", baseBranch, err)
-	}
-	logf("mergeBranch: checked out %s", baseBranch)
-
-	logf("mergeBranch: merging %s", branchName)
-	cmd := gitMergeCmd(branchName, ".")
-	cmd.Dir = repoRoot
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		logf("mergeBranch: merge failed: %v", err)
-		return fmt.Errorf("merging %s: %w", branchName, err)
-	}
-
-	logf("mergeBranch: merge successful")
-	return nil
-}
-
-// cleanGoBinaries removes untracked executable files with no extension from
-// dir before staging. Go binaries produced by `go build ./cmd/<name>/` land
-// in the working directory as extensionless executables; this prevents them
-// from being committed to the generation branch (GH-456).
-// Errors are logged but never fatal — a missed binary is less harmful than
-// blocking the commit.
-func cleanGoBinaries(dir string) {
-	cmd := exec.Command(binGit, "ls-files", "--others", "--exclude-standard")
-	cmd.Dir = dir
-	out, err := cmd.Output()
-	if err != nil {
-		logf("cleanGoBinaries: git ls-files: %v", err)
-		return
-	}
-
-	removed := 0
-	for _, name := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if name == "" || filepath.Ext(name) != "" {
-			continue // skip empty lines and files with extensions
-		}
-		path := filepath.Join(dir, name)
-		info, err := os.Stat(path)
-		if err != nil || info.IsDir() || info.Mode()&0o111 == 0 {
-			continue // skip missing, directories, and non-executables
-		}
-		if err := os.Remove(path); err != nil {
-			logf("cleanGoBinaries: remove %s: %v", name, err)
-		} else {
-			logf("cleanGoBinaries: removed binary %s", name)
-			removed++
-		}
-	}
-	logf("cleanGoBinaries: removed %d binary file(s)", removed)
-}
-
-// commitWorktreeChanges stages and commits all changes Claude made in the
-// worktree. Claude does not run git commands; the orchestrator handles git
-// externally. Returns nil if there are no changes to commit.
-func commitWorktreeChanges(task stitchTask) error {
-	logf("commitWorktreeChanges: staging changes in %s", task.worktreeDir)
-
-	// Remove compiled Go binaries before staging so they are not committed.
-	cleanGoBinaries(task.worktreeDir)
-
-	addCmd := exec.Command(binGit, "add", "-A")
-	addCmd.Dir = task.worktreeDir
-	if out, err := addCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git add -A: %w\n%s", err, out)
-	}
-
-	// Check if there are staged changes to commit.
-	diffCmd := exec.Command(binGit, "diff", "--cached", "--quiet")
-	diffCmd.Dir = task.worktreeDir
-	if diffCmd.Run() == nil {
-		logf("commitWorktreeChanges: no changes to commit for %s", task.id)
-		return nil
-	}
-
-	msg := fmt.Sprintf("Task %s: %s", task.id, task.title)
-	logf("commitWorktreeChanges: committing %q", msg)
-	commitCmd := exec.Command(binGit, "commit", "--no-verify", "-m", msg)
-	commitCmd.Dir = task.worktreeDir
-	if out, err := commitCmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git commit: %w\n%s", err, out)
-	}
-
-	logf("commitWorktreeChanges: committed in worktree for %s", task.id)
-	return nil
-}
-
-// resetTask removes the in-progress label from a failed task, cleans up its
-// worktree and branch. The reason string is included in log messages for traceability.
-func (o *Orchestrator) resetTask(task stitchTask, reason string) {
-	logf("resetTask: resetting #%d to ready (%s)", task.ghNumber, reason)
-	if err := removeInProgressLabel(task.repo, task.ghNumber); err != nil {
-		logf("resetTask: WARNING removeInProgressLabel failed for #%d: %v", task.ghNumber, err)
-	}
-	if !cleanupWorktree(task) {
-		logf("resetTask: skipping force branch delete for %s (worktree not removed)", task.branchName)
-		return
-	}
-	if err := gitForceDeleteBranch(task.branchName, "."); err != nil {
-		logf("resetTask: WARNING force branch delete failed for %s: %v", task.branchName, err)
-	}
-}
-
-// cleanupWorktree removes the worktree and its branch. Returns true if the
-// worktree was removed successfully, false if removal failed (branch is left
-// intact to avoid orphaning the worktree).
-func cleanupWorktree(task stitchTask) bool {
-	logf("cleanupWorktree: removing worktree %s", task.worktreeDir)
-	if err := gitWorktreeRemove(task.worktreeDir, "."); err != nil {
-		logf("cleanupWorktree: worktree remove failed, skipping branch delete: %v", err)
-		return false
-	}
-
-	logf("cleanupWorktree: deleting branch %s", task.branchName)
-	if err := gitDeleteBranch(task.branchName, "."); err != nil {
-		logf("cleanupWorktree: branch delete warning: %v", err)
-	}
-
-	logf("cleanupWorktree: done for task %s", task.id)
-	return true
-}
-
 func (o *Orchestrator) closeStitchTask(task stitchTask, rec InvocationRecord) {
-	logf("closeStitchTask: closing #%d %q", task.ghNumber, task.title)
+	logf("closeStitchTask: closing #%d %q", task.GhNumber, task.Title)
 	locDeltaProd := rec.LOCAfter.Production - rec.LOCBefore.Production
 	locDeltaTest := rec.LOCAfter.Test - rec.LOCBefore.Test
 	comment := fmt.Sprintf(
@@ -925,11 +495,27 @@ func (o *Orchestrator) closeStitchTask(task stitchTask, rec InvocationRecord) {
 		rec.NumTurns,
 		rec.Tokens.Input, rec.Tokens.Output,
 	)
-	commentCobblerIssue(task.repo, task.ghNumber, comment)
-	if err := closeCobblerIssue(task.repo, task.ghNumber, task.generation); err != nil {
-		logf("closeStitchTask: closeCobblerIssue warning for #%d: %v", task.ghNumber, err)
+	commentCobblerIssue(task.Repo, task.GhNumber, comment)
+	if err := closeCobblerIssue(task.Repo, task.GhNumber, task.Generation); err != nil {
+		logf("closeStitchTask: closeCobblerIssue warning for #%d: %v", task.GhNumber, err)
 	}
-	logf("closeStitchTask: #%d closed", task.ghNumber)
+	logf("closeStitchTask: #%d closed", task.GhNumber)
+}
+
+// resetTask removes the in-progress label from a failed task, cleans up its
+// worktree and branch.
+func (o *Orchestrator) resetTask(task stitchTask, reason string) {
+	logf("resetTask: resetting #%d to ready (%s)", task.GhNumber, reason)
+	if err := removeInProgressLabel(task.Repo, task.GhNumber); err != nil {
+		logf("resetTask: WARNING removeInProgressLabel failed for #%d: %v", task.GhNumber, err)
+	}
+	if !cleanupWorktree(task) {
+		logf("resetTask: skipping force branch delete for %s (worktree not removed)", task.BranchName)
+		return
+	}
+	if err := gitForceDeleteBranch(task.BranchName, "."); err != nil {
+		logf("resetTask: WARNING force branch delete failed for %s: %v", task.BranchName, err)
+	}
 }
 
 // failTask posts a failure comment on the task issue, then resets it.
@@ -939,6 +525,6 @@ func (o *Orchestrator) failTask(task stitchTask, reason string, startedAt time.T
 		"Stitch failed after %dm %ds. Error: %s.",
 		durationS/60, durationS%60, reason,
 	)
-	commentCobblerIssue(task.repo, task.ghNumber, comment)
+	commentCobblerIssue(task.Repo, task.GhNumber, comment)
 	o.resetTask(task, reason)
 }

--- a/pkg/orchestrator/stitch_test.go
+++ b/pkg/orchestrator/stitch_test.go
@@ -169,9 +169,9 @@ func TestBuildStitchPrompt_NilContext(t *testing.T) {
 	// embedded constitution defaults.
 	o := New(Config{})
 	task := stitchTask{
-		id:        "test-01",
-		title:     "Add unit tests",
-		issueType: "code",
+		ID:        "test-01",
+		Title:     "Add unit tests",
+		IssueType: "code",
 	}
 	out, err := o.buildStitchPrompt(task)
 	if err != nil {
@@ -192,10 +192,10 @@ func TestBuildStitchPrompt_ConstitutionDocs(t *testing.T) {
 	tmp := t.TempDir()
 	o := New(Config{})
 	task := stitchTask{
-		id:          "test-02",
-		title:       "Implement feature",
-		issueType:   "code",
-		worktreeDir: tmp,
+		ID:          "test-02",
+		Title:       "Implement feature",
+		IssueType:   "code",
+		WorktreeDir: tmp,
 	}
 	out, err := o.buildStitchPrompt(task)
 	if err != nil {
@@ -215,7 +215,7 @@ func TestBuildStitchPrompt_InvalidTemplate(t *testing.T) {
 	cfg := Config{}
 	cfg.Cobbler.StitchPrompt = "role: [unclosed bracket"
 	o := New(cfg)
-	task := stitchTask{id: "test-03", title: "Test", issueType: "code"}
+	task := stitchTask{ID: "test-03", Title: "Test", IssueType: "code"}
 	_, err := o.buildStitchPrompt(task)
 	if err == nil {
 		t.Error("buildStitchPrompt() expected error for invalid template, got nil")
@@ -230,9 +230,9 @@ func TestCleanupWorktree_NonExistentDir_NoOp(t *testing.T) {
 	// not exist (e.g., in test environments without a real git repo),
 	// cleanupWorktree must not panic; git errors are logged as warnings.
 	task := stitchTask{
-		id:          "test-cleanup",
-		worktreeDir: "/nonexistent/worktree/path",
-		branchName:  "stitch-test-cleanup",
+		ID:          "test-cleanup",
+		WorktreeDir: "/nonexistent/worktree/path",
+		BranchName:  "stitch-test-cleanup",
 	}
 	ok := cleanupWorktree(task) // must not panic
 	if ok {
@@ -261,10 +261,10 @@ func TestBuildStitchPrompt_RepositoryFiles(t *testing.T) {
 
 	o := New(Config{})
 	task := stitchTask{
-		id:          "test-05",
-		title:       "Repository files test",
-		issueType:   "code",
-		worktreeDir: tmp,
+		ID:          "test-05",
+		Title:       "Repository files test",
+		IssueType:   "code",
+		WorktreeDir: tmp,
 	}
 	out, err := o.buildStitchPrompt(task)
 	if err != nil {
@@ -471,7 +471,7 @@ func TestCleanGoBinaries_BinaryNotCommittedAfterClean(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "wc"), []byte("ELF binary"), 0o755)
 	os.WriteFile(filepath.Join(dir, "wc.go"), []byte("package main\n"), 0o644)
 
-	task := stitchTask{id: "1", title: "wc impl", worktreeDir: dir}
+	task := stitchTask{ID: "1", Title: "wc impl", WorktreeDir: dir}
 	if err := commitWorktreeChanges(task); err != nil {
 		t.Fatalf("commitWorktreeChanges() error = %v", err)
 	}
@@ -510,9 +510,9 @@ func TestCommitWorktreeChanges_NoChanges(t *testing.T) {
 	run("git", "commit", "--allow-empty", "-m", "initial")
 
 	task := stitchTask{
-		id:          "123",
-		title:       "test task",
-		worktreeDir: dir,
+		ID:          "123",
+		Title:       "test task",
+		WorktreeDir: dir,
 	}
 
 	if err := commitWorktreeChanges(task); err != nil {
@@ -539,9 +539,9 @@ func TestCommitWorktreeChanges_WithChanges(t *testing.T) {
 	os.WriteFile(filepath.Join(dir, "newfile.go"), []byte("package main\n"), 0o644)
 
 	task := stitchTask{
-		id:          "456",
-		title:       "add file",
-		worktreeDir: dir,
+		ID:          "456",
+		Title:       "add file",
+		WorktreeDir: dir,
 	}
 
 	if err := commitWorktreeChanges(task); err != nil {
@@ -566,27 +566,27 @@ func TestCreateWorktree_CreatesWorktreeAndBranch(t *testing.T) {
 	dir := initTestGitRepo(t)
 
 	task := stitchTask{
-		id:          "789",
-		branchName:  "task/main-789",
-		worktreeDir: filepath.Join(dir+"-worktrees", "789"),
+		ID:          "789",
+		BranchName:  "task/main-789",
+		WorktreeDir: filepath.Join(dir+"-worktrees", "789"),
 	}
 
 	if err := createWorktree(task); err != nil {
 		t.Fatalf("createWorktree() error = %v", err)
 	}
 	t.Cleanup(func() {
-		gitWorktreeRemove(task.worktreeDir, "")
-		gitDeleteBranch(task.branchName, "")
+		gitWorktreeRemove(task.WorktreeDir, "")
+		gitDeleteBranch(task.BranchName, "")
 	})
 
 	// Verify the worktree directory exists.
-	if _, err := os.Stat(task.worktreeDir); os.IsNotExist(err) {
+	if _, err := os.Stat(task.WorktreeDir); os.IsNotExist(err) {
 		t.Error("worktree directory should exist after createWorktree()")
 	}
 
 	// Verify the branch was created.
-	if !gitBranchExists(task.branchName, "") {
-		t.Errorf("branch %q should exist after createWorktree()", task.branchName)
+	if !gitBranchExists(task.BranchName, "") {
+		t.Errorf("branch %q should exist after createWorktree()", task.BranchName)
 	}
 }
 
@@ -596,14 +596,14 @@ func TestBuildStitchPrompt_RequiredReadingFilter(t *testing.T) {
 	tmp := t.TempDir()
 	o := New(Config{})
 	task := stitchTask{
-		id:        "test-04",
-		title:     "Filter sources",
-		issueType: "code",
-		description: `required_reading:
+		ID:        "test-04",
+		Title:     "Filter sources",
+		IssueType: "code",
+		Description: `required_reading:
   - pkg/orchestrator/context.go
   - pkg/orchestrator/stitch.go
 `,
-		worktreeDir: tmp,
+		WorktreeDir: tmp,
 	}
 	out, err := o.buildStitchPrompt(task)
 	if err != nil {
@@ -811,11 +811,11 @@ func TestResetTask_NonExistentWorktree(t *testing.T) {
 	// resetTask must not panic when the worktree and branch don't exist.
 	o := New(Config{})
 	task := stitchTask{
-		id:          "99999",
-		ghNumber:    99999,
-		branchName:  "task/main-99999",
-		worktreeDir: "/nonexistent/worktree/path",
-		repo:        "fake/repo",
+		ID:          "99999",
+		GhNumber:    99999,
+		BranchName:  "task/main-99999",
+		WorktreeDir: "/nonexistent/worktree/path",
+		Repo:        "fake/repo",
 	}
 
 	o.resetTask(task, "test reason") // must not panic
@@ -832,11 +832,11 @@ func TestResetTask_WithRealWorktree(t *testing.T) {
 
 	o := New(Config{})
 	task := stitchTask{
-		id:          "66666",
-		ghNumber:    66666,
-		branchName:  branchName,
-		worktreeDir: worktreeDir,
-		repo:        "fake/repo",
+		ID:          "66666",
+		GhNumber:    66666,
+		BranchName:  branchName,
+		WorktreeDir: worktreeDir,
+		Repo:        "fake/repo",
 	}
 
 	o.resetTask(task, "test cleanup")
@@ -858,11 +858,11 @@ func TestCloseStitchTask_GHFailureNoOp(t *testing.T) {
 	// (e.g., fake repo, no network).
 	o := New(Config{})
 	task := stitchTask{
-		id:         "99999",
-		ghNumber:   99999,
-		title:      "test task",
-		repo:       "fake/repo",
-		generation: "test-gen",
+		ID:         "99999",
+		GhNumber:   99999,
+		Title:      "test task",
+		Repo:       "fake/repo",
+		Generation: "test-gen",
 	}
 	rec := InvocationRecord{}
 
@@ -878,20 +878,20 @@ func TestCreateWorktree_ExistingBranch(t *testing.T) {
 	gitRun(t, "branch", branchName)
 
 	task := stitchTask{
-		id:          "existing",
-		branchName:  branchName,
-		worktreeDir: filepath.Join(dir+"-worktrees", "existing"),
+		ID:          "existing",
+		BranchName:  branchName,
+		WorktreeDir: filepath.Join(dir+"-worktrees", "existing"),
 	}
 
 	if err := createWorktree(task); err != nil {
 		t.Fatalf("createWorktree() with existing branch error = %v", err)
 	}
 	t.Cleanup(func() {
-		gitWorktreeRemove(task.worktreeDir, "")
-		gitDeleteBranch(task.branchName, "")
+		gitWorktreeRemove(task.WorktreeDir, "")
+		gitDeleteBranch(task.BranchName, "")
 	})
 
-	if _, err := os.Stat(task.worktreeDir); os.IsNotExist(err) {
+	if _, err := os.Stat(task.WorktreeDir); os.IsNotExist(err) {
 		t.Error("worktree directory should exist")
 	}
 }
@@ -909,9 +909,9 @@ func TestCleanupWorktree_RealWorktree(t *testing.T) {
 	gitRun(t, "worktree", "add", worktreeDir, branchName)
 
 	task := stitchTask{
-		id:          "cleanup",
-		branchName:  branchName,
-		worktreeDir: worktreeDir,
+		ID:          "cleanup",
+		BranchName:  branchName,
+		WorktreeDir: worktreeDir,
 	}
 
 	ok := cleanupWorktree(task)
@@ -936,9 +936,9 @@ func TestCreateWorktree_Success(t *testing.T) {
 
 	worktreeDir := filepath.Join(dir+"-worktrees", "wt-create")
 	task := stitchTask{
-		id:          "12345",
-		branchName:  "task/main-12345",
-		worktreeDir: worktreeDir,
+		ID:          "12345",
+		BranchName:  "task/main-12345",
+		WorktreeDir: worktreeDir,
 	}
 
 	err := createWorktree(task)
@@ -952,7 +952,7 @@ func TestCreateWorktree_Success(t *testing.T) {
 	}
 
 	// Branch should exist.
-	if !gitBranchExists(task.branchName, ".") {
+	if !gitBranchExists(task.BranchName, ".") {
 		t.Error("branch should exist after createWorktree")
 	}
 
@@ -963,9 +963,9 @@ func TestCreateWorktree_Success(t *testing.T) {
 func TestCreateWorktree_InvalidParentDir(t *testing.T) {
 	t.Parallel()
 	task := stitchTask{
-		id:          "88888",
-		branchName:  "task/main-88888",
-		worktreeDir: "/dev/null/impossible/path",
+		ID:          "88888",
+		BranchName:  "task/main-88888",
+		WorktreeDir: "/dev/null/impossible/path",
 	}
 
 	err := createWorktree(task)
@@ -1103,9 +1103,9 @@ func TestScopeSourceDirs_PkgNarrows(t *testing.T) {
 func TestCommitWorktreeChanges_InvalidDir(t *testing.T) {
 	t.Parallel()
 	task := stitchTask{
-		id:          "invalid",
-		title:       "invalid dir test",
-		worktreeDir: "/nonexistent/dir/xyz",
+		ID:          "invalid",
+		Title:       "invalid dir test",
+		WorktreeDir: "/nonexistent/dir/xyz",
 	}
 
 	err := commitWorktreeChanges(task)


### PR DESCRIPTION
## Summary

Extracts the generation workflow cluster (generator.go, measure.go, stitch.go — ~2984 lines) into pkg/orchestrator/internal/generate/. This is the most coupled extraction in the restructuring series (#1173-#1180), requiring GitDeps, StitchGitDeps, and StitchIssueDeps structs for dependency injection.

## Changes

- New `pkg/orchestrator/internal/generate/generator.go` — branch management, gitignore helpers, generation naming
- New `pkg/orchestrator/internal/generate/measure.go` — validation types, PRD/roadmap types, measure output validation, filtering
- New `pkg/orchestrator/internal/generate/stitch.go` — StitchTask, worktree management, branch operations, task picking
- Parent generator.go, measure.go, stitch.go rewritten as thin wrappers with DI init
- Updated stitch_test.go, prompt_test.go for exported field names
- Updated build.go for compatibility

## Stats

- go_loc_prod: 16822 (was 16556, +266 from wrappers/DI overhead)
- go_loc_test: 26567 (unchanged)
- spec_words: prd=8441, use_case=7163, test_suite=3676

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] `go build ./...` succeeds

Closes #1180