### PR TITLE
GH-1187: Mark use cases as implemented when stitch tasks complete

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -437,6 +437,9 @@ func (o *Orchestrator) RunCycles(label string) error {
 			consecutiveZeroLOC = 0
 		}
 
+		// Mark UCs as implemented when no open issues remain (GH-1187).
+		o.markCompletedReleaseUCs()
+
 		// Check if the current release is complete and auto-advance if so.
 		if advanced, ver := o.checkAutoAdvanceRelease(); advanced {
 			logf("generator %s: cycle %d — auto-advanced release %s", label, cycle, ver)
@@ -516,6 +519,65 @@ func (o *Orchestrator) checkAutoAdvanceRelease() (bool, string) {
 	}
 
 	return true, target.Version
+}
+
+// markCompletedReleaseUCs checks whether all cobbler issues for the current
+// generation are closed. If so, it marks the first non-implemented release's
+// use cases as "implemented" in road-map.yaml so that checkAutoAdvanceRelease
+// can detect the completion and advance the release (GH-1187).
+func (o *Orchestrator) markCompletedReleaseUCs() {
+	open, err := o.hasOpenIssues()
+	if err != nil || open {
+		return
+	}
+	o.markActiveReleaseUCsDone()
+}
+
+// markActiveReleaseUCsDone finds the first non-implemented release in
+// road-map.yaml and marks all its UCs as "implemented". Commits the change.
+// Separated from markCompletedReleaseUCs for testability (no GitHub API).
+func (o *Orchestrator) markActiveReleaseUCsDone() {
+	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
+	if rm == nil {
+		return
+	}
+
+	// Find the first release that is not yet done/implemented.
+	var target *RoadmapRelease
+	for i := range rm.Releases {
+		rel := &rm.Releases[i]
+		if !ucStatusDone(rel.Status) {
+			target = rel
+			break
+		}
+	}
+	if target == nil || len(target.UseCases) == 0 {
+		return
+	}
+
+	// Check if any UCs still need marking.
+	allDone := true
+	for _, uc := range target.UseCases {
+		if !ucStatusDone(uc.Status) {
+			allDone = false
+			break
+		}
+	}
+	if allDone {
+		return
+	}
+
+	logf("markActiveReleaseUCsDone: marking release %s UCs as implemented", target.Version)
+	if err := updateRoadmapUCStatuses(target.Version, "implemented"); err != nil {
+		logf("markActiveReleaseUCsDone: failed: %v", err)
+		return
+	}
+
+	_ = gitStageAll(".")
+	msg := fmt.Sprintf("Mark release %s use cases as implemented\n\nAll cobbler issues closed; UCs updated in road-map.yaml.", target.Version)
+	if err := gitCommit(msg, "."); err != nil {
+		logf("markActiveReleaseUCsDone: commit failed: %v", err)
+	}
 }
 
 // GeneratorStart begins a new generation trail.

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -1390,6 +1390,118 @@ func TestResolveStopTarget_CallerOnCustomBase_UsesCustomBase(t *testing.T) {
 	}
 }
 
+// --- markActiveReleaseUCsDone (GH-1187) ---
+
+func TestMarkActiveReleaseUCsDone(t *testing.T) {
+	dir := initTestGitRepo(t)
+
+	// Release 00.0 has spec_complete UCs (stitch has finished all tasks but
+	// UC statuses were never updated — the bug this fixes).
+	roadmapContent := `id: rm1
+title: Test Roadmap
+releases:
+  - version: "00.0"
+    name: Release 0
+    status: in_progress
+    use_cases:
+      - id: rel00.0-uc001-format
+        status: spec_complete
+        summary: Format output
+      - id: rel00.0-uc002-build
+        status: spec_complete
+        summary: Build pipeline
+  - version: "01.0"
+    name: Release 1
+    status: pending
+    use_cases:
+      - id: rel01.0-uc001-ext
+        status: spec_complete
+        summary: Extension
+`
+	writeRoadmapFile(t, dir, roadmapContent)
+
+	o := &Orchestrator{cfg: Config{}}
+	o.markActiveReleaseUCsDone()
+
+	// Verify 00.0 UCs are now "implemented".
+	rmPath := filepath.Join(dir, "docs", "road-map.yaml")
+	relStatus, err := roadmapReleaseStatus(rmPath, "00.0")
+	if err != nil {
+		t.Fatalf("read release status for 00.0: %v", err)
+	}
+	if relStatus != "implemented" {
+		t.Errorf("release 00.0 status: want implemented, got %q", relStatus)
+	}
+	statuses, err := roadmapUCStatuses(rmPath, "00.0")
+	if err != nil {
+		t.Fatalf("read UC statuses for 00.0: %v", err)
+	}
+	for id, status := range statuses {
+		if status != "implemented" {
+			t.Errorf("UC %s: want implemented, got %q", id, status)
+		}
+	}
+
+	// Verify 01.0 is unchanged.
+	statuses01, err := roadmapUCStatuses(rmPath, "01.0")
+	if err != nil {
+		t.Fatalf("read UC statuses for 01.0: %v", err)
+	}
+	for id, status := range statuses01 {
+		if status != "spec_complete" {
+			t.Errorf("UC %s (rel 01.0): want spec_complete, got %q", id, status)
+		}
+	}
+}
+
+func TestMarkActiveReleaseUCsDone_AlreadyImplemented(t *testing.T) {
+	dir := initTestGitRepo(t)
+
+	// Release 00.0 is already implemented — should be a no-op.
+	roadmapContent := `id: rm1
+title: Test Roadmap
+releases:
+  - version: "00.0"
+    name: Release 0
+    status: implemented
+    use_cases:
+      - id: rel00.0-uc001-format
+        status: implemented
+        summary: Format output
+  - version: "01.0"
+    name: Release 1
+    status: in_progress
+    use_cases:
+      - id: rel01.0-uc001-ext
+        status: spec_complete
+        summary: Extension
+`
+	writeRoadmapFile(t, dir, roadmapContent)
+
+	o := &Orchestrator{cfg: Config{}}
+	o.markActiveReleaseUCsDone()
+
+	// 01.0 should now be marked as implemented (it's the first non-done release).
+	rmPath := filepath.Join(dir, "docs", "road-map.yaml")
+	statuses, err := roadmapUCStatuses(rmPath, "01.0")
+	if err != nil {
+		t.Fatalf("read UC statuses for 01.0: %v", err)
+	}
+	for id, status := range statuses {
+		if status != "implemented" {
+			t.Errorf("UC %s (rel 01.0): want implemented, got %q", id, status)
+		}
+	}
+}
+
+func TestMarkActiveReleaseUCsDone_NoRoadmap(t *testing.T) {
+	initTestGitRepo(t)
+
+	o := &Orchestrator{cfg: Config{}}
+	// Should be a no-op, no panic.
+	o.markActiveReleaseUCsDone()
+}
+
 // --- checkAutoAdvanceRelease (GH-1006) ---
 
 func TestCheckAutoAdvanceRelease_AllUCsDone(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes auto-advance not triggering during generator runs. After each stitch cycle, checks if all cobbler issues are closed and marks the active release UCs as implemented in road-map.yaml, enabling checkAutoAdvanceRelease to detect completion.

## Changes

- Added `markCompletedReleaseUCs` to generator loop (after stitch, before checkAutoAdvanceRelease)
- Added `markActiveReleaseUCsDone` as testable inner function (no GitHub API dependency)
- 3 new tests: basic marking, already-implemented skip, no-roadmap no-op

## Test plan

- [x] `go build ./...` passes
- [x] All tests pass
- [x] New tests verify UC status transitions

Closes #1187