### PR TITLE
GH-1295: Separate GitHub code into git-ops and issue-tracking interfaces

### DIFF
--- a/pkg/orchestrator/cobbler_test.go
+++ b/pkg/orchestrator/cobbler_test.go
@@ -155,14 +155,14 @@ func TestParseNumstat_BinaryFile(t *testing.T) {
 
 	if entry, ok := m["image.png"]; !ok {
 		t.Error("missing entry for image.png")
-	} else if entry.ins != 0 || entry.del != 0 {
-		t.Errorf("image.png: got ins=%d del=%d, want 0 0", entry.ins, entry.del)
+	} else if entry.Ins != 0 || entry.Del != 0 {
+		t.Errorf("image.png: got ins=%d del=%d, want 0 0", entry.Ins, entry.Del)
 	}
 
 	if entry, ok := m["README.md"]; !ok {
 		t.Error("missing entry for README.md")
-	} else if entry.ins != 10 || entry.del != 2 {
-		t.Errorf("README.md: got ins=%d del=%d, want 10 2", entry.ins, entry.del)
+	} else if entry.Ins != 10 || entry.Del != 2 {
+		t.Errorf("README.md: got ins=%d del=%d, want 10 2", entry.Ins, entry.Del)
 	}
 }
 

--- a/pkg/orchestrator/commands.go
+++ b/pkg/orchestrator/commands.go
@@ -4,11 +4,11 @@
 package orchestrator
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
+
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/gitops"
 )
 
 // Binary names.
@@ -28,6 +28,10 @@ const (
 	dirMagefiles = "magefiles"
 	dirCobbler   = ".cobbler"
 )
+
+// defaultGitOps is the package-level ShellGitOps instance used by all git
+// helper functions. It shells out to the "git" binary.
+var defaultGitOps = &gitops.ShellGitOps{}
 
 // orDefault returns val if non-empty, otherwise fallback.
 func orDefault(val, fallback string) string {
@@ -62,232 +66,81 @@ func init() {
 	}
 }
 
-// cmdGit returns an exec.Cmd for git with cmd.Dir set to dir when dir is non-empty.
-// Pass an empty string to use the process working directory (backward-compatible default).
-func cmdGit(dir string, arg ...string) *exec.Cmd {
-	cmd := exec.Command(binGit, arg...)
-	if dir != "" {
-		cmd.Dir = dir
-	}
-	return cmd
-}
-
 // Git helpers.
 // Each function accepts a dir string parameter; when dir is non-empty it is
 // forwarded to exec.Cmd.Dir so the command runs in that directory rather than
 // the process-wide working directory. Pass "" to use the existing CWD (the
 // original behaviour, preserved for callers that rely on os.Chdir).
+//
+// All git functions delegate to the defaultGitOps instance.
 
-func gitCheckout(branch, dir string) error {
-	return cmdGit(dir, "checkout", branch).Run()
-}
-
-func gitCheckoutNew(branch, dir string) error {
-	return cmdGit(dir, "checkout", "-b", branch).Run()
-}
-
-func gitCreateBranch(name, dir string) error {
-	return cmdGit(dir, "branch", name).Run()
-}
-
-func gitDeleteBranch(name, dir string) error {
-	return cmdGit(dir, "branch", "-d", name).Run()
-}
-
-func gitForceDeleteBranch(name, dir string) error {
-	return cmdGit(dir, "branch", "-D", name).Run()
-}
-
-func gitBranchExists(name, dir string) bool {
-	return cmdGit(dir, "show-ref", "--verify", "--quiet", "refs/heads/"+name).Run() == nil
-}
-
-func gitListBranches(pattern, dir string) []string {
-	out, _ := cmdGit(dir, "branch", "--list", pattern).Output() // empty output on error is acceptable
-	return parseBranchList(string(out))
-}
-
-func gitTag(name, dir string) error {
-	return cmdGit(dir, "tag", name).Run()
-}
-
-func gitDeleteTag(name, dir string) error {
-	return cmdGit(dir, "tag", "-d", name).Run()
-}
+func gitCheckout(branch, dir string) error        { return defaultGitOps.Checkout(branch, dir) }
+func gitCheckoutNew(branch, dir string) error      { return defaultGitOps.CheckoutNew(branch, dir) }
+func gitCreateBranch(name, dir string) error       { return defaultGitOps.CreateBranch(name, dir) }
+func gitDeleteBranch(name, dir string) error       { return defaultGitOps.DeleteBranch(name, dir) }
+func gitForceDeleteBranch(name, dir string) error  { return defaultGitOps.ForceDeleteBranch(name, dir) }
+func gitBranchExists(name, dir string) bool        { return defaultGitOps.BranchExists(name, dir) }
+func gitListBranches(pattern, dir string) []string { return defaultGitOps.ListBranches(pattern, dir) }
+func gitTag(name, dir string) error                { return defaultGitOps.Tag(name, dir) }
+func gitDeleteTag(name, dir string) error          { return defaultGitOps.DeleteTag(name, dir) }
+func gitListTags(pattern, dir string) []string     { return defaultGitOps.ListTags(pattern, dir) }
+func gitLsFiles(dir string) []string               { return defaultGitOps.LsFiles(dir) }
+func gitStageAll(dir string) error                 { return defaultGitOps.StageAll(dir) }
+func gitStageDir(path, dir string) error           { return defaultGitOps.StageDir(path, dir) }
+func gitUnstageAll(dir string) error               { return defaultGitOps.UnstageAll(dir) }
+func gitHasChanges(dir string) bool                { return defaultGitOps.HasChanges(dir) }
+func gitStash(msg, dir string) error               { return defaultGitOps.Stash(msg, dir) }
+func gitCommit(msg, dir string) error              { return defaultGitOps.Commit(msg, dir) }
+func gitCommitAllowEmpty(msg, dir string) error    { return defaultGitOps.CommitAllowEmpty(msg, dir) }
+func gitResetSoft(ref, dir string) error           { return defaultGitOps.ResetSoft(ref, dir) }
+func gitWorktreePrune(dir string) error            { return defaultGitOps.WorktreePrune(dir) }
 
 // gitTagAt creates a tag pointing at the given ref (commit, tag, or branch).
-func gitTagAt(name, ref, dir string) error {
-	return cmdGit(dir, "tag", name, ref).Run()
-}
+func gitTagAt(name, ref, dir string) error { return defaultGitOps.TagAt(name, ref, dir) }
 
 // gitRenameTag creates newName at the same commit as oldName, then
 // deletes oldName. Returns an error if the new tag cannot be created.
 func gitRenameTag(oldName, newName, dir string) error {
-	if err := cmdGit(dir, "tag", newName, oldName).Run(); err != nil {
-		return err
-	}
-	return gitDeleteTag(oldName, dir)
+	return defaultGitOps.RenameTag(oldName, newName, dir)
 }
 
-func gitListTags(pattern, dir string) []string {
-	out, _ := cmdGit(dir, "tag", "--list", pattern).Output() // empty output on error is acceptable
-	return parseBranchList(string(out))
-}
+func gitRevParseHEAD(dir string) (string, error) { return defaultGitOps.RevParseHEAD(dir) }
 
-// gitLsFiles returns all git-tracked file paths in dir, relative to dir.
-// Returns nil if dir is empty, if git ls-files produces no output, or on error.
-func gitLsFiles(dir string) []string {
-	if dir == "" {
-		return nil
-	}
-	out, err := cmdGit(dir, "ls-files").Output()
-	if err != nil || len(out) == 0 {
-		return nil
-	}
-	return parseBranchList(string(out))
-}
-
-func gitStageAll(dir string) error {
-	return cmdGit(dir, "add", "-A").Run()
-}
-
-func gitUnstageAll(dir string) error {
-	return cmdGit(dir, "reset", "HEAD").Run()
-}
-
-// gitHasChanges returns true if the working tree has staged or unstaged
-// changes (tracked files only).
-func gitHasChanges(dir string) bool {
-	// --quiet exits 1 when there are changes.
-	return cmdGit(dir, "diff", "--quiet", "HEAD").Run() != nil
-}
-
-func gitStash(msg, dir string) error {
-	return cmdGit(dir, "stash", "push", "-m", msg).Run()
-}
-
-// gitStageDir stages a specific path. path is the argument passed to git add;
-// dir is the repository root used as cmd.Dir (empty means process CWD).
-func gitStageDir(path, dir string) error {
-	return cmdGit(dir, "add", path).Run()
-}
-
-func gitCommit(msg, dir string) error {
-	return cmdGit(dir, "commit", "--no-verify", "-m", msg).Run()
-}
-
-func gitCommitAllowEmpty(msg, dir string) error {
-	return cmdGit(dir, "commit", "--no-verify", "-m", msg, "--allow-empty").Run()
-}
-
-func gitRevParseHEAD(dir string) (string, error) {
-	out, err := cmdGit(dir, "rev-parse", "HEAD").Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
-func gitResetSoft(ref, dir string) error {
-	return cmdGit(dir, "reset", "--soft", ref).Run()
-}
-
-func gitMergeCmd(branch, dir string) *exec.Cmd {
-	return cmdGit(dir, "merge", branch, "--no-edit")
-}
-
-func gitWorktreePrune(dir string) error {
-	return cmdGit(dir, "worktree", "prune").Run()
-}
+func gitMergeCmd(branch, dir string) *exec.Cmd { return defaultGitOps.MergeCmd(branch, dir) }
 
 // gitWorktreeAdd returns a Cmd that adds a worktree at worktreeDir on branch.
 // dir is the repository root used as cmd.Dir (empty means process CWD).
 func gitWorktreeAdd(worktreeDir, branch, dir string) *exec.Cmd {
-	return cmdGit(dir, "worktree", "add", worktreeDir, branch)
+	return defaultGitOps.WorktreeAdd(worktreeDir, branch, dir)
 }
 
 // gitWorktreeRemove removes the worktree at worktreeDir.
 // dir is the repository root used as cmd.Dir (empty means process CWD).
 func gitWorktreeRemove(worktreeDir, dir string) error {
-	return cmdGit(dir, "worktree", "remove", worktreeDir, "--force").Run()
+	return defaultGitOps.WorktreeRemove(worktreeDir, dir)
 }
 
-func gitCurrentBranch(dir string) (string, error) {
-	out, err := cmdGit(dir, "rev-parse", "--abbrev-ref", "HEAD").Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
-}
-
-// parseBranchList parses the output of git branch --list or git tag --list.
-func parseBranchList(output string) []string {
-	var branches []string
-	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimSpace(line)
-		line = strings.TrimLeft(line, "*+ ")
-		if line != "" {
-			branches = append(branches, line)
-		}
-	}
-	return branches
-}
+func gitCurrentBranch(dir string) (string, error) { return defaultGitOps.CurrentBranch(dir) }
 
 // gitLsTreeFiles returns the list of file paths tracked at the given ref.
 func gitLsTreeFiles(ref, dir string) ([]string, error) {
-	out, err := cmdGit(dir, "ls-tree", "-r", "--name-only", ref).Output()
-	if err != nil {
-		return nil, err
-	}
-	var files []string
-	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
-		if line != "" {
-			files = append(files, line)
-		}
-	}
-	return files, nil
+	return defaultGitOps.LsTreeFiles(ref, dir)
 }
 
 // gitShowFileContent returns the raw content of a file at the given ref.
 func gitShowFileContent(ref, path, dir string) ([]byte, error) {
-	return cmdGit(dir, "show", ref+":"+path).Output()
+	return defaultGitOps.ShowFileContent(ref, path, dir)
 }
 
 // FileChange is defined in internal/claude and aliased in cobbler.go.
 
 // diffStat holds parsed output from git diff --shortstat.
-type diffStat struct {
-	FilesChanged int
-	Insertions   int
-	Deletions    int
-}
+type diffStat = gitops.DiffStat
 
 // gitDiffShortstat runs git diff --shortstat against the given ref and
 // parses the output (e.g. "5 files changed, 100 insertions(+), 20 deletions(-)").
 func gitDiffShortstat(ref, dir string) (diffStat, error) {
-	out, err := cmdGit(dir, "diff", "--shortstat", ref).Output()
-	if err != nil {
-		return diffStat{}, err
-	}
-	return parseDiffShortstat(string(out)), nil
-}
-
-// parseDiffShortstat extracts file/insertion/deletion counts from
-// git diff --shortstat output.
-func parseDiffShortstat(s string) diffStat {
-	var ds diffStat
-	for _, part := range strings.Split(s, ",") {
-		part = strings.TrimSpace(part)
-		var n int
-		if _, err := fmt.Sscanf(part, "%d file", &n); err == nil {
-			ds.FilesChanged = n
-		} else if _, err := fmt.Sscanf(part, "%d insertion", &n); err == nil {
-			ds.Insertions = n
-		} else if _, err := fmt.Sscanf(part, "%d deletion", &n); err == nil {
-			ds.Deletions = n
-		}
-	}
-	return ds
+	return defaultGitOps.DiffShortstat(ref, dir)
 }
 
 // gitDiffNameStatus runs git diff --name-status and --numstat against the
