### PR TITLE
GH-1259: Refactor Claude runner into interface with three implementations

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -29,6 +29,18 @@ func init() {
 // Type aliases for backward compatibility
 // ---------------------------------------------------------------------------
 
+// Runner executes Claude in a specific mode (CLI, Podman, or SDK).
+type Runner = claude.Runner
+
+// CLIRunner executes Claude by running the claude binary directly.
+type CLIRunner = claude.CLIRunner
+
+// PodmanRunner executes Claude inside a podman container.
+type PodmanRunner = claude.PodmanRunner
+
+// SDKRunner executes Claude via the Go Agent SDK.
+type SDKRunner = claude.SDKRunner
+
 // ClaudeResult holds token usage from a Claude invocation.
 type ClaudeResult = claude.ClaudeResult
 
@@ -136,6 +148,11 @@ func (o *Orchestrator) logConfig(target string) {
 		GenerationBranch:        o.cfg.Generation.Branch,
 		UserPrompt:              o.cfg.Cobbler.UserPrompt,
 	})
+}
+
+// runner returns a Runner for the configured execution mode.
+func (o *Orchestrator) runner() Runner {
+	return claude.NewRunner(o.runClaudeDeps())
 }
 
 // runClaude executes Claude and returns token usage.

--- a/pkg/orchestrator/internal/claude/claude.go
+++ b/pkg/orchestrator/internal/claude/claude.go
@@ -16,7 +16,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -656,9 +655,9 @@ func (t *IdleTrackingWriter) Write(p []byte) (int, error) {
 // RunClaude
 // ---------------------------------------------------------------------------
 
-// RunClaude executes Claude and returns token usage. In SDK mode it calls
-// RunClaudeSDK; in CLI mode it runs the binary directly; in podman mode it
-// runs via a container. The process is killed if the timeout is exceeded.
+// RunClaude executes Claude and returns token usage. It performs shared
+// pre-flight (logging, credential refresh, workDir resolution, timeout
+// context) and delegates to a mode-specific Runner created via NewRunner.
 func RunClaude(deps RunClaudeDeps, prompt, dir string, silence bool, extraClaudeArgs ...string) (ClaudeResult, error) {
 	Log("runClaude: promptLen=%d dir=%q silence=%v", len(prompt), dir, silence)
 
@@ -686,83 +685,8 @@ func RunClaude(deps RunClaudeDeps, prompt, dir string, silence bool, extraClaude
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	if deps.EffectiveMode == "sdk" {
-		return RunClaudeSDK(deps, ctx, prompt, workDir, silence, extraClaudeArgs...)
-	}
-
-	var cmd *exec.Cmd
-	if deps.EffectiveMode == "cli" {
-		cmd = BuildDirectCmd(ctx, workDir, deps.ClaudeArgs, extraClaudeArgs...)
-	} else {
-		cmd = deps.BuildPodmanCmdFn(ctx, workDir, extraClaudeArgs...)
-	}
-
-	cmd.Stdin = strings.NewReader(prompt)
-
-	var idleAt atomic.Int64
-	idleAt.Store(time.Now().UnixNano())
-
-	var stdoutBuf bytes.Buffer
-	var outputWriter io.Writer
-	var pw *ProgressWriter
-	if silence {
-		pw = NewProgressWriter(&stdoutBuf, time.Now())
-		outputWriter = pw
-	} else {
-		outputWriter = io.MultiWriter(os.Stdout, &stdoutBuf)
-		cmd.Stderr = os.Stderr
-	}
-	cmd.Stdout = &IdleTrackingWriter{W: outputWriter, LastWrite: &idleAt}
-
-	idleDur := time.Duration(deps.IdleTimeoutS) * time.Second
-	if idleDur > 0 {
-		go func() {
-			ticker := time.NewTicker(time.Second)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ctx.Done():
-					return
-				case <-ticker.C:
-					last := time.Unix(0, idleAt.Load())
-					if time.Since(last) >= idleDur {
-						Log("runClaude: idle watchdog triggered after %s with no output — cancelling session",
-							time.Since(last).Round(time.Second))
-						cancel()
-						return
-					}
-				}
-			}
-		}()
-	}
-
-	start := time.Now()
-	err := cmd.Run()
-
-	if ctx.Err() == context.DeadlineExceeded {
-		elapsed := time.Since(start).Round(time.Second)
-		last := time.Unix(0, idleAt.Load())
-		idleElapsed := time.Since(last).Round(time.Second)
-		if idleDur > 0 && idleElapsed >= idleDur {
-			Log("runClaude: idle timeout after %s with no output (session ran %s)", idleElapsed, elapsed)
-			return ClaudeResult{}, fmt.Errorf("claude idle timeout: no output for %s", idleElapsed)
-		}
-		Log("runClaude: killed after %s (max time %s exceeded)", elapsed, timeout)
-		return ClaudeResult{}, fmt.Errorf("claude max time exceeded (%s)", timeout)
-	}
-
-	rawOutput := stdoutBuf.Bytes()
-	result := ParseClaudeTokens(rawOutput)
-	if pw != nil {
-		result.NumTurns = pw.Turn
-	}
-	result.RawOutput = make([]byte, len(rawOutput))
-	copy(result.RawOutput, rawOutput)
-	Log("runClaude: finished in %s in=%d (cache_create=%d cache_read=%d) out=%d cost=$%.4f (err=%v)",
-		time.Since(start).Round(time.Second), result.InputTokens,
-		result.CacheCreationTokens, result.CacheReadTokens,
-		result.OutputTokens, result.CostUSD, err)
-	return result, err
+	runner := NewRunner(deps)
+	return runner.Run(ctx, prompt, workDir, silence, extraClaudeArgs...)
 }
 
 // BuildDirectCmd constructs the exec.Cmd for running the claude binary
