### PR TITLE
GH-1170: Run mage test:usecase and fix failures

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -438,7 +438,11 @@ func (o *Orchestrator) RunCycles(label string) error {
 		}
 
 		// Mark UCs as implemented when no open issues remain (GH-1187).
-		o.markCompletedReleaseUCs()
+		// Only check after stitch has completed at least one task to avoid
+		// false positives on the first cycle before measure creates issues.
+		if totalStitched > 0 {
+			o.markCompletedReleaseUCs()
+		}
 
 		// Check if the current release is complete and auto-advance if so.
 		if advanced, ver := o.checkAutoAdvanceRelease(); advanced {


### PR DESCRIPTION
## Summary

55/55 pass on re-run. Fixed regression from GH-1187 where markCompletedReleaseUCs fired on cycle 1 before measure created issues, causing generator:stop to fail.

## Changes

- Guard markCompletedReleaseUCs with totalStitched > 0 in generator loop
- Prevents false positive UC marking when no issues have been created yet

## Test plan

- [x] TestRel01_UC002_RunOneCycle passes
- [x] Full test:usecase 55/55 pass (transient UC003 passed on re-run)
- [x] Unit tests pass

Closes #1170