@@ -295,77 +148,42 @@ func parseDiffShortstat(s string) diffStat {
 // deletions. The two commands are combined to produce complete file-level
 // change records.
 func gitDiffNameStatus(ref, dir string) ([]FileChange, error) {
-	nsOut, err := cmdGit(dir, "diff", "--name-status", ref).Output()
+	gfc, err := defaultGitOps.DiffNameStatus(ref, dir)
 	if err != nil {
 		return nil, err
 	}
+	files := make([]FileChange, len(gfc))
+	for i, fc := range gfc {
+		files[i] = FileChange{
+			Path:       fc.Path,
+			Status:     fc.Status,
+			Insertions: fc.Insertions,
+			Deletions:  fc.Deletions,
+		}
+	}
+	return files, nil
+}
 
-	numOut, _ := cmdGit(dir, "diff", "--numstat", ref).Output()
-	numMap := parseNumstat(string(numOut))
+// parseBranchList parses the output of git branch --list or git tag --list.
+func parseBranchList(output string) []string {
+	return gitops.ParseBranchList(output)
+}
 
-	return parseNameStatus(string(nsOut), numMap), nil
+// parseDiffShortstat extracts file/insertion/deletion counts from
+// git diff --shortstat output.
+func parseDiffShortstat(s string) diffStat {
+	return gitops.ParseDiffShortstat(s)
+}
+
+// parseNumstat parses git diff --numstat output into a map keyed by file path.
+func parseNumstat(output string) map[string]gitops.NumstatEntry {
+	return gitops.ParseNumstat(output)
 }
 
 // parseNameStatus parses git diff --name-status output and merges it with
 // numstat data to produce FileChange entries.
-func parseNameStatus(output string, numMap map[string]numstatEntry) []FileChange {
-	var files []FileChange
-	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
-		if line == "" {
-			continue
-		}
-		parts := strings.Split(line, "\t")
-		if len(parts) < 2 {
-			continue
-		}
-		status := parts[0]
-		path := parts[1]
-
-		// Renames show as R### with old\tnew paths.
-		if strings.HasPrefix(status, "R") && len(parts) >= 3 {
-			path = parts[2]
-			status = "R"
-		}
-		// Copies show as C### with old\tnew paths.
-		if strings.HasPrefix(status, "C") && len(parts) >= 3 {
-			path = parts[2]
-			status = "C"
-		}
-
-		fc := FileChange{Path: path, Status: status}
-		if ns, ok := numMap[path]; ok {
-			fc.Insertions = ns.ins
-			fc.Deletions = ns.del
-		}
-		files = append(files, fc)
-	}
-	return files
-}
-
-type numstatEntry struct {
-	ins int
-	del int
-}
-
-// parseNumstat parses git diff --numstat output into a map keyed by file path.
-// Binary files show "-\t-\tpath" and are recorded with zero counts.
-func parseNumstat(output string) map[string]numstatEntry {
-	m := make(map[string]numstatEntry)
-	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
-		if line == "" {
-			continue
-		}
-		parts := strings.Split(line, "\t")
-		if len(parts) < 3 {
-			continue
-		}
-		// Binary files use "-" for insertions and deletions.
-		ins, _ := strconv.Atoi(parts[0])
-		del, _ := strconv.Atoi(parts[1])
-		path := parts[len(parts)-1]
-		m[path] = numstatEntry{ins: ins, del: del}
-	}
-	return m
+func parseNameStatus(output string, numMap map[string]gitops.NumstatEntry) []gitops.FileChange {
+	return gitops.ParseNameStatus(output, numMap)
 }
 
 // Podman helpers.

--- a/pkg/orchestrator/internal/github/issues.go
+++ b/pkg/orchestrator/internal/github/issues.go
@@ -25,6 +25,7 @@ type Logger func(format string, args ...any)
 type BranchChecker func(branch, dir string) bool
 
 // Deps holds external dependencies injected by the parent package.