@@ -784,109 +708,11 @@ func BuildDirectCmd(ctx context.Context, workDir string, claudeArgs []string, ex
 	return cmd
 }
 
-// RunClaudeSDK executes Claude via the Go Agent SDK and returns token usage.
+// RunClaudeSDK delegates to SDKRunner.Run. It is kept for backward
+// compatibility with callers that construct a RunClaudeDeps directly.
 func RunClaudeSDK(deps RunClaudeDeps, ctx context.Context, prompt, workDir string, silence bool, extraClaudeArgs ...string) (ClaudeResult, error) {
-	opts := claudetypes.NewClaudeAgentOptions()
-	opts.CWD = &workDir
-	opts.DangerouslySkipPermissions = true
-	opts.AllowDangerouslySkipPermissions = true
-
-	opts = opts.WithSystemPromptPreset(claudetypes.SystemPromptPreset{
-		Type:   "preset",
-		Preset: "claude_code",
-	})
-
-	for i := 0; i+1 < len(extraClaudeArgs); i++ {
-		if extraClaudeArgs[i] == "--max-turns" {
-			if n, err := strconv.Atoi(extraClaudeArgs[i+1]); err == nil {
-				opts = opts.WithMaxTurns(n)
-			}
-			i++
-		}
-	}
-
-	start := time.Now()
-
-	sdkStderrMu.Lock()
-	origStderr := os.Stderr
-	pr, pw, pipeErr := os.Pipe()
-	if pipeErr == nil {
-		os.Stderr = pw
-	}
-	stderrDone := make(chan struct{})
-	if pipeErr == nil {
-		go FilterSDKStderr(pr, origStderr, stderrDone)
-	}
-	Log("runClaude: SDK query workDir=%q (timeout=%s)", workDir, deps.ClaudeTimeout)
-
-	defer func() {
-		if pipeErr == nil {
-			pw.Close()
-			<-stderrDone
-			os.Stderr = origStderr
-		}
-		sdkStderrMu.Unlock()
-	}()
-
-	sdkEnvMu.Lock()
-	oldVal, hadVal := os.LookupEnv("CLAUDECODE")
-	_ = os.Unsetenv("CLAUDECODE")
-
-	msgChan, err := deps.SdkQueryFn(ctx, prompt, opts)
-
-	if hadVal {
-		_ = os.Setenv("CLAUDECODE", oldVal)
-	}
-	sdkEnvMu.Unlock()
-
-	if err != nil {
-		return ClaudeResult{}, fmt.Errorf("claude SDK query: %w", err)
-	}
-
-	var result ClaudeResult
-	var textBuf strings.Builder
-	var gotResult bool
-
-	for msg := range msgChan {
-		switch m := msg.(type) {
-		case *claudetypes.AssistantMessage:
-			for _, block := range m.Content {
-				switch b := block.(type) {
-				case *claudetypes.TextBlock:
-					if !silence {
-						fmt.Print(b.Text)
-					}
-					textBuf.WriteString(b.Text)
-				}
-			}
-		case *claudetypes.ResultMessage:
-			gotResult = true
-			if m.TotalCostUSD != nil {
-				result.CostUSD = *m.TotalCostUSD
-			}
-			result.InputTokens = IntFromUsage(m.Usage, "input_tokens")
-			result.OutputTokens = IntFromUsage(m.Usage, "output_tokens")
-			result.CacheCreationTokens = IntFromUsage(m.Usage, "cache_creation_input_tokens")
-			result.CacheReadTokens = IntFromUsage(m.Usage, "cache_read_input_tokens")
-			result.NumTurns = m.NumTurns
-			result.DurationAPIMs = m.DurationAPIMs
-			result.SessionID = m.SessionID
-			if m.IsError {
-				return result, fmt.Errorf("claude SDK session returned error result")
-			}
-		}
-	}
-
-	if !gotResult {
-		return ClaudeResult{}, fmt.Errorf("claude SDK session produced no result (subprocess may have exited early)")
-	}
-
-	result.RawOutput = []byte(textBuf.String())
-	Log("runClaude: SDK finished in %s in=%d (cache_create=%d cache_read=%d) out=%d cost=$%.4f",
-		time.Since(start).Round(time.Second),
-		result.InputTokens, result.CacheCreationTokens, result.CacheReadTokens,
-		result.OutputTokens, result.CostUSD)
-	return result, nil
+	r := &SDKRunner{queryFn: deps.SdkQueryFn, claudeTimeout: deps.ClaudeTimeout}
+	return r.Run(ctx, prompt, workDir, silence, extraClaudeArgs...)
 }
 
 // ---------------------------------------------------------------------------

