### PR TITLE
GH-1189: Reset release-level status in resetImplementedReleases

### DIFF
--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -1540,11 +1540,19 @@ releases:
 		t.Fatalf("resetImplementedReleases error: %v", err)
 	}
 
-	// Verify 00.0 and 01.0 are reset to spec_complete.
+	// Verify 00.0 and 01.0 are reset to spec_complete (both release and UC level).
+	rmPath := filepath.Join(dir, "docs", "road-map.yaml")
 	for _, ver := range []string{"00.0", "01.0"} {
-		statuses, err := roadmapUCStatuses(filepath.Join(dir, "docs", "road-map.yaml"), ver)
+		relStatus, err := roadmapReleaseStatus(rmPath, ver)
 		if err != nil {
-			t.Fatalf("read statuses for %s: %v", ver, err)
+			t.Fatalf("read release status for %s: %v", ver, err)
+		}
+		if relStatus != "spec_complete" {
+			t.Errorf("release %s status: want spec_complete, got %q", ver, relStatus)
+		}
+		statuses, err := roadmapUCStatuses(rmPath, ver)
+		if err != nil {
+			t.Fatalf("read UC statuses for %s: %v", ver, err)
 		}
 		for id, status := range statuses {
 			if status != "spec_complete" {
@@ -1553,8 +1561,15 @@ releases:
 		}
 	}
 
-	// Verify 02.0 is unchanged.
-	statuses, err := roadmapUCStatuses(filepath.Join(dir, "docs", "road-map.yaml"), "02.0")
+	// Verify 02.0 is unchanged (both release and UC level).
+	relStatus02, err := roadmapReleaseStatus(rmPath, "02.0")
+	if err != nil {
+		t.Fatalf("read release status for 02.0: %v", err)
+	}
+	if relStatus02 != "spec_complete" {
+		t.Errorf("release 02.0 status: want spec_complete, got %q", relStatus02)
+	}
+	statuses, err := roadmapUCStatuses(rmPath, "02.0")
 	if err != nil {
 		t.Fatalf("read statuses for 02.0: %v", err)
 	}

--- a/pkg/orchestrator/internal/release/release.go
+++ b/pkg/orchestrator/internal/release/release.go
@@ -42,6 +42,7 @@ type roadmapDoc struct {
 
 type roadmapRelease struct {
 	Version  string           `yaml:"version"`
+	Status   string           `yaml:"status"`
 	UseCases []roadmapUseCase `yaml:"use_cases"`
 }
 
@@ -139,8 +140,8 @@ func UpdateRoadmapUCStatuses(version, newStatus string) error {
 }
 
 // SetRoadmapUCStatuses mutates the yaml.Node tree of road-map.yaml, finding
-// the release with the given version and setting all its use_cases[*].status
-// scalar values to newStatus.
+// the release with the given version and setting both the release-level status
+// and all its use_cases[*].status scalar values to newStatus.
 func SetRoadmapUCStatuses(root *yaml.Node, version, newStatus string) error {
 	// Unwrap document node.
 	doc := root
@@ -156,6 +157,10 @@ func SetRoadmapUCStatuses(root *yaml.Node, version, newStatus string) error {
 		versionNode := MappingValue(relNode, "version")
 		if versionNode == nil || versionNode.Value != version {
 			continue
+		}
+		// Reset the release-level status itself (GH-1189).
+		if relStatus := MappingValue(relNode, "status"); relStatus != nil {
+			relStatus.Value = newStatus
 		}
 		ucSeq := MappingValue(relNode, "use_cases")
 		if ucSeq == nil || ucSeq.Kind != yaml.SequenceNode {
@@ -323,4 +328,22 @@ func RoadmapUCStatuses(roadmapPath, version string) (map[string]string, error) {
 		}
 	}
 	return nil, fmt.Errorf("version %q not found", version)
+}
+
+// RoadmapReleaseStatus returns the release-level status for the given version.
+func RoadmapReleaseStatus(roadmapPath, version string) (string, error) {
+	data, err := os.ReadFile(roadmapPath)
+	if err != nil {
+		return "", err
+	}
+	var doc roadmapDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return "", err
+	}
+	for _, rel := range doc.Releases {
+		if rel.Version == version {
+			return rel.Status, nil
+		}
+	}
+	return "", fmt.Errorf("version %q not found", version)
 }

--- a/pkg/orchestrator/release.go
+++ b/pkg/orchestrator/release.go
@@ -89,3 +89,8 @@ func releaseVersionsFromConfig(configPath string) ([]string, error) {
 func roadmapUCStatuses(roadmapPath, version string) (map[string]string, error) {
 	return rel.RoadmapUCStatuses(roadmapPath, version)
 }
+
+// roadmapReleaseStatus delegates to the internal/release package.
+func roadmapReleaseStatus(roadmapPath, version string) (string, error) {
+	return rel.RoadmapReleaseStatus(roadmapPath, version)
+}


### PR DESCRIPTION
## Summary

Fixes resetImplementedReleases to also reset the release-level status to spec_complete, not just UC-level statuses. Previously generator:stop would leave the release marked as implemented even after clearing all UC statuses.

## Changes

- `internal/release/release.go`: SetRoadmapUCStatuses now also resets the release-level status node
- `internal/release/release.go`: Added RoadmapReleaseStatus helper, added Status field to roadmapRelease
- `release.go`: Added roadmapReleaseStatus wrapper
- `generator_test.go`: Updated TestResetImplementedReleases to verify release-level status reset

## Test plan

- [x] `go build ./...` passes
- [x] All tests pass
- [x] TestResetImplementedReleases verifies both release and UC level statuses

Closes #1189