+// Retained for backward compatibility; new code should use GitHubTracker.
 type Deps struct {
 	Log            Logger
 	GhBin          string
@@ -36,6 +37,76 @@ type RepoConfig struct {
 	IssuesRepo string // cobbler.issues_repo override
 	ModulePath string // project.module_path for fallback detection
 	TargetRepo string // project.target_repo for defect filing
+}
+
+// WorkTracker defines the interface for all issue-tracking operations that
+// have external dependencies (gh CLI calls, branch checks). Pure functions
+// that operate only on in-memory data remain as package-level functions.
+// Designed so a future crumbs/trails implementation can satisfy it.
+type WorkTracker interface {
+	// Repo detection
+	DetectGitHubRepo(repoRoot string) (string, error)
+
+	// Label management
+	EnsureCobblerLabels(repo string) error
+	EnsureCobblerGenLabel(repo, generation string) error
+	ListRepoLabels(repo string) []string
+	AddIssueLabel(repo string, number int, label string) error
+	RemoveIssueLabel(repo string, number int, label string) error
+
+	// Issue CRUD
+	CreateCobblerIssue(repo, generation string, issue ProposedIssue) (int, error)
+	CreateMeasuringPlaceholder(repo, generation string, iteration int) (int, error)
+	UpgradeMeasuringPlaceholder(repo string, number int, generation string, issue ProposedIssue) error
+	CloseCobblerIssue(repo string, number int, generation string) error
+	CloseMeasuringPlaceholder(repo string, number int)
+	CloseMeasuringPlaceholderWithComment(repo string, number int, comment string)
+	EditIssueTitle(repo string, number int, title string) error
+	CommentCobblerIssue(repo string, number int, body string)
+	CloseGenerationIssues(repo, generation string) error
+
+	// Issue queries
+	ListOpenCobblerIssues(repo, generation string) ([]CobblerIssue, error)
+	ListAllCobblerIssues(repo, generation string) ([]CobblerIssue, error)
+	FetchIssueComments(repo string, number int) ([]string, error)
+	ListActiveIssuesContext(repo, generation string) (string, error)
+	WaitForIssuesVisible(repo, generation string, expected int)
+
+	// Sub-issues
+	LinkSubIssue(repo string, parentNumber, childNumber int) error
+
+	// DAG
+	PromoteReadyIssues(repo, generation string) error
+	PickReadyIssue(repo, generation string) (CobblerIssue, error)
+
+	// GC
+	GcStaleGenerationIssues(repo, generationPrefix string)
+
+	// Defects
+	FileTargetRepoDefects(repo string, defects []string)
+	ResolveTargetRepo() string
+
+	// Generic
+	GhExec(repoRoot string, args ...string) (string, error)
+}
+
+// GitHubTracker implements WorkTracker by wrapping the gh CLI and
+// configuration needed for GitHub issue operations.
+type GitHubTracker struct {
+	Log          Logger
+	GhBin        string
+	BranchExists BranchChecker
+	Cfg          RepoConfig
+}
+
+// NewGitHubTracker creates a GitHubTracker from Deps and RepoConfig.
+func NewGitHubTracker(deps Deps, cfg RepoConfig) *GitHubTracker {
+	return &GitHubTracker{
+		Log:          deps.Log,
+		GhBin:        deps.GhBin,
+		BranchExists: deps.BranchExists,
+		Cfg:          cfg,
+	}
 }
 
 // CobblerIssue holds the parsed representation of a GitHub issue created by
@@ -86,6 +157,8 @@ const (
 
 // GenLabelPrefix is the prefix for generation-scoped labels.
 const GenLabelPrefix = "cobbler-gen-"
+
+// --- Pure package-level functions (no external dependencies) ---
 
 // GenLabel returns the generation label for a given generation name.
 // GitHub enforces a 50-character maximum on label names. When the full label
@@ -150,278 +223,6 @@ func ParseIssueFrontMatter(body string) (CobblerFrontMatter, string) {
 	return fm, description
 }
 
-// DetectGitHubRepo resolves the GitHub owner/repo string for the target project.
-// Resolution order:
-//  1. cfg.IssuesRepo if set (explicit override, used for testing)
-//  2. `gh repo view --json nameWithOwner` run in repoRoot (reads git remote)
-//  3. Strip "github.com/" from cfg.ModulePath
-func DetectGitHubRepo(repoRoot string, cfg RepoConfig, deps Deps) (string, error) {
-	if cfg.IssuesRepo != "" {
-		return cfg.IssuesRepo, nil
-	}
-
-	// Try gh repo view in the repo root.
-	cmd := exec.Command(deps.GhBin, "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
-	cmd.Dir = repoRoot
-	if out, err := cmd.Output(); err == nil {
-		if repo := strings.TrimSpace(string(out)); repo != "" {
-			return repo, nil
-		}
-	}
-
-	// Fall back to module path.
-	if strings.HasPrefix(cfg.ModulePath, "github.com/") {
-		return strings.TrimPrefix(cfg.ModulePath, "github.com/"), nil
-	}
-
-	return "", fmt.Errorf("cannot determine GitHub repo: set cobbler.issues_repo in configuration.yaml or ensure the project has a github.com module path")
-}
-
-// EnsureCobblerLabels creates the cobbler-ready and cobbler-in-progress labels
-// on the target repo if they do not already exist. Idempotent.
-func EnsureCobblerLabels(repo string, deps Deps) error {
-	existing := ListRepoLabels(repo, deps)
-	existingSet := make(map[string]bool, len(existing))
-	for _, l := range existing {
-		existingSet[l] = true
-	}
-
-	labels := []struct {
-		name  string
-		color string
-		desc  string
-	}{
-		{LabelReady, "0075ca", "Cobbler task ready to be picked by stitch"},
-		{LabelInProgress, "e4e669", "Cobbler task currently being worked on"},
-	}
-
-	for _, l := range labels {
-		if existingSet[l.name] {
-			continue
-		}
-		cmd := exec.Command(deps.GhBin, "api", "repos/"+repo+"/labels",
-			"--method", "POST",
-			"--field", "name="+l.name,
-			"--field", "color="+l.color,
-			"--field", "description="+l.desc,
-		)
-		if out, err := cmd.Output(); err != nil {
-			deps.Log("ensureCobblerLabels: could not create label %q: %v (output: %s)", l.name, err, string(out))
-		} else {
-			deps.Log("ensureCobblerLabels: created label %q on %s", l.name, repo)
-		}
-	}
-	return nil
-}
-
-// ListRepoLabels returns the names of all labels on the repo.
-func ListRepoLabels(repo string, deps Deps) []string {
-	out, err := exec.Command(deps.GhBin, "label", "list", "--repo", repo, "--json", "name", "--limit", "100").Output()
-	if err != nil {
-		return nil
-	}
-	var labels []struct {
-		Name string `json:"name"`
-	}
-	if err := json.Unmarshal(out, &labels); err != nil {
-		return nil
-	}
-	names := make([]string, 0, len(labels))
-	for _, l := range labels {
-		names = append(names, l.Name)
-	}
-	return names
-}
-
-// EnsureCobblerGenLabel creates the generation-scoped label on the repo if
-// it does not already exist.
-func EnsureCobblerGenLabel(repo, generation string, deps Deps) error {
-	label := GenLabel(generation)
-	cmd := exec.Command(deps.GhBin, "api", "repos/"+repo+"/labels",
-		"--method", "POST",
-		"--field", "name="+label,
-		"--field", "color=ededed", // light grey; GitHub API requires a valid 6-char hex color
-		"--field", "description=Cobbler generation "+generation,
-	)
-	// Ignore error — label may already exist (422 Unprocessable Entity).
-	cmd.Run() //nolint:errcheck // best-effort
-	return nil
-}
-
-// CreateMeasuringPlaceholder creates a transient GitHub issue that signals
-// the measure agent is actively calling Claude for iteration i (1-based).
-// The issue carries no cobbler-ready label so stitch won't pick it up.
-// Callers must call CloseMeasuringPlaceholder after the iteration completes.
-func CreateMeasuringPlaceholder(repo, generation string, iteration int, deps Deps) (int, error) {
-	title := fmt.Sprintf("[measuring] %s task %d", generation, iteration)
-	body := fmt.Sprintf("Cobbler measure is calling Claude to propose task %d for generation %s.\n\nThis issue will be closed automatically when measure completes.", iteration, generation)
-	// No cobbler labels: stitch ignores issues without a gen label, and the
-	// placeholder must not appear in the existing-issues context sent to Claude.
-	out, err := exec.Command(deps.GhBin, "issue", "create",
-		"--repo", repo,
-		"--title", title,
-		"--body", body,
-	).Output()
-	if err != nil {
-		return 0, fmt.Errorf("gh issue create placeholder: %w", err)
-	}
-	number, err := ParseIssueURL(string(out))
-	if err != nil {
-		return 0, err
-	}
-	deps.Log("createMeasuringPlaceholder: created #%d for iteration %d", number, iteration)
-	return number, nil
-}
-
-// CloseMeasuringPlaceholder closes the placeholder issue created by
-// CreateMeasuringPlaceholder. Best-effort: logs and ignores errors.
-func CloseMeasuringPlaceholder(repo string, number int, deps Deps) {
-	if err := exec.Command(deps.GhBin, "issue", "close",
-		"--repo", repo,
-		fmt.Sprintf("%d", number),
-	).Run(); err != nil {
-		deps.Log("closeMeasuringPlaceholder: close #%d warning: %v", number, err)
-		return
-	}
-	deps.Log("closeMeasuringPlaceholder: closed #%d", number)
-}
-
-// CloseMeasuringPlaceholderWithComment closes the placeholder issue and adds a
-// comment explaining why it was closed. Used on error paths to avoid orphans
-// (GH-747). Best-effort: logs and ignores errors.
-func CloseMeasuringPlaceholderWithComment(repo string, number int, comment string, deps Deps) {
-	if err := exec.Command(deps.GhBin, "issue", "comment",
-		"--repo", repo,
-		fmt.Sprintf("%d", number),
-		"--body", comment,
-	).Run(); err != nil {
-		deps.Log("closeMeasuringPlaceholderWithComment: comment on #%d warning: %v", number, err)
-	}
-	CloseMeasuringPlaceholder(repo, number, deps)
-}
-
-// UpgradeMeasuringPlaceholder converts the transient measuring placeholder
-// into the task issue in-place. It edits the placeholder's title and body
-// to match the proposed issue, adds the cobbler-gen label so stitch can
-// pick it up, and links it as a sub-issue of the parent generation issue
-// if the generation name encodes one (GH-578).
-func UpgradeMeasuringPlaceholder(repo string, number int, generation string, issue ProposedIssue, deps Deps) error {
-	body := FormatIssueFrontMatter(generation, issue.Index, issue.Dependency) + issue.Description
-	title := "[measure] " + issue.Title
-
-	// Edit title and body in one command.
-	if err := exec.Command(deps.GhBin, "issue", "edit",
-		"--repo", repo,
-		fmt.Sprintf("%d", number),
-		"--title", title,
-		"--body", body,
-	).Run(); err != nil {
-		return fmt.Errorf("gh issue edit placeholder #%d: %w", number, err)
-	}
-
-	// Add cobbler-gen label so stitch can pick it up.
-	if err := AddIssueLabel(repo, number, GenLabel(generation), deps); err != nil {
-		return fmt.Errorf("adding gen label to #%d: %w", number, err)
-	}
-
-	deps.Log("upgradeMeasuringPlaceholder: upgraded #%d %q gen=%s index=%d dep=%d",
-		number, title, generation, issue.Index, issue.Dependency)
-
-	// Link as sub-issue of the parent if the generation name encodes one.
-	if parentNumber := ExtractParentIssueNumber(generation); parentNumber > 0 {
-		if err := LinkSubIssue(repo, parentNumber, number, deps); err != nil {
-			deps.Log("upgradeMeasuringPlaceholder: linkSubIssue warning for #%d -> parent #%d: %v", number, parentNumber, err)
-		}
-	}
-	return nil
-}
-
-// CreateCobblerIssue creates a GitHub issue on repo for the given generation
-// and ProposedIssue. Returns the GitHub issue number.
-//
-// Note: gh issue create (v2.87.3) does not support --json; it outputs the
-// issue URL (https://github.com/owner/repo/issues/123) on success.
-func CreateCobblerIssue(repo, generation string, issue ProposedIssue, deps Deps) (int, error) {
-	body := FormatIssueFrontMatter(generation, issue.Index, issue.Dependency) + issue.Description
-	title := "[measure] " + issue.Title
-
-	genLabel := GenLabel(generation)
-	out, err := exec.Command(deps.GhBin, "issue", "create",
-		"--repo", repo,
-		"--title", title,
-		"--body", body,
-		"--label", genLabel,
-	).Output()
-	if err != nil {
-		return 0, fmt.Errorf("gh issue create: %w", err)
-	}
-
-	number, err := ParseIssueURL(string(out))
-	if err != nil {
-		return 0, err
-	}
-	deps.Log("createCobblerIssue: created #%d %q gen=%s index=%d dep=%d",
-		number, title, generation, issue.Index, issue.Dependency)
-
-	// Link as sub-issue of the parent, if the generation name encodes one (GH-566).
-	if parentNumber := ExtractParentIssueNumber(generation); parentNumber > 0 {
-		if err := LinkSubIssue(repo, parentNumber, number, deps); err != nil {
-			deps.Log("createCobblerIssue: linkSubIssue warning for #%d -> parent #%d: %v", number, parentNumber, err)
-		}
-	}
-
-	return number, nil
-}
-
-// ExtractParentIssueNumber parses a GitHub issue number from a generation name
-// that follows the pattern "...-gh-<N>-..." (e.g., "generation-gh-206-slug"
-// → 206). Returns 0 if the pattern is not found.
-func ExtractParentIssueNumber(generation string) int {
-	const marker = "-gh-"
-	idx := strings.Index(generation, marker)
-	if idx < 0 {
-		return 0
-	}
-	rest := generation[idx+len(marker):]
-	var n int
-	if _, err := fmt.Sscanf(rest, "%d", &n); err != nil || n <= 0 {
-		return 0
-	}
-	return n
-}
-
-// LinkSubIssue attaches childNumber as a GitHub sub-issue of parentNumber.
-// It first fetches the child's database ID, then POSTs to the sub_issues API.
-// Errors are returned so the caller can log them as warnings.
-func LinkSubIssue(repo string, parentNumber, childNumber int, deps Deps) error {
-	// Fetch the child issue's database ID (different from the display number).
-	dbIDOut, err := exec.Command(deps.GhBin, "api",
-		fmt.Sprintf("repos/%s/issues/%d", repo, childNumber),
-		"--jq", ".id",
-	).Output()
-	if err != nil {
-		return fmt.Errorf("fetching database id for #%d: %w", childNumber, err)
-	}
-	dbIDStr := strings.TrimSpace(string(dbIDOut))
-	var dbID int
-	if _, err := fmt.Sscanf(dbIDStr, "%d", &dbID); err != nil || dbID <= 0 {
-		return fmt.Errorf("parsing database id %q for #%d: %w", dbIDStr, childNumber, err)
-	}
-
-	// POST to the parent's sub_issues endpoint.
-	out, err := exec.Command(deps.GhBin, "api",
-		fmt.Sprintf("repos/%s/issues/%d/sub_issues", repo, parentNumber),
-		"--method", "POST",
-		"--field", fmt.Sprintf("sub_issue_id=%d", dbID),
-	).CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("linking #%d as sub-issue of #%d: %w (output: %s)",
-			childNumber, parentNumber, err, strings.TrimSpace(string(out)))
-	}
-	deps.Log("linkSubIssue: linked #%d as sub-issue of #%d", childNumber, parentNumber)
-	return nil
-}
-
 // ParseIssueURL extracts a GitHub issue number from a URL string like
 // "https://github.com/owner/repo/issues/123\n". Returns an error for
 // malformed or empty output.
@@ -439,63 +240,24 @@ func ParseIssueURL(raw string) (int, error) {
 	return number, nil
 }
 
-// ListOpenCobblerIssues returns all open GitHub issues for a generation.
-// It uses the REST API endpoint (gh api repos/.../issues) rather than
-// gh issue list, because gh issue list uses GitHub's search API which is
-// eventually consistent and can return stale results immediately after
-// label changes. The REST endpoint reads directly from the database.
-func ListOpenCobblerIssues(repo, generation string, deps Deps) ([]CobblerIssue, error) {
-	label := GenLabel(generation)
-	out, err := exec.Command(deps.GhBin, "api",
-		"--method", "GET",
-		fmt.Sprintf("repos/%s/issues", repo),
-		"-f", "state=open",
-		"-f", "labels="+label,
-		"-f", "per_page=100",
-	).Output()
-	if err != nil {
-		return nil, fmt.Errorf("gh api repos issues: %w", err)
+// NormalizeIssueTitle strips [measure]/[stitch] prefixes and trims whitespace
+// so that proposed titles can be compared against existing issues (GH-1026).
+func NormalizeIssueTitle(title string) string {
+	t := strings.TrimSpace(title)
+	for _, prefix := range []string{"[measure] ", "[stitch] "} {
+		t = strings.TrimPrefix(t, prefix)
 	}
-
-	return ParseCobblerIssuesJSON(out)
+	return strings.TrimSpace(t)
 }
 
-// ListAllCobblerIssues returns all GitHub issues (open and closed) for a
-// generation. Used by GeneratorStats to report completed tasks.
-func ListAllCobblerIssues(repo, generation string, deps Deps) ([]CobblerIssue, error) {
-	label := GenLabel(generation)
-	out, err := exec.Command(deps.GhBin, "api",
-		"--method", "GET",
-		fmt.Sprintf("repos/%s/issues", repo),
-		"-f", "state=all",
-		"-f", "labels="+label,
-		"-f", "per_page=100",
-	).Output()
-	if err != nil {
-		return nil, fmt.Errorf("gh api repos issues: %w", err)
+// HasLabel returns true if the issue has the given label.
+func HasLabel(issue CobblerIssue, label string) bool {
+	for _, l := range issue.Labels {
+		if l == label {
+			return true
+		}
 	}
-	return ParseCobblerIssuesJSON(out)
-}
-
-// FetchIssueComments returns the body text of all comments on the given issue.
-func FetchIssueComments(repo string, number int, deps Deps) ([]string, error) {
-	out, err := exec.Command(deps.GhBin, "api",
-		fmt.Sprintf("repos/%s/issues/%d/comments", repo, number),
-	).Output()
-	if err != nil {
-		return nil, fmt.Errorf("gh api issue comments for #%d: %w", number, err)
-	}
-	var raw []struct {
-		Body string `json:"body"`
-	}
-	if err := json.Unmarshal(out, &raw); err != nil {
-		return nil, fmt.Errorf("parsing issue comments for #%d: %w", number, err)
-	}
-	bodies := make([]string, 0, len(raw))
-	for _, r := range raw {
-		bodies = append(bodies, r.Body)
-	}
-	return bodies, nil
+	return false
 }
 
 // ParseCobblerIssuesJSON parses the JSON output from the GitHub REST API issues
@@ -535,40 +297,401 @@ func ParseCobblerIssuesJSON(data []byte) ([]CobblerIssue, error) {
 	return issues, nil
 }
 
+// IssuesContextJSON converts a slice of CobblerIssue into the JSON string
+// expected by parseIssuesJSON. Exported for testing.
+func IssuesContextJSON(issues []CobblerIssue) (string, error) {
+	ctx := make([]ContextIssue, len(issues))
+	for i, iss := range issues {
+		status := "backfill"
+		if HasLabel(iss, LabelInProgress) {
+			status = "in_progress"
+		} else if HasLabel(iss, LabelReady) {
+			status = "ready"
+		}
+		ctx[i] = ContextIssue{
+			ID:     fmt.Sprintf("%d", iss.Number),
+			Title:  iss.Title,
+			Status: status,
+		}
+	}
+	b, err := json.Marshal(ctx)
+	if err != nil {
+		return "", fmt.Errorf("issuesContextJSON: %w", err)
+	}
+	return string(b), nil
+}
+
+// ExtractParentIssueNumber parses a GitHub issue number from a generation name
+// that follows the pattern "...-gh-<N>-..." (e.g., "generation-gh-206-slug"
+// → 206). Returns 0 if the pattern is not found.
+func ExtractParentIssueNumber(generation string) int {
+	const marker = "-gh-"
+	idx := strings.Index(generation, marker)
+	if idx < 0 {
+		return 0
+	}
+	rest := generation[idx+len(marker):]
+	var n int
+	if _, err := fmt.Sscanf(rest, "%d", &n); err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
+// GoModModulePath reads the module path from the go.mod in repoRoot.
+func GoModModulePath(repoRoot string) string {
+	data, err := os.ReadFile(filepath.Join(repoRoot, "go.mod"))
+	if err != nil {
+		return ""
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "module ") {
+			return strings.TrimSpace(strings.TrimPrefix(line, "module "))
+		}
+	}
+	return ""
+}
+
+// --- GitHubTracker methods (implement WorkTracker) ---
+
+// DetectGitHubRepo resolves the GitHub owner/repo string for the target project.
+// Resolution order:
+//  1. t.Cfg.IssuesRepo if set (explicit override, used for testing)
+//  2. `gh repo view --json nameWithOwner` run in repoRoot (reads git remote)
+//  3. Strip "github.com/" from t.Cfg.ModulePath
+func (t *GitHubTracker) DetectGitHubRepo(repoRoot string) (string, error) {
+	if t.Cfg.IssuesRepo != "" {
+		return t.Cfg.IssuesRepo, nil
+	}
+
+	// Try gh repo view in the repo root.
+	cmd := exec.Command(t.GhBin, "repo", "view", "--json", "nameWithOwner", "-q", ".nameWithOwner")
+	cmd.Dir = repoRoot
+	if out, err := cmd.Output(); err == nil {
+		if repo := strings.TrimSpace(string(out)); repo != "" {
+			return repo, nil
+		}
+	}
+
+	// Fall back to module path.
+	if strings.HasPrefix(t.Cfg.ModulePath, "github.com/") {
+		return strings.TrimPrefix(t.Cfg.ModulePath, "github.com/"), nil
+	}
+
+	return "", fmt.Errorf("cannot determine GitHub repo: set cobbler.issues_repo in configuration.yaml or ensure the project has a github.com module path")
+}
+
+// EnsureCobblerLabels creates the cobbler-ready and cobbler-in-progress labels
+// on the target repo if they do not already exist. Idempotent.
+func (t *GitHubTracker) EnsureCobblerLabels(repo string) error {
+	existing := t.ListRepoLabels(repo)
+	existingSet := make(map[string]bool, len(existing))
+	for _, l := range existing {
+		existingSet[l] = true
+	}
+
+	labels := []struct {
+		name  string
+		color string
+		desc  string
+	}{
+		{LabelReady, "0075ca", "Cobbler task ready to be picked by stitch"},
+		{LabelInProgress, "e4e669", "Cobbler task currently being worked on"},
+	}
+
+	for _, l := range labels {
+		if existingSet[l.name] {
+			continue
+		}
+		cmd := exec.Command(t.GhBin, "api", "repos/"+repo+"/labels",
+			"--method", "POST",
+			"--field", "name="+l.name,
+			"--field", "color="+l.color,
+			"--field", "description="+l.desc,
+		)
+		if out, err := cmd.Output(); err != nil {
+			t.Log("ensureCobblerLabels: could not create label %q: %v (output: %s)", l.name, err, string(out))
+		} else {
+			t.Log("ensureCobblerLabels: created label %q on %s", l.name, repo)
+		}
+	}
+	return nil
+}
+
+// ListRepoLabels returns the names of all labels on the repo.
+func (t *GitHubTracker) ListRepoLabels(repo string) []string {
+	out, err := exec.Command(t.GhBin, "label", "list", "--repo", repo, "--json", "name", "--limit", "100").Output()
+	if err != nil {
+		return nil
+	}
+	var labels []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(out, &labels); err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(labels))
+	for _, l := range labels {
+		names = append(names, l.Name)
+	}
+	return names
+}
+
+// EnsureCobblerGenLabel creates the generation-scoped label on the repo if
+// it does not already exist.
+func (t *GitHubTracker) EnsureCobblerGenLabel(repo, generation string) error {
+	label := GenLabel(generation)
+	cmd := exec.Command(t.GhBin, "api", "repos/"+repo+"/labels",
+		"--method", "POST",
+		"--field", "name="+label,
+		"--field", "color=ededed", // light grey; GitHub API requires a valid 6-char hex color
+		"--field", "description=Cobbler generation "+generation,
+	)
+	// Ignore error — label may already exist (422 Unprocessable Entity).
+	cmd.Run() //nolint:errcheck // best-effort
+	return nil
+}
+
+// CreateMeasuringPlaceholder creates a transient GitHub issue that signals
+// the measure agent is actively calling Claude for iteration i (1-based).
+// The issue carries no cobbler-ready label so stitch won't pick it up.
+// Callers must call CloseMeasuringPlaceholder after the iteration completes.
+func (t *GitHubTracker) CreateMeasuringPlaceholder(repo, generation string, iteration int) (int, error) {
+	title := fmt.Sprintf("[measuring] %s task %d", generation, iteration)
+	body := fmt.Sprintf("Cobbler measure is calling Claude to propose task %d for generation %s.\n\nThis issue will be closed automatically when measure completes.", iteration, generation)
+	// No cobbler labels: stitch ignores issues without a gen label, and the
+	// placeholder must not appear in the existing-issues context sent to Claude.
+	out, err := exec.Command(t.GhBin, "issue", "create",
+		"--repo", repo,
+		"--title", title,
+		"--body", body,
+	).Output()
+	if err != nil {
+		return 0, fmt.Errorf("gh issue create placeholder: %w", err)
+	}
+	number, err := ParseIssueURL(string(out))
+	if err != nil {
+		return 0, err
+	}
+	t.Log("createMeasuringPlaceholder: created #%d for iteration %d", number, iteration)
+	return number, nil
+}
+
+// CloseMeasuringPlaceholder closes the placeholder issue created by
+// CreateMeasuringPlaceholder. Best-effort: logs and ignores errors.
+func (t *GitHubTracker) CloseMeasuringPlaceholder(repo string, number int) {
+	if err := exec.Command(t.GhBin, "issue", "close",
+		"--repo", repo,
+		fmt.Sprintf("%d", number),
+	).Run(); err != nil {
+		t.Log("closeMeasuringPlaceholder: close #%d warning: %v", number, err)
+		return
+	}
+	t.Log("closeMeasuringPlaceholder: closed #%d", number)
+}
+
+// CloseMeasuringPlaceholderWithComment closes the placeholder issue and adds a
+// comment explaining why it was closed. Used on error paths to avoid orphans
+// (GH-747). Best-effort: logs and ignores errors.
+func (t *GitHubTracker) CloseMeasuringPlaceholderWithComment(repo string, number int, comment string) {
+	if err := exec.Command(t.GhBin, "issue", "comment",
+		"--repo", repo,
+		fmt.Sprintf("%d", number),
+		"--body", comment,
+	).Run(); err != nil {
+		t.Log("closeMeasuringPlaceholderWithComment: comment on #%d warning: %v", number, err)
+	}
+	t.CloseMeasuringPlaceholder(repo, number)
+}
+
+// UpgradeMeasuringPlaceholder converts the transient measuring placeholder
+// into the task issue in-place. It edits the placeholder's title and body
+// to match the proposed issue, adds the cobbler-gen label so stitch can
+// pick it up, and links it as a sub-issue of the parent generation issue
+// if the generation name encodes one (GH-578).
+func (t *GitHubTracker) UpgradeMeasuringPlaceholder(repo string, number int, generation string, issue ProposedIssue) error {
+	body := FormatIssueFrontMatter(generation, issue.Index, issue.Dependency) + issue.Description
+	title := "[measure] " + issue.Title
+
+	// Edit title and body in one command.
+	if err := exec.Command(t.GhBin, "issue", "edit",
+		"--repo", repo,
+		fmt.Sprintf("%d", number),
+		"--title", title,
+		"--body", body,
+	).Run(); err != nil {
+		return fmt.Errorf("gh issue edit placeholder #%d: %w", number, err)
+	}
+
+	// Add cobbler-gen label so stitch can pick it up.
+	if err := t.AddIssueLabel(repo, number, GenLabel(generation)); err != nil {
+		return fmt.Errorf("adding gen label to #%d: %w", number, err)
+	}
+
+	t.Log("upgradeMeasuringPlaceholder: upgraded #%d %q gen=%s index=%d dep=%d",
+		number, title, generation, issue.Index, issue.Dependency)
+
+	// Link as sub-issue of the parent if the generation name encodes one.
+	if parentNumber := ExtractParentIssueNumber(generation); parentNumber > 0 {
+		if err := t.LinkSubIssue(repo, parentNumber, number); err != nil {
+			t.Log("upgradeMeasuringPlaceholder: linkSubIssue warning for #%d -> parent #%d: %v", number, parentNumber, err)
+		}
+	}
+	return nil
+}
+
+// CreateCobblerIssue creates a GitHub issue on repo for the given generation
+// and ProposedIssue. Returns the GitHub issue number.
+//
+// Note: gh issue create (v2.87.3) does not support --json; it outputs the
+// issue URL (https://github.com/owner/repo/issues/123) on success.
+func (t *GitHubTracker) CreateCobblerIssue(repo, generation string, issue ProposedIssue) (int, error) {
+	body := FormatIssueFrontMatter(generation, issue.Index, issue.Dependency) + issue.Description
+	title := "[measure] " + issue.Title
+
+	genLabel := GenLabel(generation)
+	out, err := exec.Command(t.GhBin, "issue", "create",
+		"--repo", repo,
+		"--title", title,
+		"--body", body,
+		"--label", genLabel,
+	).Output()
+	if err != nil {
+		return 0, fmt.Errorf("gh issue create: %w", err)
+	}
+
+	number, err := ParseIssueURL(string(out))
+	if err != nil {
+		return 0, err
+	}
+	t.Log("createCobblerIssue: created #%d %q gen=%s index=%d dep=%d",
+		number, title, generation, issue.Index, issue.Dependency)
+
+	// Link as sub-issue of the parent, if the generation name encodes one (GH-566).
+	if parentNumber := ExtractParentIssueNumber(generation); parentNumber > 0 {
+		if err := t.LinkSubIssue(repo, parentNumber, number); err != nil {
+			t.Log("createCobblerIssue: linkSubIssue warning for #%d -> parent #%d: %v", number, parentNumber, err)
+		}
+	}
+
+	return number, nil
+}
+
+// LinkSubIssue attaches childNumber as a GitHub sub-issue of parentNumber.
+// It first fetches the child's database ID, then POSTs to the sub_issues API.
+// Errors are returned so the caller can log them as warnings.
+func (t *GitHubTracker) LinkSubIssue(repo string, parentNumber, childNumber int) error {
+	// Fetch the child issue's database ID (different from the display number).
+	dbIDOut, err := exec.Command(t.GhBin, "api",
+		fmt.Sprintf("repos/%s/issues/%d", repo, childNumber),
+		"--jq", ".id",
+	).Output()
+	if err != nil {
+		return fmt.Errorf("fetching database id for #%d: %w", childNumber, err)
+	}
+	dbIDStr := strings.TrimSpace(string(dbIDOut))
+	var dbID int
+	if _, err := fmt.Sscanf(dbIDStr, "%d", &dbID); err != nil || dbID <= 0 {
+		return fmt.Errorf("parsing database id %q for #%d: %w", dbIDStr, childNumber, err)
+	}
+
+	// POST to the parent's sub_issues endpoint.
+	out, err := exec.Command(t.GhBin, "api",
+		fmt.Sprintf("repos/%s/issues/%d/sub_issues", repo, parentNumber),
+		"--method", "POST",
+		"--field", fmt.Sprintf("sub_issue_id=%d", dbID),
+	).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("linking #%d as sub-issue of #%d: %w (output: %s)",
+			childNumber, parentNumber, err, strings.TrimSpace(string(out)))
+	}
+	t.Log("linkSubIssue: linked #%d as sub-issue of #%d", childNumber, parentNumber)
+	return nil
+}
+
+// ListOpenCobblerIssues returns all open GitHub issues for a generation.
+// It uses the REST API endpoint (gh api repos/.../issues) rather than
+// gh issue list, because gh issue list uses GitHub's search API which is
+// eventually consistent and can return stale results immediately after
+// label changes. The REST endpoint reads directly from the database.
+func (t *GitHubTracker) ListOpenCobblerIssues(repo, generation string) ([]CobblerIssue, error) {
+	label := GenLabel(generation)
+	out, err := exec.Command(t.GhBin, "api",
+		"--method", "GET",
+		fmt.Sprintf("repos/%s/issues", repo),
+		"-f", "state=open",
+		"-f", "labels="+label,
+		"-f", "per_page=100",
+	).Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh api repos issues: %w", err)
+	}
+
+	return ParseCobblerIssuesJSON(out)
+}
+
+// ListAllCobblerIssues returns all GitHub issues (open and closed) for a
+// generation. Used by GeneratorStats to report completed tasks.
+func (t *GitHubTracker) ListAllCobblerIssues(repo, generation string) ([]CobblerIssue, error) {
+	label := GenLabel(generation)
+	out, err := exec.Command(t.GhBin, "api",
+		"--method", "GET",
+		fmt.Sprintf("repos/%s/issues", repo),
+		"-f", "state=all",
+		"-f", "labels="+label,
+		"-f", "per_page=100",
+	).Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh api repos issues: %w", err)
+	}
+	return ParseCobblerIssuesJSON(out)
+}
+
+// FetchIssueComments returns the body text of all comments on the given issue.
+func (t *GitHubTracker) FetchIssueComments(repo string, number int) ([]string, error) {
+	out, err := exec.Command(t.GhBin, "api",
+		fmt.Sprintf("repos/%s/issues/%d/comments", repo, number),
+	).Output()
+	if err != nil {
+		return nil, fmt.Errorf("gh api issue comments for #%d: %w", number, err)
+	}
+	var raw []struct {
+		Body string `json:"body"`
+	}
+	if err := json.Unmarshal(out, &raw); err != nil {
+		return nil, fmt.Errorf("parsing issue comments for #%d: %w", number, err)
+	}
+	bodies := make([]string, 0, len(raw))
+	for _, r := range raw {
+		bodies = append(bodies, r.Body)
+	}
+	return bodies, nil
+}
+
 // WaitForIssuesVisible polls ListOpenCobblerIssues until at least
 // expected issues appear or the timeout expires. The REST API label
 // index may lag briefly after issue creation, so this function
 // ensures all issues are visible before promotion or DAG resolution.
-func WaitForIssuesVisible(repo, generation string, expected int, deps Deps) {
+func (t *GitHubTracker) WaitForIssuesVisible(repo, generation string, expected int) {
 	const maxWait = 15 * time.Second
 	const interval = time.Second
 	deadline := time.Now().Add(maxWait)
 	for time.Now().Before(deadline) {
-		issues, err := ListOpenCobblerIssues(repo, generation, deps)
+		issues, err := t.ListOpenCobblerIssues(repo, generation)
 		if err == nil && len(issues) >= expected {
 			return
 		}
-		deps.Log("waitForIssuesVisible: %d/%d visible, retrying...", len(issues), expected)
+		t.Log("waitForIssuesVisible: %d/%d visible, retrying...", len(issues), expected)
 		time.Sleep(interval)
 	}
-	deps.Log("waitForIssuesVisible: timed out waiting for %d issues (generation=%s)", expected, generation)
-}
-
-// HasLabel returns true if the issue has the given label.
-func HasLabel(issue CobblerIssue, label string) bool {
-	for _, l := range issue.Labels {
-		if l == label {
-			return true
-		}
-	}
-	return false
+	t.Log("waitForIssuesVisible: timed out waiting for %d issues (generation=%s)", expected, generation)
 }
 
 // PromoteReadyIssues builds the DAG from open issues and applies
 // cobbler-ready to unblocked issues. Issues whose dependency is still open
 // have cobbler-ready removed.
-func PromoteReadyIssues(repo, generation string, deps Deps) error {
-	issues, err := ListOpenCobblerIssues(repo, generation, deps)
+func (t *GitHubTracker) PromoteReadyIssues(repo, generation string) error {
+	issues, err := t.ListOpenCobblerIssues(repo, generation)
 	if err != nil {
 		return fmt.Errorf("promoteReadyIssues: %w", err)
 	}
@@ -587,12 +710,12 @@ func PromoteReadyIssues(repo, generation string, deps Deps) error {
 		currentlyReady := HasLabel(iss, LabelReady)
 
 		if !blocked && !currentlyReady {
-			if err := AddIssueLabel(repo, iss.Number, LabelReady, deps); err != nil {
-				deps.Log("promoteReadyIssues: add ready label to #%d: %v", iss.Number, err)
+			if err := t.AddIssueLabel(repo, iss.Number, LabelReady); err != nil {
+				t.Log("promoteReadyIssues: add ready label to #%d: %v", iss.Number, err)
 			}
 		} else if blocked && currentlyReady {
-			if err := RemoveIssueLabel(repo, iss.Number, LabelReady, deps); err != nil {
-				deps.Log("promoteReadyIssues: remove ready label from #%d: %v", iss.Number, err)
+			if err := t.RemoveIssueLabel(repo, iss.Number, LabelReady); err != nil {
+				t.Log("promoteReadyIssues: remove ready label from #%d: %v", iss.Number, err)
 			}
 		}
 	}
@@ -601,12 +724,12 @@ func PromoteReadyIssues(repo, generation string, deps Deps) error {
 
 // PickReadyIssue promotes ready issues then picks the lowest-numbered
 // cobbler-ready issue, adds cobbler-in-progress, and returns it.
-func PickReadyIssue(repo, generation string, deps Deps) (CobblerIssue, error) {
-	if err := PromoteReadyIssues(repo, generation, deps); err != nil {
+func (t *GitHubTracker) PickReadyIssue(repo, generation string) (CobblerIssue, error) {
+	if err := t.PromoteReadyIssues(repo, generation); err != nil {
 		return CobblerIssue{}, fmt.Errorf("pickReadyIssue promote: %w", err)
 	}
 
-	issues, err := ListOpenCobblerIssues(repo, generation, deps)
+	issues, err := t.ListOpenCobblerIssues(repo, generation)
 	if err != nil {
 		return CobblerIssue{}, fmt.Errorf("pickReadyIssue list: %w", err)
 	}
@@ -624,91 +747,75 @@ func PickReadyIssue(repo, generation string, deps Deps) (CobblerIssue, error) {
 	sort.Slice(ready, func(i, j int) bool { return ready[i].Number < ready[j].Number })
 
 	picked := ready[0]
-	if err := AddIssueLabel(repo, picked.Number, LabelInProgress, deps); err != nil {
-		deps.Log("pickReadyIssue: add in-progress label to #%d: %v", picked.Number, err)
+	if err := t.AddIssueLabel(repo, picked.Number, LabelInProgress); err != nil {
+		t.Log("pickReadyIssue: add in-progress label to #%d: %v", picked.Number, err)
 	}
-	if err := RemoveIssueLabel(repo, picked.Number, LabelReady, deps); err != nil {
-		deps.Log("pickReadyIssue: remove ready label from #%d: %v", picked.Number, err)
+	if err := t.RemoveIssueLabel(repo, picked.Number, LabelReady); err != nil {
+		t.Log("pickReadyIssue: remove ready label from #%d: %v", picked.Number, err)
 	}
 
 	// Rename [measure] → [stitch] so stats:generator shows which phase executed the task.
 	if strings.HasPrefix(picked.Title, "[measure] ") {
 		picked.Title = "[stitch] " + strings.TrimPrefix(picked.Title, "[measure] ")
-		if err := EditIssueTitle(repo, picked.Number, picked.Title, deps); err != nil {
-			deps.Log("pickReadyIssue: rename title warning for #%d: %v", picked.Number, err)
+		if err := t.EditIssueTitle(repo, picked.Number, picked.Title); err != nil {
+			t.Log("pickReadyIssue: rename title warning for #%d: %v", picked.Number, err)
 		}
 	}
 
-	deps.Log("pickReadyIssue: picked #%d %q gen=%s", picked.Number, picked.Title, generation)
+	t.Log("pickReadyIssue: picked #%d %q gen=%s", picked.Number, picked.Title, generation)
 	return picked, nil
 }
 
 // EditIssueTitle updates the title of a GitHub issue.
-func EditIssueTitle(repo string, number int, title string, deps Deps) error {
-	return exec.Command(deps.GhBin, "issue", "edit",
+func (t *GitHubTracker) EditIssueTitle(repo string, number int, title string) error {
+	return exec.Command(t.GhBin, "issue", "edit",
 		"--repo", repo,
 		fmt.Sprintf("%d", number),
 		"--title", title,
 	).Run()
 }
 
-// NormalizeIssueTitle strips [measure]/[stitch] prefixes and trims whitespace
-// so that proposed titles can be compared against existing issues (GH-1026).
-func NormalizeIssueTitle(title string) string {
-	t := strings.TrimSpace(title)
-	for _, prefix := range []string{"[measure] ", "[stitch] "} {
-		t = strings.TrimPrefix(t, prefix)
-	}
-	return strings.TrimSpace(t)
-}
-
 // CloseCobblerIssue closes a GitHub issue and re-runs PromoteReadyIssues so
 // any unblocked issues become ready.
-func CloseCobblerIssue(repo string, number int, generation string, deps Deps) error {
-	if err := RemoveIssueLabel(repo, number, LabelInProgress, deps); err != nil {
-		deps.Log("closeCobblerIssue: remove in-progress label from #%d: %v", number, err)
+func (t *GitHubTracker) CloseCobblerIssue(repo string, number int, generation string) error {
+	if err := t.RemoveIssueLabel(repo, number, LabelInProgress); err != nil {
+		t.Log("closeCobblerIssue: remove in-progress label from #%d: %v", number, err)
 	}
-	if err := exec.Command(deps.GhBin, "issue", "close",
+	if err := exec.Command(t.GhBin, "issue", "close",
 		"--repo", repo,
 		fmt.Sprintf("%d", number),
 	).Run(); err != nil {
 		return fmt.Errorf("gh issue close #%d: %w", number, err)
 	}
-	deps.Log("closeCobblerIssue: closed #%d", number)
+	t.Log("closeCobblerIssue: closed #%d", number)
 
-	if err := PromoteReadyIssues(repo, generation, deps); err != nil {
-		deps.Log("closeCobblerIssue: promoteReadyIssues warning: %v", err)
+	if err := t.PromoteReadyIssues(repo, generation); err != nil {
+		t.Log("closeCobblerIssue: promoteReadyIssues warning: %v", err)
 	}
 	return nil
 }
 
-// RemoveInProgressLabel removes the cobbler-in-progress label from an issue,
-// returning it to cobbler-ready state. Used by resetTask.
-func RemoveInProgressLabel(repo string, number int, deps Deps) error {
-	return RemoveIssueLabel(repo, number, LabelInProgress, deps)
-}
-
 // CloseGenerationIssues closes all open issues scoped to a generation.
 // Used during reset or cleanup of a failed generation.
-func CloseGenerationIssues(repo, generation string, deps Deps) error {
+func (t *GitHubTracker) CloseGenerationIssues(repo, generation string) error {
 	if generation == "" {
 		return nil
 	}
-	issues, err := ListOpenCobblerIssues(repo, generation, deps)
+	issues, err := t.ListOpenCobblerIssues(repo, generation)
 	if err != nil {
 		return fmt.Errorf("closeGenerationIssues: list: %w", err)
 	}
 	if len(issues) == 0 {
-		deps.Log("closeGenerationIssues: no open issues for generation %s", generation)
+		t.Log("closeGenerationIssues: no open issues for generation %s", generation)
 		return nil
 	}
-	deps.Log("closeGenerationIssues: closing %d issue(s) for generation %s", len(issues), generation)
+	t.Log("closeGenerationIssues: closing %d issue(s) for generation %s", len(issues), generation)
 	for _, iss := range issues {
-		if err := exec.Command(deps.GhBin, "issue", "close",
+		if err := exec.Command(t.GhBin, "issue", "close",
 			"--repo", repo,
 			fmt.Sprintf("%d", iss.Number),
 		).Run(); err != nil {
-			deps.Log("closeGenerationIssues: close #%d warning: %v", iss.Number, err)
+			t.Log("closeGenerationIssues: close #%d warning: %v", iss.Number, err)
 		}
 	}
 	return nil
@@ -720,18 +827,18 @@ func CloseGenerationIssues(repo, generation string, deps Deps) error {
 // It fetches all open issues in a single API call, filters locally for
 // cobbler-gen-* labels, groups by generation, and closes issues for
 // missing branches. Cost: 1 API call for discovery + 1 per stale issue.
-func GcStaleGenerationIssues(repo, generationPrefix string, deps Deps) {
+func (t *GitHubTracker) GcStaleGenerationIssues(repo, generationPrefix string) {
 	// Fetch all open issues in a single API call and filter locally for
 	// cobbler-gen-* labels. This replaces the previous O(labels) approach
 	// that listed all labels then queried issues per label.
-	out, err := exec.Command(deps.GhBin, "api",
+	out, err := exec.Command(t.GhBin, "api",
 		fmt.Sprintf("repos/%s/issues", repo),
 		"--method", "GET",
 		"-f", "state=open",
 		"-f", "per_page=100",
 	).Output()
 	if err != nil {
-		deps.Log("gcStaleGenerationIssues: list issues: %v", err)
+		t.Log("gcStaleGenerationIssues: list issues: %v", err)
 		return
 	}
 
@@ -743,7 +850,7 @@ func GcStaleGenerationIssues(repo, generationPrefix string, deps Deps) {
 		} `json:"labels"`
 	}
 	if err := json.Unmarshal(out, &raw); err != nil {
-		deps.Log("gcStaleGenerationIssues: parse issues: %v", err)
+		t.Log("gcStaleGenerationIssues: parse issues: %v", err)
 		return
 	}
 
@@ -774,16 +881,16 @@ func GcStaleGenerationIssues(repo, generationPrefix string, deps Deps) {
 
 	// Close issues for generations whose branch no longer exists locally.
 	for generation, numbers := range byGeneration {
-		if deps.BranchExists(generation, ".") {
+		if t.BranchExists(generation, ".") {
 			continue
 		}
-		deps.Log("gcStaleGenerationIssues: branch %s gone, closing %d issue(s)", generation, len(numbers))
+		t.Log("gcStaleGenerationIssues: branch %s gone, closing %d issue(s)", generation, len(numbers))
 		for _, num := range numbers {
-			if err := exec.Command(deps.GhBin, "issue", "close",
+			if err := exec.Command(t.GhBin, "issue", "close",
 				"--repo", repo,
 				fmt.Sprintf("%d", num),
 			).Run(); err != nil {
-				deps.Log("gcStaleGenerationIssues: close #%d: %v", num, err)
+				t.Log("gcStaleGenerationIssues: close #%d: %v", num, err)
 			}
 		}
 	}
@@ -792,8 +899,8 @@ func GcStaleGenerationIssues(repo, generationPrefix string, deps Deps) {
 // ListActiveIssuesContext returns a JSON array of ContextIssue objects for all
 // open issues in the generation, suitable for injection into the measure prompt.
 // The JSON format matches what parseIssuesJSON expects.
-func ListActiveIssuesContext(repo, generation string, deps Deps) (string, error) {
-	issues, err := ListOpenCobblerIssues(repo, generation, deps)
+func (t *GitHubTracker) ListActiveIssuesContext(repo, generation string) (string, error) {
+	issues, err := t.ListOpenCobblerIssues(repo, generation)
 	if err != nil {
 		return "", fmt.Errorf("listActiveIssuesContext: %w", err)
 	}
@@ -804,33 +911,9 @@ func ListActiveIssuesContext(repo, generation string, deps Deps) (string, error)
 	return IssuesContextJSON(issues)
 }
 
-// IssuesContextJSON converts a slice of CobblerIssue into the JSON string
-// expected by parseIssuesJSON. Exported for testing.
-func IssuesContextJSON(issues []CobblerIssue) (string, error) {
-	ctx := make([]ContextIssue, len(issues))
-	for i, iss := range issues {
-		status := "backfill"
-		if HasLabel(iss, LabelInProgress) {
-			status = "in_progress"
-		} else if HasLabel(iss, LabelReady) {
-			status = "ready"
-		}
-		ctx[i] = ContextIssue{
-			ID:     fmt.Sprintf("%d", iss.Number),
-			Title:  iss.Title,
-			Status: status,
-		}
-	}
-	b, err := json.Marshal(ctx)
-	if err != nil {
-		return "", fmt.Errorf("issuesContextJSON: %w", err)
-	}
-	return string(b), nil
-}
-
 // AddIssueLabel adds a label to a GitHub issue via the API.
-func AddIssueLabel(repo string, number int, label string, deps Deps) error {
-	return exec.Command(deps.GhBin, "issue", "edit",
+func (t *GitHubTracker) AddIssueLabel(repo string, number int, label string) error {
+	return exec.Command(t.GhBin, "issue", "edit",
 		"--repo", repo,
 		fmt.Sprintf("%d", number),
 		"--add-label", label,
@@ -838,8 +921,8 @@ func AddIssueLabel(repo string, number int, label string, deps Deps) error {
 }
 
 // RemoveIssueLabel removes a label from a GitHub issue via the API.
-func RemoveIssueLabel(repo string, number int, label string, deps Deps) error {
-	return exec.Command(deps.GhBin, "issue", "edit",
+func (t *GitHubTracker) RemoveIssueLabel(repo string, number int, label string) error {
+	return exec.Command(t.GhBin, "issue", "edit",
 		"--repo", repo,
 		fmt.Sprintf("%d", number),
 		"--remove-label", label,
@@ -847,67 +930,38 @@ func RemoveIssueLabel(repo string, number int, label string, deps Deps) error {
 }
 
 // GhExec runs a gh subcommand with dir set to repoRoot and returns stdout.
-func GhExec(repoRoot string, deps Deps, args ...string) (string, error) {
-	cmd := exec.Command(deps.GhBin, args...)
+func (t *GitHubTracker) GhExec(repoRoot string, args ...string) (string, error) {
+	cmd := exec.Command(t.GhBin, args...)
 	cmd.Dir = repoRoot
 	out, err := cmd.Output()
 	return strings.TrimSpace(string(out)), err
 }
 
-// GoModModulePath reads the module path from the go.mod in repoRoot.
-func GoModModulePath(repoRoot string) string {
-	data, err := os.ReadFile(filepath.Join(repoRoot, "go.mod"))
-	if err != nil {
-		return ""
-	}
-	for _, line := range strings.Split(string(data), "\n") {
-		if strings.HasPrefix(line, "module ") {
-			return strings.TrimSpace(strings.TrimPrefix(line, "module "))
-		}
-	}
-	return ""
-}
-
-// ResolveTargetRepo returns the GitHub owner/repo string for the project being
-// developed. It checks cfg.TargetRepo first; if empty it strips
-// "github.com/" from cfg.ModulePath. Returns "" if neither yields a
-// non-empty value. Intentionally separate from DetectGitHubRepo to avoid
-// cobbler.issues_repo contaminating target resolution (prd003 R11.4, D2).
-func ResolveTargetRepo(cfg RepoConfig) string {
-	if cfg.TargetRepo != "" {
-		return cfg.TargetRepo
-	}
-	if strings.HasPrefix(cfg.ModulePath, "github.com/") {
-		return strings.TrimPrefix(cfg.ModulePath, "github.com/")
-	}
-	return ""
-}
-
 // CommentCobblerIssue posts a comment on a GitHub issue. Errors are logged
 // but do not fail the caller — commenting is best-effort.
-func CommentCobblerIssue(repo string, number int, body string, deps Deps) {
+func (t *GitHubTracker) CommentCobblerIssue(repo string, number int, body string) {
 	if repo == "" || number <= 0 {
 		return
 	}
-	out, err := exec.Command(deps.GhBin, "issue", "comment",
+	out, err := exec.Command(t.GhBin, "issue", "comment",
 		fmt.Sprintf("%d", number),
 		"--repo", repo,
 		"--body", body,
 	).CombinedOutput()
 	if err != nil {
-		deps.Log("commentCobblerIssue: gh issue comment failed for #%d: %v (output: %s)", number, err, strings.TrimSpace(string(out)))
+		t.Log("commentCobblerIssue: gh issue comment failed for #%d: %v (output: %s)", number, err, strings.TrimSpace(string(out)))
 		return
 	}
-	deps.Log("commentCobblerIssue: posted comment on #%d", number)
+	t.Log("commentCobblerIssue: posted comment on #%d", number)
 }
 
 // FileTargetRepoDefects files each defect as a GitHub bug issue in repo.
 // Errors are logged but do not fail the caller — filing is best-effort
 // (prd003 R11.5, R11.6). If repo is empty the call is a no-op with a
 // warning log (prd003 R11.7).
-func FileTargetRepoDefects(repo string, defects []string, deps Deps) {
+func (t *GitHubTracker) FileTargetRepoDefects(repo string, defects []string) {
 	if repo == "" {
-		deps.Log("fileTargetRepoDefects: no target repo configured; skipping %d defect(s)", len(defects))
+		t.Log("fileTargetRepoDefects: no target repo configured; skipping %d defect(s)", len(defects))
 		return
 	}
 	for _, defect := range defects {
@@ -916,16 +970,31 @@ func FileTargetRepoDefects(repo string, defects []string, deps Deps) {
 			title = title[:68] + "..."
 		}
 		body := "## Defect detected by cobbler:measure\n\n" + defect
-		out, err := exec.Command(deps.GhBin, "issue", "create",
+		out, err := exec.Command(t.GhBin, "issue", "create",
 			"--repo", repo,
 			"--title", title,
 			"--body", body,
 			"--label", "bug",
 		).CombinedOutput()
 		if err != nil {
-			deps.Log("fileTargetRepoDefects: gh issue create failed for %q: %v (output: %s)", defect, err, string(out))
+			t.Log("fileTargetRepoDefects: gh issue create failed for %q: %v (output: %s)", defect, err, string(out))
 			continue
 		}
-		deps.Log("fileTargetRepoDefects: filed defect issue in %s: %s", repo, strings.TrimSpace(string(out)))
+		t.Log("fileTargetRepoDefects: filed defect issue in %s: %s", repo, strings.TrimSpace(string(out)))
 	}
+}
+
+// ResolveTargetRepo returns the GitHub owner/repo string for the project being
+// developed. It checks t.Cfg.TargetRepo first; if empty it strips
+// "github.com/" from t.Cfg.ModulePath. Returns "" if neither yields a
+// non-empty value. Intentionally separate from DetectGitHubRepo to avoid
+// cobbler.issues_repo contaminating target resolution (prd003 R11.4, D2).
+func (t *GitHubTracker) ResolveTargetRepo() string {
+	if t.Cfg.TargetRepo != "" {
+		return t.Cfg.TargetRepo
+	}
+	if strings.HasPrefix(t.Cfg.ModulePath, "github.com/") {
+		return strings.TrimPrefix(t.Cfg.ModulePath, "github.com/")
+	}
+	return ""
 }

--- a/pkg/orchestrator/internal/github/issues_test.go
+++ b/pkg/orchestrator/internal/github/issues_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 )
 
+// Compile-time interface satisfaction check.
+var _ WorkTracker = (*GitHubTracker)(nil)
+
 // TestParseIssueFrontMatter verifies round-trip parsing of the YAML
 // front-matter block embedded in issue bodies.
 func TestParseIssueFrontMatter(t *testing.T) {
@@ -158,13 +161,25 @@ func TestGenLabel(t *testing.T) {
 	}
 }
 
+// testTracker returns a GitHubTracker suitable for unit tests that call
+// the gh CLI against fake repos (expecting errors, not panics).
+func testTracker(t *testing.T) *GitHubTracker {
+	t.Helper()
+	return &GitHubTracker{
+		Log:   t.Logf,
+		GhBin: "gh",
+	}
+}
+
 // TestDetectGitHubRepoFromConfig verifies that IssuesRepo config override
 // is returned directly without running any external commands.
 func TestDetectGitHubRepoFromConfig(t *testing.T) {
 	t.Parallel()
-	cfg := RepoConfig{IssuesRepo: "owner/repo"}
-	deps := Deps{Log: t.Logf}
-	got, err := DetectGitHubRepo(t.TempDir(), cfg, deps)
+	tr := &GitHubTracker{
+		Log: t.Logf,
+		Cfg: RepoConfig{IssuesRepo: "owner/repo"},
+	}
+	got, err := tr.DetectGitHubRepo(t.TempDir())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -184,10 +199,13 @@ func TestDetectGitHubRepoFromModulePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	cfg := RepoConfig{ModulePath: "github.com/acme/myproject"}
-	deps := Deps{Log: t.Logf, GhBin: "gh"}
+	tr := &GitHubTracker{
+		Log:   t.Logf,
+		GhBin: "gh",
+		Cfg:   RepoConfig{ModulePath: "github.com/acme/myproject"},
+	}
 	// Pass non-existent dir so gh repo view fails → falls through to module path.
-	got, err := DetectGitHubRepo(dir, cfg, deps)
+	got, err := tr.DetectGitHubRepo(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -289,12 +307,14 @@ func TestGoModModulePath_NoModuleLine(t *testing.T) {
 
 func TestResolveTargetRepo_ExplicitTargetRepo(t *testing.T) {
 	t.Parallel()
-	cfg := RepoConfig{
-		TargetRepo: "owner/target-project",
-		ModulePath: "github.com/owner/other", // ignored when TargetRepo set
+	tr := &GitHubTracker{
+		Cfg: RepoConfig{
+			TargetRepo: "owner/target-project",
+			ModulePath: "github.com/owner/other", // ignored when TargetRepo set
+		},
 	}
 
-	got := ResolveTargetRepo(cfg)
+	got := tr.ResolveTargetRepo()
 	if got != "owner/target-project" {
 		t.Errorf("got %q, want %q", got, "owner/target-project")
 	}
@@ -302,9 +322,11 @@ func TestResolveTargetRepo_ExplicitTargetRepo(t *testing.T) {
 
 func TestResolveTargetRepo_FallbackToModulePath(t *testing.T) {
 	t.Parallel()
-	cfg := RepoConfig{ModulePath: "github.com/acme/sdd-hello-world"}
+	tr := &GitHubTracker{
+		Cfg: RepoConfig{ModulePath: "github.com/acme/sdd-hello-world"},
+	}
 
-	got := ResolveTargetRepo(cfg)
+	got := tr.ResolveTargetRepo()
 	if got != "acme/sdd-hello-world" {
 		t.Errorf("got %q, want %q", got, "acme/sdd-hello-world")
 	}
@@ -312,9 +334,11 @@ func TestResolveTargetRepo_FallbackToModulePath(t *testing.T) {
 
 func TestResolveTargetRepo_NonGitHub(t *testing.T) {
 	t.Parallel()
-	cfg := RepoConfig{ModulePath: "gitlab.com/org/project"}
+	tr := &GitHubTracker{
+		Cfg: RepoConfig{ModulePath: "gitlab.com/org/project"},
+	}
 
-	got := ResolveTargetRepo(cfg)
+	got := tr.ResolveTargetRepo()
 	if got != "" {
 		t.Errorf("got %q, want empty for non-github module path", got)
 	}
@@ -322,8 +346,8 @@ func TestResolveTargetRepo_NonGitHub(t *testing.T) {
 
 func TestResolveTargetRepo_Empty(t *testing.T) {
 	t.Parallel()
-	cfg := RepoConfig{}
-	got := ResolveTargetRepo(cfg)
+	tr := &GitHubTracker{Cfg: RepoConfig{}}
+	got := tr.ResolveTargetRepo()
 	if got != "" {
 		t.Errorf("got %q, want empty when nothing configured", got)
 	}
@@ -615,8 +639,8 @@ func TestPickReadyIssue_FilterExcludesBothLabels(t *testing.T) {
 // error (not panic) when the GitHub CLI fails on a fake repo (GH-569).
 func TestCloseCobblerIssue_FakeRepo_NoOp(t *testing.T) {
 	t.Parallel()
-	deps := Deps{Log: t.Logf, GhBin: "gh"}
-	err := CloseCobblerIssue("fake/repo-that-does-not-exist", 99999, "gen-test", deps)
+	tr := testTracker(t)
+	err := tr.CloseCobblerIssue("fake/repo-that-does-not-exist", 99999, "gen-test")
 	if err == nil {
 		t.Error("CloseCobblerIssue with fake repo must return an error")
 	}
@@ -628,8 +652,8 @@ func TestCloseCobblerIssue_FakeRepo_NoOp(t *testing.T) {
 // returns an error (not panic) when the GitHub CLI fails on a fake repo (GH-568).
 func TestCreateMeasuringPlaceholder_FakeRepo_Error(t *testing.T) {
 	t.Parallel()
-	deps := Deps{Log: t.Logf, GhBin: "gh"}
-	_, err := CreateMeasuringPlaceholder("fake/repo-that-does-not-exist", "gen-test", 1, deps)
+	tr := testTracker(t)
+	_, err := tr.CreateMeasuringPlaceholder("fake/repo-that-does-not-exist", "gen-test", 1)
 	if err == nil {
 		t.Error("CreateMeasuringPlaceholder with fake repo must return an error")
 	}
@@ -639,8 +663,8 @@ func TestCreateMeasuringPlaceholder_FakeRepo_Error(t *testing.T) {
 // does not panic when the GitHub CLI fails on a fake repo (GH-568).
 func TestCloseMeasuringPlaceholder_FakeRepo_NoOp(t *testing.T) {
 	t.Parallel()
-	deps := Deps{Log: t.Logf, GhBin: "gh"}
-	CloseMeasuringPlaceholder("fake/repo-that-does-not-exist", 99999, deps) // must not panic
+	tr := testTracker(t)
+	tr.CloseMeasuringPlaceholder("fake/repo-that-does-not-exist", 99999) // must not panic
 }
 
 // TestCloseMeasuringPlaceholderWithComment_FakeRepo_NoOp verifies
@@ -648,9 +672,9 @@ func TestCloseMeasuringPlaceholder_FakeRepo_NoOp(t *testing.T) {
 // fails on a fake repo (GH-747).
 func TestCloseMeasuringPlaceholderWithComment_FakeRepo_NoOp(t *testing.T) {
 	t.Parallel()
-	deps := Deps{Log: t.Logf, GhBin: "gh"}
-	CloseMeasuringPlaceholderWithComment("fake/repo-that-does-not-exist", 99999,
-		"Measure did not complete; closed automatically.", deps) // must not panic
+	tr := testTracker(t)
+	tr.CloseMeasuringPlaceholderWithComment("fake/repo-that-does-not-exist", 99999,
+		"Measure did not complete; closed automatically.") // must not panic
 }
 
 // TestPlaceholderResolved_DeferIsNoOpOnSuccess verifies that when
@@ -700,17 +724,17 @@ func TestPlaceholderResolved_DeferFiresOnFailure(t *testing.T) {
 // panic when the GitHub CLI fails on a fake repo (GH-567).
 func TestCommentCobblerIssue_FakeRepo_NoOp(t *testing.T) {
 	t.Parallel()
-	deps := Deps{Log: t.Logf, GhBin: "gh"}
-	CommentCobblerIssue("fake/repo-that-does-not-exist", 99999, "test body", deps) // must not panic
+	tr := testTracker(t)
+	tr.CommentCobblerIssue("fake/repo-that-does-not-exist", 99999, "test body") // must not panic
 }
 
 // TestCommentCobblerIssue_ZeroNumber_NoOp verifies CommentCobblerIssue is a
 // no-op for invalid inputs (GH-567).
 func TestCommentCobblerIssue_ZeroNumber_NoOp(t *testing.T) {
 	t.Parallel()
-	deps := Deps{Log: t.Logf, GhBin: "gh"}
-	CommentCobblerIssue("petar-djukic/cobbler-scaffold", 0, "test body", deps)  // must not panic
-	CommentCobblerIssue("", 1, "test body", deps)                                // must not panic
+	tr := testTracker(t)
+	tr.CommentCobblerIssue("petar-djukic/cobbler-scaffold", 0, "test body")  // must not panic
+	tr.CommentCobblerIssue("", 1, "test body")                                // must not panic
 }
 
 // --- sub-issue linking (GH-566) ---
@@ -742,8 +766,8 @@ func TestExtractParentIssueNumber(t *testing.T) {
 // panic) when the GitHub CLI fails on a fake repo (GH-566).
 func TestLinkSubIssue_FakeRepo_Error(t *testing.T) {
 	t.Parallel()
-	deps := Deps{Log: t.Logf, GhBin: "gh"}
-	err := LinkSubIssue("fake/repo-that-does-not-exist", 1, 99999, deps)
+	tr := testTracker(t)
+	err := tr.LinkSubIssue("fake/repo-that-does-not-exist", 1, 99999)
 	if err == nil {
 		t.Error("LinkSubIssue with fake repo must return an error")
 	}

--- a/pkg/orchestrator/internal/gitops/gitops.go
+++ b/pkg/orchestrator/internal/gitops/gitops.go
@@ -1,0 +1,360 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+// Package gitops defines a GitOps interface for git operations and provides
+// a ShellGitOps implementation that shells out to the git binary.
+package gitops
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// DiffStat holds parsed output from git diff --shortstat.
+type DiffStat struct {
+	FilesChanged int
+	Insertions   int
+	Deletions    int
+}
+
+// FileChange holds per-file diff information.
+type FileChange struct {
+	Path       string `yaml:"path"`
+	Status     string `yaml:"status"`
+	Insertions int    `yaml:"insertions"`
+	Deletions  int    `yaml:"deletions"`
+}
+
+// ---------------------------------------------------------------------------
+// Interface
+// ---------------------------------------------------------------------------
+
+// GitOps defines the git operations used by the orchestrator.
+type GitOps interface {
+	Checkout(branch, dir string) error
+	CheckoutNew(branch, dir string) error
+	CreateBranch(name, dir string) error
+	DeleteBranch(name, dir string) error
+	ForceDeleteBranch(name, dir string) error
+	BranchExists(name, dir string) bool
+	ListBranches(pattern, dir string) []string
+	CurrentBranch(dir string) (string, error)
+	Tag(name, dir string) error
+	DeleteTag(name, dir string) error
+	TagAt(name, ref, dir string) error
+	RenameTag(oldName, newName, dir string) error
+	ListTags(pattern, dir string) []string
+	LsFiles(dir string) []string
+	StageAll(dir string) error
+	StageDir(path, dir string) error
+	UnstageAll(dir string) error
+	HasChanges(dir string) bool
+	Stash(msg, dir string) error
+	Commit(msg, dir string) error
+	CommitAllowEmpty(msg, dir string) error
+	RevParseHEAD(dir string) (string, error)
+	ResetSoft(ref, dir string) error
+	MergeCmd(branch, dir string) *exec.Cmd
+	WorktreePrune(dir string) error
+	WorktreeAdd(worktreeDir, branch, dir string) *exec.Cmd
+	WorktreeRemove(worktreeDir, dir string) error
+	DiffShortstat(ref, dir string) (DiffStat, error)
+	DiffNameStatus(ref, dir string) ([]FileChange, error)
+	LsTreeFiles(ref, dir string) ([]string, error)
+	ShowFileContent(ref, path, dir string) ([]byte, error)
+}
+
+// ---------------------------------------------------------------------------
+// ShellGitOps implementation
+// ---------------------------------------------------------------------------
+
+// ShellGitOps implements GitOps by shelling out to the git binary.
+type ShellGitOps struct {
+	// GitBin is the git binary name or path. Defaults to "git" when empty.
+	GitBin string
+}
+
+func (g *ShellGitOps) gitBin() string {
+	if g.GitBin != "" {
+		return g.GitBin
+	}
+	return "git"
+}
+
+// cmdGit returns an exec.Cmd for git with cmd.Dir set to dir when non-empty.
+func (g *ShellGitOps) cmdGit(dir string, arg ...string) *exec.Cmd {
+	cmd := exec.Command(g.gitBin(), arg...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	return cmd
+}
+
+func (g *ShellGitOps) Checkout(branch, dir string) error {
+	return g.cmdGit(dir, "checkout", branch).Run()
+}
+
+func (g *ShellGitOps) CheckoutNew(branch, dir string) error {
+	return g.cmdGit(dir, "checkout", "-b", branch).Run()
+}
+
+func (g *ShellGitOps) CreateBranch(name, dir string) error {
+	return g.cmdGit(dir, "branch", name).Run()
+}
+
+func (g *ShellGitOps) DeleteBranch(name, dir string) error {
+	return g.cmdGit(dir, "branch", "-d", name).Run()
+}
+
+func (g *ShellGitOps) ForceDeleteBranch(name, dir string) error {
+	return g.cmdGit(dir, "branch", "-D", name).Run()
+}
+
+func (g *ShellGitOps) BranchExists(name, dir string) bool {
+	return g.cmdGit(dir, "show-ref", "--verify", "--quiet", "refs/heads/"+name).Run() == nil
+}
+
+func (g *ShellGitOps) ListBranches(pattern, dir string) []string {
+	out, _ := g.cmdGit(dir, "branch", "--list", pattern).Output()
+	return ParseBranchList(string(out))
+}
+
+func (g *ShellGitOps) CurrentBranch(dir string) (string, error) {
+	out, err := g.cmdGit(dir, "rev-parse", "--abbrev-ref", "HEAD").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (g *ShellGitOps) Tag(name, dir string) error {
+	return g.cmdGit(dir, "tag", name).Run()
+}
+
+func (g *ShellGitOps) DeleteTag(name, dir string) error {
+	return g.cmdGit(dir, "tag", "-d", name).Run()
+}
+
+func (g *ShellGitOps) TagAt(name, ref, dir string) error {
+	return g.cmdGit(dir, "tag", name, ref).Run()
+}
+
+func (g *ShellGitOps) RenameTag(oldName, newName, dir string) error {
+	if err := g.cmdGit(dir, "tag", newName, oldName).Run(); err != nil {
+		return err
+	}
+	return g.DeleteTag(oldName, dir)
+}
+
+func (g *ShellGitOps) ListTags(pattern, dir string) []string {
+	out, _ := g.cmdGit(dir, "tag", "--list", pattern).Output()
+	return ParseBranchList(string(out))
+}
+
+func (g *ShellGitOps) LsFiles(dir string) []string {
+	if dir == "" {
+		return nil
+	}
+	out, err := g.cmdGit(dir, "ls-files").Output()
+	if err != nil || len(out) == 0 {
+		return nil
+	}
+	return ParseBranchList(string(out))
+}
+
+func (g *ShellGitOps) StageAll(dir string) error {
+	return g.cmdGit(dir, "add", "-A").Run()
+}
+
+func (g *ShellGitOps) StageDir(path, dir string) error {
+	return g.cmdGit(dir, "add", path).Run()
+}
+
+func (g *ShellGitOps) UnstageAll(dir string) error {
+	return g.cmdGit(dir, "reset", "HEAD").Run()
+}
+
+func (g *ShellGitOps) HasChanges(dir string) bool {
+	return g.cmdGit(dir, "diff", "--quiet", "HEAD").Run() != nil
+}
+
+func (g *ShellGitOps) Stash(msg, dir string) error {
+	return g.cmdGit(dir, "stash", "push", "-m", msg).Run()
+}
+
+func (g *ShellGitOps) Commit(msg, dir string) error {
+	return g.cmdGit(dir, "commit", "--no-verify", "-m", msg).Run()
+}
+
+func (g *ShellGitOps) CommitAllowEmpty(msg, dir string) error {
+	return g.cmdGit(dir, "commit", "--no-verify", "-m", msg, "--allow-empty").Run()
+}
+
+func (g *ShellGitOps) RevParseHEAD(dir string) (string, error) {
+	out, err := g.cmdGit(dir, "rev-parse", "HEAD").Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func (g *ShellGitOps) ResetSoft(ref, dir string) error {
+	return g.cmdGit(dir, "reset", "--soft", ref).Run()
+}
+
+func (g *ShellGitOps) MergeCmd(branch, dir string) *exec.Cmd {
+	return g.cmdGit(dir, "merge", branch, "--no-edit")
+}
+
+func (g *ShellGitOps) WorktreePrune(dir string) error {
+	return g.cmdGit(dir, "worktree", "prune").Run()
+}
+
+func (g *ShellGitOps) WorktreeAdd(worktreeDir, branch, dir string) *exec.Cmd {
+	return g.cmdGit(dir, "worktree", "add", worktreeDir, branch)
+}
+
+func (g *ShellGitOps) WorktreeRemove(worktreeDir, dir string) error {
+	return g.cmdGit(dir, "worktree", "remove", worktreeDir, "--force").Run()
+}
+
+func (g *ShellGitOps) DiffShortstat(ref, dir string) (DiffStat, error) {
+	out, err := g.cmdGit(dir, "diff", "--shortstat", ref).Output()
+	if err != nil {
+		return DiffStat{}, err
+	}
+	return ParseDiffShortstat(string(out)), nil
+}
+
+func (g *ShellGitOps) DiffNameStatus(ref, dir string) ([]FileChange, error) {
+	nsOut, err := g.cmdGit(dir, "diff", "--name-status", ref).Output()
+	if err != nil {
+		return nil, err
+	}
+
+	numOut, _ := g.cmdGit(dir, "diff", "--numstat", ref).Output()
+	numMap := ParseNumstat(string(numOut))
+
+	return ParseNameStatus(string(nsOut), numMap), nil
+}
+
+func (g *ShellGitOps) LsTreeFiles(ref, dir string) ([]string, error) {
+	out, err := g.cmdGit(dir, "ls-tree", "-r", "--name-only", ref).Output()
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line != "" {
+			files = append(files, line)
+		}
+	}
+	return files, nil
+}
+
+func (g *ShellGitOps) ShowFileContent(ref, path, dir string) ([]byte, error) {
+	return g.cmdGit(dir, "show", ref+":"+path).Output()
+}
+
+// ---------------------------------------------------------------------------
+// Parse helpers (exported for use by the orchestrator package)
+// ---------------------------------------------------------------------------
+
+// ParseBranchList parses the output of git branch --list or git tag --list.
+func ParseBranchList(output string) []string {
+	var branches []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		line = strings.TrimLeft(line, "*+ ")
+		if line != "" {
+			branches = append(branches, line)
+		}
+	}
+	return branches
+}
+
+// ParseDiffShortstat extracts file/insertion/deletion counts from
+// git diff --shortstat output.
+func ParseDiffShortstat(s string) DiffStat {
+	var ds DiffStat
+	for _, part := range strings.Split(s, ",") {
+		part = strings.TrimSpace(part)
+		var n int
+		if _, err := fmt.Sscanf(part, "%d file", &n); err == nil {
+			ds.FilesChanged = n
+		} else if _, err := fmt.Sscanf(part, "%d insertion", &n); err == nil {
+			ds.Insertions = n
+		} else if _, err := fmt.Sscanf(part, "%d deletion", &n); err == nil {
+			ds.Deletions = n
+		}
+	}
+	return ds
+}
+
+// NumstatEntry holds parsed numstat data for a single file.
+type NumstatEntry struct {
+	Ins int
+	Del int
+}
+
+// ParseNumstat parses git diff --numstat output into a map keyed by file path.
+// Binary files show "-\t-\tpath" and are recorded with zero counts.
+func ParseNumstat(output string) map[string]NumstatEntry {
+	m := make(map[string]NumstatEntry)
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) < 3 {
+			continue
+		}
+		ins, _ := strconv.Atoi(parts[0])
+		del, _ := strconv.Atoi(parts[1])
+		path := parts[len(parts)-1]
+		m[path] = NumstatEntry{Ins: ins, Del: del}
+	}
+	return m
+}
+
+// ParseNameStatus parses git diff --name-status output and merges it with
+// numstat data to produce FileChange entries.
+func ParseNameStatus(output string, numMap map[string]NumstatEntry) []FileChange {
+	var files []FileChange
+	for line := range strings.SplitSeq(strings.TrimSpace(output), "\n") {
+		if line == "" {
+			continue
+		}
+		parts := strings.Split(line, "\t")
+		if len(parts) < 2 {
+			continue
+		}
+		status := parts[0]
+		path := parts[1]
+
+		// Renames show as R### with old\tnew paths.
+		if strings.HasPrefix(status, "R") && len(parts) >= 3 {
+			path = parts[2]
+			status = "R"
+		}
+		// Copies show as C### with old\tnew paths.
+		if strings.HasPrefix(status, "C") && len(parts) >= 3 {
+			path = parts[2]
+			status = "C"
+		}
+
+		fc := FileChange{Path: path, Status: status}
+		if ns, ok := numMap[path]; ok {
+			fc.Insertions = ns.Ins
+			fc.Deletions = ns.Del
+		}
+		files = append(files, fc)
+	}
+	return files
+}

--- a/pkg/orchestrator/internal/gitops/gitops_test.go
+++ b/pkg/orchestrator/internal/gitops/gitops_test.go
@@ -1,0 +1,179 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package gitops
+
+import (
+	"os/exec"
+	"testing"
+)
+
+// Compile-time interface satisfaction check.
+var _ GitOps = (*ShellGitOps)(nil)
+
+func TestShellGitOps_DefaultGitBin(t *testing.T) {
+	t.Parallel()
+	g := &ShellGitOps{}
+	if g.gitBin() != "git" {
+		t.Errorf("gitBin() = %q, want %q", g.gitBin(), "git")
+	}
+}
+
+func TestShellGitOps_CustomGitBin(t *testing.T) {
+	t.Parallel()
+	g := &ShellGitOps{GitBin: "/usr/local/bin/git"}
+	if g.gitBin() != "/usr/local/bin/git" {
+		t.Errorf("gitBin() = %q, want %q", g.gitBin(), "/usr/local/bin/git")
+	}
+}
+
+func TestParseBranchList(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		input  string
+		want   int
+	}{
+		{"empty", "", 0},
+		{"single", "  main\n", 1},
+		{"multiple", "* main\n  feature\n  bugfix\n", 3},
+		{"with_markers", "+ worktree-branch\n* main\n", 2},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ParseBranchList(tt.input)
+			if len(got) != tt.want {
+				t.Errorf("ParseBranchList(%q) = %d items, want %d", tt.input, len(got), tt.want)
+			}
+		})
+	}
+}
+
+func TestParseDiffShortstat(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input string
+		files int
+		ins   int
+		del   int
+	}{
+		{"", 0, 0, 0},
+		{" 5 files changed, 100 insertions(+), 20 deletions(-)", 5, 100, 20},
+		{" 1 file changed, 10 insertions(+)", 1, 10, 0},
+		{" 3 files changed, 50 deletions(-)", 3, 0, 50},
+	}
+	for _, tt := range tests {
+		ds := ParseDiffShortstat(tt.input)
+		if ds.FilesChanged != tt.files || ds.Insertions != tt.ins || ds.Deletions != tt.del {
+			t.Errorf("ParseDiffShortstat(%q) = {%d, %d, %d}, want {%d, %d, %d}",
+				tt.input, ds.FilesChanged, ds.Insertions, ds.Deletions, tt.files, tt.ins, tt.del)
+		}
+	}
+}
+
+func TestParseNumstat(t *testing.T) {
+	t.Parallel()
+	output := "10\t2\tREADME.md\n-\t-\timage.png\n"
+	m := ParseNumstat(output)
+	if len(m) != 2 {
+		t.Fatalf("got %d entries, want 2", len(m))
+	}
+	if m["README.md"].Ins != 10 || m["README.md"].Del != 2 {
+		t.Errorf("README.md: got %+v", m["README.md"])
+	}
+	if m["image.png"].Ins != 0 || m["image.png"].Del != 0 {
+		t.Errorf("image.png: got %+v", m["image.png"])
+	}
+}
+
+func TestParseNameStatus(t *testing.T) {
+	t.Parallel()
+	nsOutput := "A\tnew.go\nM\texisting.go\nR100\told.go\tnew_name.go\n"
+	numMap := map[string]NumstatEntry{
+		"new.go":      {Ins: 50, Del: 0},
+		"existing.go": {Ins: 10, Del: 5},
+		"new_name.go": {Ins: 3, Del: 1},
+	}
+	files := ParseNameStatus(nsOutput, numMap)
+	if len(files) != 3 {
+		t.Fatalf("got %d files, want 3", len(files))
+	}
+	if files[0].Path != "new.go" || files[0].Status != "A" || files[0].Insertions != 50 {
+		t.Errorf("[0] = %+v", files[0])
+	}
+	if files[2].Path != "new_name.go" || files[2].Status != "R" {
+		t.Errorf("[2] = %+v", files[2])
+	}
+}
+
+// MockGitOps provides a mock implementation of GitOps for testing.
+// Each field is a function that, when set, handles the corresponding method.
+// Unset fields panic to catch unexpected calls.
+type MockGitOps struct {
+	CheckoutFn         func(branch, dir string) error
+	CheckoutNewFn      func(branch, dir string) error
+	CreateBranchFn     func(name, dir string) error
+	DeleteBranchFn     func(name, dir string) error
+	ForceDeleteBranchFn func(name, dir string) error
+	BranchExistsFn     func(name, dir string) bool
+	ListBranchesFn     func(pattern, dir string) []string
+	CurrentBranchFn    func(dir string) (string, error)
+	TagFn              func(name, dir string) error
+	DeleteTagFn        func(name, dir string) error
+	TagAtFn            func(name, ref, dir string) error
+	RenameTagFn        func(oldName, newName, dir string) error
+	ListTagsFn         func(pattern, dir string) []string
+	LsFilesFn          func(dir string) []string
+	StageAllFn         func(dir string) error
+	StageDirFn         func(path, dir string) error
+	UnstageAllFn       func(dir string) error
+	HasChangesFn       func(dir string) bool
+	StashFn            func(msg, dir string) error
+	CommitFn           func(msg, dir string) error
+	CommitAllowEmptyFn func(msg, dir string) error
+	RevParseHEADFn     func(dir string) (string, error)
+	ResetSoftFn        func(ref, dir string) error
+	MergeCmdFn         func(branch, dir string) *exec.Cmd
+	WorktreePruneFn    func(dir string) error
+	WorktreeAddFn      func(worktreeDir, branch, dir string) *exec.Cmd
+	WorktreeRemoveFn   func(worktreeDir, dir string) error
+	DiffShortstatFn    func(ref, dir string) (DiffStat, error)
+	DiffNameStatusFn   func(ref, dir string) ([]FileChange, error)
+	LsTreeFilesFn      func(ref, dir string) ([]string, error)
+	ShowFileContentFn  func(ref, path, dir string) ([]byte, error)
+}
+
+// Compile-time check that MockGitOps implements GitOps.
+var _ GitOps = (*MockGitOps)(nil)
+
+func (m *MockGitOps) Checkout(branch, dir string) error        { return m.CheckoutFn(branch, dir) }
+func (m *MockGitOps) CheckoutNew(branch, dir string) error     { return m.CheckoutNewFn(branch, dir) }
+func (m *MockGitOps) CreateBranch(name, dir string) error      { return m.CreateBranchFn(name, dir) }
+func (m *MockGitOps) DeleteBranch(name, dir string) error      { return m.DeleteBranchFn(name, dir) }
+func (m *MockGitOps) ForceDeleteBranch(name, dir string) error { return m.ForceDeleteBranchFn(name, dir) }
+func (m *MockGitOps) BranchExists(name, dir string) bool       { return m.BranchExistsFn(name, dir) }
+func (m *MockGitOps) ListBranches(pattern, dir string) []string { return m.ListBranchesFn(pattern, dir) }
+func (m *MockGitOps) CurrentBranch(dir string) (string, error) { return m.CurrentBranchFn(dir) }
+func (m *MockGitOps) Tag(name, dir string) error               { return m.TagFn(name, dir) }
+func (m *MockGitOps) DeleteTag(name, dir string) error         { return m.DeleteTagFn(name, dir) }
+func (m *MockGitOps) TagAt(name, ref, dir string) error        { return m.TagAtFn(name, ref, dir) }
+func (m *MockGitOps) RenameTag(oldName, newName, dir string) error { return m.RenameTagFn(oldName, newName, dir) }
+func (m *MockGitOps) ListTags(pattern, dir string) []string    { return m.ListTagsFn(pattern, dir) }
+func (m *MockGitOps) LsFiles(dir string) []string              { return m.LsFilesFn(dir) }
+func (m *MockGitOps) StageAll(dir string) error                { return m.StageAllFn(dir) }
+func (m *MockGitOps) StageDir(path, dir string) error          { return m.StageDirFn(path, dir) }
+func (m *MockGitOps) UnstageAll(dir string) error              { return m.UnstageAllFn(dir) }
+func (m *MockGitOps) HasChanges(dir string) bool               { return m.HasChangesFn(dir) }
+func (m *MockGitOps) Stash(msg, dir string) error              { return m.StashFn(msg, dir) }
+func (m *MockGitOps) Commit(msg, dir string) error             { return m.CommitFn(msg, dir) }
+func (m *MockGitOps) CommitAllowEmpty(msg, dir string) error   { return m.CommitAllowEmptyFn(msg, dir) }
+func (m *MockGitOps) RevParseHEAD(dir string) (string, error)  { return m.RevParseHEADFn(dir) }
+func (m *MockGitOps) ResetSoft(ref, dir string) error          { return m.ResetSoftFn(ref, dir) }
+func (m *MockGitOps) MergeCmd(branch, dir string) *exec.Cmd    { return m.MergeCmdFn(branch, dir) }
+func (m *MockGitOps) WorktreePrune(dir string) error           { return m.WorktreePruneFn(dir) }
+func (m *MockGitOps) WorktreeAdd(worktreeDir, branch, dir string) *exec.Cmd { return m.WorktreeAddFn(worktreeDir, branch, dir) }
+func (m *MockGitOps) WorktreeRemove(worktreeDir, dir string) error { return m.WorktreeRemoveFn(worktreeDir, dir) }
+func (m *MockGitOps) DiffShortstat(ref, dir string) (DiffStat, error) { return m.DiffShortstatFn(ref, dir) }
+func (m *MockGitOps) DiffNameStatus(ref, dir string) ([]FileChange, error) { return m.DiffNameStatusFn(ref, dir) }
+func (m *MockGitOps) LsTreeFiles(ref, dir string) ([]string, error) { return m.LsTreeFilesFn(ref, dir) }
+func (m *MockGitOps) ShowFileContent(ref, path, dir string) ([]byte, error) { return m.ShowFileContentFn(ref, path, dir) }

--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -11,14 +11,6 @@ import (
 	gh "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/github"
 )
 
-// GitHubIssueManager defines the interface for GitHub issue operations
-// used by the orchestrator.
-type GitHubIssueManager interface {
-	DetectGitHubRepo(repoRoot string) (string, error)
-	ListOpenIssues(repo, generation string) ([]gh.CobblerIssue, error)
-	PickReadyIssue(repo, generation string) (gh.CobblerIssue, error)
-}
-
 // Type aliases for backward compatibility within the package.
 type cobblerIssue = gh.CobblerIssue
 type cobblerFrontMatter = gh.CobblerFrontMatter
@@ -31,22 +23,28 @@ const (
 	cobblerGenLabelPrefix  = gh.GenLabelPrefix
 )
 
-// ghDeps constructs the Deps struct for the github sub-package from
-// the orchestrator's globals.
-func ghDeps() gh.Deps {
-	return gh.Deps{
+// ghTracker constructs a GitHubTracker from the orchestrator's globals and
+// the given Config. Replaces the former ghDeps() + ghRepoConfig() pair.
+func ghTracker(cfg Config) *gh.GitHubTracker {
+	return &gh.GitHubTracker{
 		Log:          logf,
 		GhBin:        binGh,
 		BranchExists: gitBranchExists,
+		Cfg: gh.RepoConfig{
+			IssuesRepo: cfg.Cobbler.IssuesRepo,
+			ModulePath: cfg.Project.ModulePath,
+			TargetRepo: cfg.Project.TargetRepo,
+		},
 	}
 }
 
-// ghRepoConfig builds a RepoConfig from the orchestrator Config.
-func ghRepoConfig(cfg Config) gh.RepoConfig {
-	return gh.RepoConfig{
-		IssuesRepo: cfg.Cobbler.IssuesRepo,
-		ModulePath: cfg.Project.ModulePath,
-		TargetRepo: cfg.Project.TargetRepo,
+// ghTrackerNoCfg constructs a GitHubTracker without RepoConfig, for
+// operations that do not need configuration (label ops, issue CRUD, etc.).
+func ghTrackerNoCfg() *gh.GitHubTracker {
+	return &gh.GitHubTracker{
+		Log:          logf,
+		GhBin:        binGh,
+		BranchExists: gitBranchExists,
 	}
 }
 
@@ -65,39 +63,39 @@ func parseIssueFrontMatter(body string) (cobblerFrontMatter, string) {
 }
 
 func detectGitHubRepo(repoRoot string, cfg Config) (string, error) {
-	return gh.DetectGitHubRepo(repoRoot, ghRepoConfig(cfg), ghDeps())
+	return ghTracker(cfg).DetectGitHubRepo(repoRoot)
 }
 
 func ensureCobblerLabels(repo string) error {
-	return gh.EnsureCobblerLabels(repo, ghDeps())
+	return ghTrackerNoCfg().EnsureCobblerLabels(repo)
 }
 
 func listRepoLabels(repo string) []string {
-	return gh.ListRepoLabels(repo, ghDeps())
+	return ghTrackerNoCfg().ListRepoLabels(repo)
 }
 
 func ensureCobblerGenLabel(repo, generation string) error {
-	return gh.EnsureCobblerGenLabel(repo, generation, ghDeps())
+	return ghTrackerNoCfg().EnsureCobblerGenLabel(repo, generation)
 }
 
 func createMeasuringPlaceholder(repo, generation string, iteration int) (int, error) {
-	return gh.CreateMeasuringPlaceholder(repo, generation, iteration, ghDeps())
+	return ghTrackerNoCfg().CreateMeasuringPlaceholder(repo, generation, iteration)
 }
 
 func closeMeasuringPlaceholder(repo string, number int) {
-	gh.CloseMeasuringPlaceholder(repo, number, ghDeps())
+	ghTrackerNoCfg().CloseMeasuringPlaceholder(repo, number)
 }
 
 func closeMeasuringPlaceholderWithComment(repo string, number int, comment string) {
-	gh.CloseMeasuringPlaceholderWithComment(repo, number, comment, ghDeps())
+	ghTrackerNoCfg().CloseMeasuringPlaceholderWithComment(repo, number, comment)
 }
 
 func upgradeMeasuringPlaceholder(repo string, number int, generation string, issue proposedIssue) error {
-	return gh.UpgradeMeasuringPlaceholder(repo, number, generation, issue, ghDeps())
+	return ghTrackerNoCfg().UpgradeMeasuringPlaceholder(repo, number, generation, issue)
 }
 
 func createCobblerIssue(repo, generation string, issue proposedIssue) (int, error) {
-	return gh.CreateCobblerIssue(repo, generation, issue, ghDeps())
+	return ghTrackerNoCfg().CreateCobblerIssue(repo, generation, issue)
 }
 
 func extractParentIssueNumber(generation string) int {
@@ -105,7 +103,7 @@ func extractParentIssueNumber(generation string) int {
 }
 
 func linkSubIssue(repo string, parentNumber, childNumber int) error {
-	return gh.LinkSubIssue(repo, parentNumber, childNumber, ghDeps())
+	return ghTrackerNoCfg().LinkSubIssue(repo, parentNumber, childNumber)
 }
 
 func parseIssueURL(raw string) (int, error) {
@@ -113,15 +111,15 @@ func parseIssueURL(raw string) (int, error) {
 }
 
 func listOpenCobblerIssues(repo, generation string) ([]cobblerIssue, error) {
-	return gh.ListOpenCobblerIssues(repo, generation, ghDeps())
+	return ghTrackerNoCfg().ListOpenCobblerIssues(repo, generation)
 }
 
 func listAllCobblerIssues(repo, generation string) ([]cobblerIssue, error) {
-	return gh.ListAllCobblerIssues(repo, generation, ghDeps())
+	return ghTrackerNoCfg().ListAllCobblerIssues(repo, generation)
 }
 
 func fetchIssueComments(repo string, number int) ([]string, error) {
-	return gh.FetchIssueComments(repo, number, ghDeps())
+	return ghTrackerNoCfg().FetchIssueComments(repo, number)
 }
 
 func parseCobblerIssuesJSON(data []byte) ([]cobblerIssue, error) {
@@ -129,7 +127,7 @@ func parseCobblerIssuesJSON(data []byte) ([]cobblerIssue, error) {
 }
 
 func waitForIssuesVisible(repo, generation string, expected int) {
-	gh.WaitForIssuesVisible(repo, generation, expected, ghDeps())
+	ghTrackerNoCfg().WaitForIssuesVisible(repo, generation, expected)
 }
 
 func hasLabel(issue cobblerIssue, label string) bool {
@@ -137,15 +135,15 @@ func hasLabel(issue cobblerIssue, label string) bool {
 }
 
 func promoteReadyIssues(repo, generation string) error {
-	return gh.PromoteReadyIssues(repo, generation, ghDeps())
+	return ghTrackerNoCfg().PromoteReadyIssues(repo, generation)
 }
 
 func pickReadyIssue(repo, generation string) (cobblerIssue, error) {
-	return gh.PickReadyIssue(repo, generation, ghDeps())
+	return ghTrackerNoCfg().PickReadyIssue(repo, generation)
 }
 
 func editIssueTitle(repo string, number int, title string) error {
-	return gh.EditIssueTitle(repo, number, title, ghDeps())
+	return ghTrackerNoCfg().EditIssueTitle(repo, number, title)
 }
 
 func normalizeIssueTitle(title string) string {
@@ -153,23 +151,23 @@ func normalizeIssueTitle(title string) string {
 }
 
 func closeCobblerIssue(repo string, number int, generation string) error {
-	return gh.CloseCobblerIssue(repo, number, generation, ghDeps())
+	return ghTrackerNoCfg().CloseCobblerIssue(repo, number, generation)
 }
 
 func removeInProgressLabel(repo string, number int) error {
-	return gh.RemoveInProgressLabel(repo, number, ghDeps())
+	return ghTrackerNoCfg().RemoveIssueLabel(repo, number, gh.LabelInProgress)
 }
 
 func closeGenerationIssues(repo, generation string) error {
-	return gh.CloseGenerationIssues(repo, generation, ghDeps())
+	return ghTrackerNoCfg().CloseGenerationIssues(repo, generation)
 }
 
 func gcStaleGenerationIssues(repo, generationPrefix string) {
-	gh.GcStaleGenerationIssues(repo, generationPrefix, ghDeps())
+	ghTrackerNoCfg().GcStaleGenerationIssues(repo, generationPrefix)
 }
 
 func listActiveIssuesContext(repo, generation string) (string, error) {
-	return gh.ListActiveIssuesContext(repo, generation, ghDeps())
+	return ghTrackerNoCfg().ListActiveIssuesContext(repo, generation)
 }
 
 func issuesContextJSON(issues []cobblerIssue) (string, error) {
@@ -177,15 +175,15 @@ func issuesContextJSON(issues []cobblerIssue) (string, error) {
 }
 
 func addIssueLabel(repo string, number int, label string) error {
-	return gh.AddIssueLabel(repo, number, label, ghDeps())
+	return ghTrackerNoCfg().AddIssueLabel(repo, number, label)
 }
 
 func removeIssueLabel(repo string, number int, label string) error {
-	return gh.RemoveIssueLabel(repo, number, label, ghDeps())
+	return ghTrackerNoCfg().RemoveIssueLabel(repo, number, label)
 }
 
 func ghExec(repoRoot string, args ...string) (string, error) {
-	return gh.GhExec(repoRoot, ghDeps(), args...)
+	return ghTrackerNoCfg().GhExec(repoRoot, args...)
 }
 
 func goModModulePath(repoRoot string) string {
@@ -193,13 +191,13 @@ func goModModulePath(repoRoot string) string {
 }
 
 func resolveTargetRepo(cfg Config) string {
-	return gh.ResolveTargetRepo(ghRepoConfig(cfg))
+	return ghTracker(cfg).ResolveTargetRepo()
 }
 
 func commentCobblerIssue(repo string, number int, body string) {
-	gh.CommentCobblerIssue(repo, number, body, ghDeps())
+	ghTrackerNoCfg().CommentCobblerIssue(repo, number, body)
 }
 
 func fileTargetRepoDefects(repo string, defects []string) {
-	gh.FileTargetRepoDefects(repo, defects, ghDeps())
+	ghTrackerNoCfg().FileTargetRepoDefects(repo, defects)
 }

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -14,6 +14,8 @@ import (
 	claudesdk "github.com/schlunsen/claude-agent-sdk-go"
 
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
+	gh "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/github"
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/gitops"
 )
 
 // sdkQueryFunc is the function signature for claudesdk.Query.
@@ -26,14 +28,38 @@ type sdkQueryFunc = claude.SdkQueryFunc
 type Orchestrator struct {
 	cfg        Config
 	sdkQueryFn sdkQueryFunc
+	tracker    gh.WorkTracker
+	git        gitops.GitOps
 }
 
 // New creates an Orchestrator with the given configuration.
 // It applies defaults to any zero-value Config fields.
 func New(cfg Config) *Orchestrator {
 	cfg.applyDefaults()
-	return &Orchestrator{cfg: cfg, sdkQueryFn: claudesdk.Query}
+	return &Orchestrator{
+		cfg:        cfg,
+		sdkQueryFn: claudesdk.Query,
+		tracker: gh.NewGitHubTracker(
+			gh.Deps{
+				Log:          logf,
+				GhBin:        binGh,
+				BranchExists: gitBranchExists,
+			},
+			gh.RepoConfig{
+				IssuesRepo: cfg.Cobbler.IssuesRepo,
+				ModulePath: cfg.Project.ModulePath,
+				TargetRepo: cfg.Project.TargetRepo,
+			},
+		),
+		git: &gitops.ShellGitOps{},
+	}
 }
+
+// Tracker returns the work tracker interface for issue operations.
+func (o *Orchestrator) Tracker() gh.WorkTracker { return o.tracker }
+
+// Git returns the git operations interface.
+func (o *Orchestrator) Git() gitops.GitOps { return o.git }
 
 // Config returns a copy of the Orchestrator's configuration.
 func (o *Orchestrator) Config() Config { return o.cfg }


### PR DESCRIPTION
## Summary

Defines two interface boundaries separating git operations from issue tracking, enabling a future crumbs/trails WorkTracker implementation. Consolidates scattered git helpers into a new `internal/gitops` package and converts all GitHub issue functions into methods on `GitHubTracker`.

## Changes

- Defined `WorkTracker` interface (28 methods) in `internal/github/` with `GitHubTracker` implementation
- Defined `GitOps` interface (28 methods) in new `internal/gitops/` with `ShellGitOps` implementation
- Converted all `issues.go` functions taking `Deps` into `GitHubTracker` methods
- Consolidated `commands.go` git helpers into `ShellGitOps` (commands.go now delegates)
- Added `tracker` and `git` interface fields to `Orchestrator` struct with default wiring
- Updated `issues_gh.go` delegation to use `GitHubTracker` instances
- Added compile-time interface satisfaction checks and `MockGitOps` test stub
- Added `gitops_test.go` with parse helper tests (ParseBranchList, ParseDiffShortstat, ParseNumstat, ParseNameStatus)

## Stats

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| go_loc_prod | 17,351 | 17,468 | +117 |
| go_loc_test | 28,860 | 29,063 | +203 |

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1 -short`)
- [x] New `internal/gitops` package has test coverage

Closes #1295