--- a/pkg/orchestrator/internal/claude/runner.go
+++ b/pkg/orchestrator/internal/claude/runner.go
@@ -1,0 +1,296 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package claude
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	claudetypes "github.com/schlunsen/claude-agent-sdk-go/types"
+)
+
+// ---------------------------------------------------------------------------
+// Runner interface
+// ---------------------------------------------------------------------------
+
+// Runner executes Claude in a specific mode and returns token usage. The
+// three implementations — CLIRunner, PodmanRunner, SDKRunner — encapsulate
+// the mode-specific command construction and output handling. Shared
+// concerns (credential refresh, timeout, workDir resolution) live in the
+// caller (RunClaude).
+type Runner interface {
+	Run(ctx context.Context, prompt, workDir string, silence bool, extraArgs ...string) (ClaudeResult, error)
+}
+
+// NewRunner returns a Runner for the given mode. It reads EffectiveMode
+// from deps and constructs the appropriate implementation.
+func NewRunner(deps RunClaudeDeps) Runner {
+	switch deps.EffectiveMode {
+	case "sdk":
+		return &SDKRunner{
+			queryFn:       deps.SdkQueryFn,
+			claudeTimeout: deps.ClaudeTimeout,
+		}
+	case "cli":
+		return &CLIRunner{
+			execRunner: execRunner{
+				buildCmd: func(ctx context.Context, workDir string, extraArgs ...string) *exec.Cmd {
+					return BuildDirectCmd(ctx, workDir, deps.ClaudeArgs, extraArgs...)
+				},
+				idleTimeoutS: deps.IdleTimeoutS,
+			},
+		}
+	default:
+		return &PodmanRunner{
+			execRunner: execRunner{
+				buildCmd:     deps.BuildPodmanCmdFn,
+				idleTimeoutS: deps.IdleTimeoutS,
+			},
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// execRunner — shared exec-based logic for CLI and Podman modes
+// ---------------------------------------------------------------------------
+
+// execRunner holds the shared execution logic for modes that run Claude as
+// an external process (CLI and Podman). It manages stdout capture, progress
+// logging, idle watchdog, and token parsing.
+type execRunner struct {
+	buildCmd     func(ctx context.Context, workDir string, extra ...string) *exec.Cmd
+	idleTimeoutS int
+}
+
+func (r *execRunner) run(ctx context.Context, prompt, workDir string, silence bool, extraArgs ...string) (ClaudeResult, error) {
+	// Derive a cancellable child context so the idle watchdog can cancel
+	// without masking the parent's DeadlineExceeded.
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	cmd := r.buildCmd(ctx, workDir, extraArgs...)
+	cmd.Stdin = strings.NewReader(prompt)
+
+	var idleAt atomic.Int64
+	idleAt.Store(time.Now().UnixNano())
+
+	var stdoutBuf bytes.Buffer
+	var outputWriter io.Writer
+	var pw *ProgressWriter
+	if silence {
+		pw = NewProgressWriter(&stdoutBuf, time.Now())
+		outputWriter = pw
+	} else {
+		outputWriter = io.MultiWriter(os.Stdout, &stdoutBuf)
+		cmd.Stderr = os.Stderr
+	}
+	cmd.Stdout = &IdleTrackingWriter{W: outputWriter, LastWrite: &idleAt}
+
+	idleDur := time.Duration(r.idleTimeoutS) * time.Second
+	if idleDur > 0 {
+		go func() {
+			ticker := time.NewTicker(time.Second)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case <-ticker.C:
+					last := time.Unix(0, idleAt.Load())
+					if time.Since(last) >= idleDur {
+						Log("runClaude: idle watchdog triggered after %s with no output — cancelling session",
+							time.Since(last).Round(time.Second))
+						cancel()
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	start := time.Now()
+	err := cmd.Run()
+
+	if ctx.Err() == context.DeadlineExceeded {
+		elapsed := time.Since(start).Round(time.Second)
+		last := time.Unix(0, idleAt.Load())
+		idleElapsed := time.Since(last).Round(time.Second)
+		if idleDur > 0 && idleElapsed >= idleDur {
+			Log("runClaude: idle timeout after %s with no output (session ran %s)", idleElapsed, elapsed)
+			return ClaudeResult{}, fmt.Errorf("claude idle timeout: no output for %s", idleElapsed)
+		}
+		deadline, _ := ctx.Deadline()
+		timeout := time.Until(deadline) + elapsed // reconstruct original timeout
+		Log("runClaude: killed after %s (max time %s exceeded)", elapsed, timeout.Round(time.Second))
+		return ClaudeResult{}, fmt.Errorf("claude max time exceeded (%s)", timeout.Round(time.Second))
+	}
+
+	rawOutput := stdoutBuf.Bytes()
+	result := ParseClaudeTokens(rawOutput)
+	if pw != nil {
+		result.NumTurns = pw.Turn
+	}
+	result.RawOutput = make([]byte, len(rawOutput))
+	copy(result.RawOutput, rawOutput)
+	Log("runClaude: finished in %s in=%d (cache_create=%d cache_read=%d) out=%d cost=$%.4f (err=%v)",
+		time.Since(start).Round(time.Second), result.InputTokens,
+		result.CacheCreationTokens, result.CacheReadTokens,
+		result.OutputTokens, result.CostUSD, err)
+	return result, err
+}
+
+// ---------------------------------------------------------------------------
+// CLIRunner
+// ---------------------------------------------------------------------------
+
+// CLIRunner executes Claude by running the claude binary directly on the
+// host. It embeds execRunner for shared process management.
+type CLIRunner struct {
+	execRunner
+}
+
+// Run executes Claude via the host CLI binary.
+func (r *CLIRunner) Run(ctx context.Context, prompt, workDir string, silence bool, extraArgs ...string) (ClaudeResult, error) {
+	return r.execRunner.run(ctx, prompt, workDir, silence, extraArgs...)
+}
+
+// ---------------------------------------------------------------------------
+// PodmanRunner
+// ---------------------------------------------------------------------------
+
+// PodmanRunner executes Claude inside a podman container. It embeds
+// execRunner for shared process management.
+type PodmanRunner struct {
+	execRunner
+}
+
+// Run executes Claude via a podman container.
+func (r *PodmanRunner) Run(ctx context.Context, prompt, workDir string, silence bool, extraArgs ...string) (ClaudeResult, error) {
+	return r.execRunner.run(ctx, prompt, workDir, silence, extraArgs...)
+}
+
+// ---------------------------------------------------------------------------
+// SDKRunner
+// ---------------------------------------------------------------------------
+
+// SDKRunner executes Claude via the Go Agent SDK. It streams messages from
+// the SDK channel, collecting text output and token usage from the
+// ResultMessage.
+type SDKRunner struct {
+	queryFn       SdkQueryFunc
+	claudeTimeout time.Duration
+}
+
+// Run executes Claude via the Go Agent SDK.
+func (r *SDKRunner) Run(ctx context.Context, prompt, workDir string, silence bool, extraArgs ...string) (ClaudeResult, error) {
+	opts := claudetypes.NewClaudeAgentOptions()
+	opts.CWD = &workDir
+	opts.DangerouslySkipPermissions = true
+	opts.AllowDangerouslySkipPermissions = true
+
+	opts = opts.WithSystemPromptPreset(claudetypes.SystemPromptPreset{
+		Type:   "preset",
+		Preset: "claude_code",
+	})
+
+	for i := 0; i+1 < len(extraArgs); i++ {
+		if extraArgs[i] == "--max-turns" {
+			if n, err := strconv.Atoi(extraArgs[i+1]); err == nil {
+				opts = opts.WithMaxTurns(n)
+			}
+			i++
+		}
+	}
+
+	start := time.Now()
+
+	sdkStderrMu.Lock()
+	origStderr := os.Stderr
+	pr, pw, pipeErr := os.Pipe()
+	if pipeErr == nil {
+		os.Stderr = pw
+	}
+	stderrDone := make(chan struct{})
+	if pipeErr == nil {
+		go FilterSDKStderr(pr, origStderr, stderrDone)
+	}
+	Log("runClaude: SDK query workDir=%q (timeout=%s)", workDir, r.claudeTimeout)
+
+	defer func() {
+		if pipeErr == nil {
+			pw.Close()
+			<-stderrDone
+			os.Stderr = origStderr
+		}
+		sdkStderrMu.Unlock()
+	}()
+
+	sdkEnvMu.Lock()
+	oldVal, hadVal := os.LookupEnv("CLAUDECODE")
+	_ = os.Unsetenv("CLAUDECODE")
+
+	msgChan, err := r.queryFn(ctx, prompt, opts)
+
+	if hadVal {
+		_ = os.Setenv("CLAUDECODE", oldVal)
+	}
+	sdkEnvMu.Unlock()
+
+	if err != nil {
+		return ClaudeResult{}, fmt.Errorf("claude SDK query: %w", err)
+	}
+
+	var result ClaudeResult
+	var textBuf strings.Builder
+	var gotResult bool
+
+	for msg := range msgChan {
+		switch m := msg.(type) {
+		case *claudetypes.AssistantMessage:
+			for _, block := range m.Content {
+				switch b := block.(type) {
+				case *claudetypes.TextBlock:
+					if !silence {
+						fmt.Print(b.Text)
+					}
+					textBuf.WriteString(b.Text)
+				}
+			}
+		case *claudetypes.ResultMessage:
+			gotResult = true
+			if m.TotalCostUSD != nil {
+				result.CostUSD = *m.TotalCostUSD
+			}
+			result.InputTokens = IntFromUsage(m.Usage, "input_tokens")
+			result.OutputTokens = IntFromUsage(m.Usage, "output_tokens")
+			result.CacheCreationTokens = IntFromUsage(m.Usage, "cache_creation_input_tokens")
+			result.CacheReadTokens = IntFromUsage(m.Usage, "cache_read_input_tokens")
+			result.NumTurns = m.NumTurns
+			result.DurationAPIMs = m.DurationAPIMs
+			result.SessionID = m.SessionID
+			if m.IsError {
+				return result, fmt.Errorf("claude SDK session returned error result")
+			}
+		}
+	}
+
+	if !gotResult {
+		return ClaudeResult{}, fmt.Errorf("claude SDK session produced no result (subprocess may have exited early)")
+	}
+
+	result.RawOutput = []byte(textBuf.String())
+	Log("runClaude: SDK finished in %s in=%d (cache_create=%d cache_read=%d) out=%d cost=$%.4f",
+		time.Since(start).Round(time.Second),
+		result.InputTokens, result.CacheCreationTokens, result.CacheReadTokens,
+		result.OutputTokens, result.CostUSD)
+	return result, nil
+}

--- a/pkg/orchestrator/internal/claude/runner_test.go
+++ b/pkg/orchestrator/internal/claude/runner_test.go
@@ -1,0 +1,201 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package claude
+
+import (
+	"context"
+	"os/exec"
+	"testing"
+	"time"
+
+	claudetypes "github.com/schlunsen/claude-agent-sdk-go/types"
+)
+
+// ---------------------------------------------------------------------------
+// NewRunner factory
+// ---------------------------------------------------------------------------
+
+func TestNewRunner_SDK(t *testing.T) {
+	deps := RunClaudeDeps{
+		EffectiveMode: "sdk",
+		ClaudeTimeout: 5 * time.Minute,
+		SdkQueryFn: func(ctx context.Context, prompt string, opts *claudetypes.ClaudeAgentOptions) (<-chan claudetypes.Message, error) {
+			return nil, nil
+		},
+	}
+	r := NewRunner(deps)
+	if _, ok := r.(*SDKRunner); !ok {
+		t.Errorf("expected *SDKRunner, got %T", r)
+	}
+}
+
+func TestNewRunner_CLI(t *testing.T) {
+	deps := RunClaudeDeps{
+		EffectiveMode: "cli",
+		ClaudeArgs:    []string{"--verbose"},
+		IdleTimeoutS:  60,
+	}
+	r := NewRunner(deps)
+	if _, ok := r.(*CLIRunner); !ok {
+		t.Errorf("expected *CLIRunner, got %T", r)
+	}
+}
+
+func TestNewRunner_Podman(t *testing.T) {
+	deps := RunClaudeDeps{
+		EffectiveMode: "podman",
+		BuildPodmanCmdFn: func(ctx context.Context, workDir string, extra ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "echo")
+		},
+		IdleTimeoutS: 120,
+	}
+	r := NewRunner(deps)
+	if _, ok := r.(*PodmanRunner); !ok {
+		t.Errorf("expected *PodmanRunner, got %T", r)
+	}
+}
+
+func TestNewRunner_DefaultIsPodman(t *testing.T) {
+	deps := RunClaudeDeps{
+		EffectiveMode: "",
+		BuildPodmanCmdFn: func(ctx context.Context, workDir string, extra ...string) *exec.Cmd {
+			return exec.CommandContext(ctx, "echo")
+		},
+	}
+	r := NewRunner(deps)
+	if _, ok := r.(*PodmanRunner); !ok {
+		t.Errorf("expected *PodmanRunner for empty mode, got %T", r)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Runner interface compliance
+// ---------------------------------------------------------------------------
+
+func TestCLIRunner_ImplementsRunner(t *testing.T) {
+	var _ Runner = (*CLIRunner)(nil)
+}
+
+func TestPodmanRunner_ImplementsRunner(t *testing.T) {
+	var _ Runner = (*PodmanRunner)(nil)
+}
+
+func TestSDKRunner_ImplementsRunner(t *testing.T) {
+	var _ Runner = (*SDKRunner)(nil)
+}
+
+// ---------------------------------------------------------------------------
+// SDKRunner.Run
+// ---------------------------------------------------------------------------
+
+func TestSDKRunner_Run_Success(t *testing.T) {
+	cost := 0.0042
+	r := &SDKRunner{
+		claudeTimeout: 5 * time.Minute,
+		queryFn: func(ctx context.Context, prompt string, opts *claudetypes.ClaudeAgentOptions) (<-chan claudetypes.Message, error) {
+			ch := make(chan claudetypes.Message, 2)
+			ch <- &claudetypes.AssistantMessage{
+				Content: []claudetypes.ContentBlock{
+					&claudetypes.TextBlock{Text: "hello"},
+				},
+			}
+			ch <- &claudetypes.ResultMessage{
+				TotalCostUSD: &cost,
+				Usage:        map[string]interface{}{"input_tokens": float64(10), "output_tokens": float64(20)},
+			}
+			close(ch)
+			return ch, nil
+		},
+	}
+
+	res, err := r.Run(context.Background(), "prompt", t.TempDir(), true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.InputTokens != 10 {
+		t.Errorf("expected InputTokens=10, got %d", res.InputTokens)
+	}
+	if res.OutputTokens != 20 {
+		t.Errorf("expected OutputTokens=20, got %d", res.OutputTokens)
+	}
+	if res.CostUSD != 0.0042 {
+		t.Errorf("expected CostUSD=0.0042, got %f", res.CostUSD)
+	}
+	if string(res.RawOutput) != "hello" {
+		t.Errorf("expected RawOutput='hello', got %q", string(res.RawOutput))
+	}
+}
+
+func TestSDKRunner_Run_QueryError(t *testing.T) {
+	r := &SDKRunner{
+		claudeTimeout: 5 * time.Minute,
+		queryFn: func(ctx context.Context, prompt string, opts *claudetypes.ClaudeAgentOptions) (<-chan claudetypes.Message, error) {
+			return nil, context.DeadlineExceeded
+		},
+	}
+
+	_, err := r.Run(context.Background(), "prompt", t.TempDir(), true)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestSDKRunner_Run_NoResult(t *testing.T) {
+	r := &SDKRunner{
+		claudeTimeout: 5 * time.Minute,
+		queryFn: func(ctx context.Context, prompt string, opts *claudetypes.ClaudeAgentOptions) (<-chan claudetypes.Message, error) {
+			ch := make(chan claudetypes.Message)
+			close(ch)
+			return ch, nil
+		},
+	}
+
+	_, err := r.Run(context.Background(), "prompt", t.TempDir(), true)
+	if err == nil {
+		t.Fatal("expected error for no result")
+	}
+}
+
+func TestSDKRunner_Run_IsError(t *testing.T) {
+	r := &SDKRunner{
+		claudeTimeout: 5 * time.Minute,
+		queryFn: func(ctx context.Context, prompt string, opts *claudetypes.ClaudeAgentOptions) (<-chan claudetypes.Message, error) {
+			ch := make(chan claudetypes.Message, 1)
+			ch <- &claudetypes.ResultMessage{IsError: true}
+			close(ch)
+			return ch, nil
+		},
+	}
+
+	_, err := r.Run(context.Background(), "prompt", t.TempDir(), true)
+	if err == nil {
+		t.Fatal("expected error for IsError result")
+	}
+}
+
+func TestSDKRunner_Run_MaxTurnsParsed(t *testing.T) {
+	var capturedOpts *claudetypes.ClaudeAgentOptions
+	cost := 0.0
+	r := &SDKRunner{
+		claudeTimeout: 5 * time.Minute,
+		queryFn: func(ctx context.Context, prompt string, opts *claudetypes.ClaudeAgentOptions) (<-chan claudetypes.Message, error) {
+			capturedOpts = opts
+			ch := make(chan claudetypes.Message, 1)
+			ch <- &claudetypes.ResultMessage{TotalCostUSD: &cost, Usage: map[string]interface{}{"input_tokens": float64(1), "output_tokens": float64(1)}}
+			close(ch)
+			return ch, nil
+		},
+	}
+
+	_, err := r.Run(context.Background(), "prompt", t.TempDir(), true, "--max-turns", "7")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedOpts == nil {
+		t.Fatal("opts not captured")
+	}
+	if capturedOpts.MaxTurns == nil || *capturedOpts.MaxTurns != 7 {
+		t.Errorf("expected MaxTurns=7, got %v", capturedOpts.MaxTurns)
+	}
+}


### PR DESCRIPTION
## Summary

Extracts the monolithic `RunClaude` dispatch function into a `Runner` interface with three concrete implementations: `CLIRunner`, `PodmanRunner`, and `SDKRunner`. Shared exec-based concerns (idle watchdog, progress logging, token parsing) live in `execRunner`, embedded by CLI and Podman runners. `RunClaude` now performs shared pre-flight and delegates to `NewRunner(deps).Run()`.

## Changes

- Added `Runner` interface with `Run(ctx, prompt, workDir, silence, extraArgs)` method
- Added `CLIRunner` and `PodmanRunner` embedding `execRunner` for shared process management
- Added `SDKRunner` for Go Agent SDK channel-based streaming
- Added `NewRunner(deps)` factory that dispatches on `EffectiveMode`
- Simplified `RunClaude` to pre-flight + runner delegation
- Added `runner()` method and type aliases to parent `cobbler.go`
- `RunClaudeSDK` kept as backward-compatible wrapper delegating to `SDKRunner`
- 12 new tests for factory, interface compliance, and SDKRunner.Run

## Stats

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| go_loc_prod | 17212 | 17197 | -15 |
| go_loc_test | 28659 | 28860 | +201 |
| go_loc | 45871 | 46057 | +186 |

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)
- [x] New runner tests pass (factory, interface compliance, SDKRunner.Run)

Closes #1259