### PR TITLE
GH-1324: Implement recommendations from GH-1296 and GH-1302 evaluations

### DIFF
--- a/docs/specs/use-cases/rel01.0-uc001-orchestrator-initialization.yaml
+++ b/docs/specs/use-cases/rel01.0-uc001-orchestrator-initialization.yaml
@@ -13,8 +13,8 @@ trigger: First-time setup of the orchestrator in a magefile
 
 flow:
   - F1: "Create Config: construct a Config struct with ModulePath, BinaryName, GoSourceDirs, and other project-specific fields"
-  - F2: "Construct Orchestrator: call New(config) to get an *Orchestrator with defaults applied"
-  - F3: "Initialize: call orchestrator.Init() to set up the cobbler scratch directory"
+  - F2: "Construct Orchestrator: call New(config) to get an *Orchestrator with defaults applied (requires Config from F1)"
+  - F3: "Initialize: call orchestrator.Init() to set up the cobbler scratch directory (requires Orchestrator from F2)"
   - F4: "Verify: confirm cobbler directory exists and git status shows tracked files"
 
 touchpoints:
@@ -24,23 +24,21 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: New(config) returns a non-nil *Orchestrator
-    traces:
-      - prd001-orchestrator-core AC2
-  - id: S2
-    criterion: Zero-value Config fields receive their documented defaults
+    criterion: New(config) returns a non-nil *Orchestrator with all zero-value fields populated to their documented defaults across all five sub-structs
     traces:
       - prd001-orchestrator-core AC1
       - prd001-orchestrator-core AC2
-  - id: S3
-    criterion: Init() creates the cobbler scratch directory without error
-    traces:
-      - prd001-orchestrator-core AC6
-  - id: S4
-    criterion: The orchestrator is ready to accept generation commands
+  - id: S2
+    criterion: After New() and Init(), the orchestrator accepts generation commands without additional setup (constructor defaults, scratch directory, and logging are all operational)
     traces:
       - prd001-orchestrator-core AC2
+      - prd001-orchestrator-core AC5
       - prd001-orchestrator-core AC6
+  - id: S3
+    criterion: NewFromFile() loads YAML, resolves seed file and prompt file paths to content, applies defaults, and returns an operational orchestrator in a single call
+    traces:
+      - prd001-orchestrator-core AC3
+      - prd001-orchestrator-core AC4
 
 out_of_scope:
   - Generation lifecycle operations (see rel01.0-uc002)

--- a/docs/specs/use-cases/rel01.0-uc002-generation-lifecycle.yaml
+++ b/docs/specs/use-cases/rel01.0-uc002-generation-lifecycle.yaml
@@ -16,9 +16,9 @@ trigger: Running mage generator:start to begin a new generation
 
 flow:
   - F1: "Start generation: call GeneratorStart() which records the current branch as the base branch, tags it, creates a generation branch, stores the base branch name in .cobbler/base-branch, resets Go sources, and commits clean state"
-  - F2: "Run cycles: call GeneratorRun() to execute Config.Cycles measure+stitch cycles on the generation branch"
+  - F2: "Run cycles: call GeneratorRun() to execute Config.Cycles measure+stitch cycles on the generation branch (requires generation branch from F1)"
   - F3: "Monitor progress: call GeneratorList() to see active generations and their lifecycle tags"
-  - F4: "Stop generation: call GeneratorStop() which tags the generation, reads the base branch from .cobbler/base-branch, switches to the base branch, merges, tags the result as v1, resets the base branch to specs-only, and deletes the generation branch"
+  - F4: "Stop generation: call GeneratorStop() which tags the generation, reads the base branch from .cobbler/base-branch, switches to the base branch, merges, tags the result as v1, resets the base branch to specs-only, and deletes the generation branch (requires completed cycles from F2)"
   - F5: "Verify: confirm the base branch is specs-only (no generated code) and the v1 tag preserves the complete code snapshot"
 
 touchpoints:
@@ -36,31 +36,21 @@ success_criteria:
       - prd002-generation-lifecycle AC1
       - prd002-generation-lifecycle AC2
   - id: S2
-    criterion: GeneratorRun executes the specified number of cycles
+    criterion: GeneratorStop reads the base branch from .cobbler/base-branch, merges, tags, resets the base branch to specs-only, and deletes the generation branch; the v1 tag preserves the complete code snapshot
     traces:
-      - prd002-generation-lifecycle AC3
+      - prd002-generation-lifecycle AC5
   - id: S3
-    criterion: GeneratorStop reads the base branch from .cobbler/base-branch and merges back to it with finished and merged tags
-    traces:
-      - prd002-generation-lifecycle AC5
-  - id: S4
-    criterion: The generation branch is deleted after successful stop
-    traces:
-      - prd002-generation-lifecycle AC5
-  - id: S5
-    criterion: The base branch is specs-only after stop (no generated Go code, no build artifacts, no history) and the v1 tag preserves the complete code
-    traces:
-      - prd002-generation-lifecycle AC5
-  - id: S6
-    criterion: When .cobbler/base-branch is absent (older generations), GeneratorStop falls back to "main" for backward compatibility
-    traces:
-      - prd002-generation-lifecycle AC6
-  - id: S7
-    criterion: Starting from a feature branch and stopping returns to that feature branch, not main
+    criterion: The full start-run-stop lifecycle round-trips correctly when initiated from a feature branch (not main), returning to the originating branch
     traces:
       - prd002-generation-lifecycle AC1
       - prd002-generation-lifecycle AC2
       - prd002-generation-lifecycle AC5
+  - id: S4
+    criterion: When preserve_sources is true, GeneratorStart retains Go source files and GeneratorStop skips the base-branch source reset, preserving library-mode project structure through the lifecycle
+    traces:
+      - prd002-generation-lifecycle AC11
+      - prd002-generation-lifecycle AC12
+      - prd002-generation-lifecycle AC13
 
 out_of_scope:
   - Content of measure and stitch workflows (see rel01.0-uc003, rel01.0-uc004)

--- a/docs/specs/use-cases/rel01.0-uc003-measure-workflow.yaml
+++ b/docs/specs/use-cases/rel01.0-uc003-measure-workflow.yaml
@@ -15,11 +15,11 @@ flow:
   - F1: "Verify preconditions: confirm cobbler scratch directory exists and resolve the target branch"
   - F2: "Query state: list existing GitHub issues as JSON context"
   - F3: "Clean scratch: remove old proposed-issues files from the cobbler directory"
-  - F4: "Build prompt: render the measure template with existing issues, task limit, output path, and user input"
-  - F5: "Invoke Claude: run Claude with the prompt, capturing token usage"
-  - F6: "Parse output: read the JSON file written by Claude"
-  - F7: "Import issues: create GitHub issues for each proposed task"
-  - F8: "Wire dependencies: link dependent issues on GitHub"
+  - F4: "Build prompt: render the measure template with existing issues, task limit, output path, and user input (requires issue list from F2)"
+  - F5: "Invoke Claude: run Claude with the prompt, capturing token usage (requires rendered prompt from F4)"
+  - F6: "Parse output: read the JSON file written by Claude (requires Claude invocation from F5)"
+  - F7: "Import issues: create GitHub issues for each proposed task (requires parsed output from F6)"
+  - F8: "Wire dependencies: link dependent issues on GitHub (requires created issues from F7)"
   - F9: "Record metrics: store token usage in history"
 
 touchpoints:
@@ -31,24 +31,21 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Measure queries existing GitHub issues and includes them in the prompt
+    criterion: Existing GitHub issues are fetched, serialized into the prompt context, and passed to Claude so the measure agent sees current project state before proposing new tasks
     traces:
       - prd003-cobbler-workflows AC1
-  - id: S2
-    criterion: Claude receives a well-formed prompt with project context
-    traces:
       - prd003-cobbler-workflows AC4
-  - id: S3
-    criterion: Proposed issues are created on GitHub with correct titles and descriptions
+  - id: S2
+    criterion: Proposed issues are created on GitHub with dependency ordering preserved (prerequisites created before dependents so GitHub issue references resolve)
     traces:
       - prd003-cobbler-workflows AC1
       - prd003-cobbler-workflows AC6
-  - id: S4
-    criterion: Dependencies between issues are wired correctly
+  - id: S3
+    criterion: When EnforceMeasureValidation is true and a proposed task exceeds MaxRequirementsPerTask, the task is rejected and Claude is re-prompted up to MaxMeasureRetries times
     traces:
-      - prd003-cobbler-workflows AC1
-  - id: S5
-    criterion: Token usage is recorded in the history directory
+      - prd003-cobbler-workflows AC6
+  - id: S4
+    criterion: Token usage and invocation duration are recorded in the history directory for every measure invocation, including failed or retried ones
     traces:
       - prd005-metrics-collection AC1
 

--- a/docs/specs/use-cases/rel01.0-uc004-stitch-workflow.yaml
+++ b/docs/specs/use-cases/rel01.0-uc004-stitch-workflow.yaml
@@ -15,13 +15,13 @@ flow:
   - F1: "Verify preconditions: confirm cobbler scratch directory exists and resolve the target branch"
   - F2: "Recover stale tasks: clean up any orphaned worktrees or in_progress issues from interrupted runs"
   - F3: "Pick task: query GitHub Issues for the next ready task"
-  - F4: "Claim task: set the task label to in_progress on GitHub"
-  - F5: "Create worktree: create a git worktree on branch task/{baseBranch}-{issueID}"
-  - F6: "Capture LOC before: snapshot production and test line counts"
-  - F7: "Build prompt: render the stitch template with task title, ID, type, and description"
-  - F8: "Invoke Claude: run Claude in the worktree directory"
-  - F9: "Merge branch: merge the task branch back to the base branch"
-  - F10: "Capture metrics: LOC after, git diff stats, token usage"
+  - F4: "Claim task: set the task label to in_progress on GitHub (requires selected task from F3)"
+  - F5: "Create worktree: create a git worktree on branch task/{baseBranch}-{issueID} (requires claimed task from F4)"
+  - F6: "Capture LOC before: snapshot production and test line counts (requires worktree from F5)"
+  - F7: "Build prompt: render the stitch template with task title, ID, type, and description (requires worktree from F5)"
+  - F8: "Invoke Claude: run Claude in the worktree directory (requires prompt from F7)"
+  - F9: "Merge branch: merge the task branch back to the base branch (requires Claude changes from F8)"
+  - F10: "Capture metrics: LOC after, git diff stats, token usage (requires merge from F9 for diff stats)"
   - F11: "Clean up: remove the worktree and delete the task branch"
   - F12: "Close task: record token usage in history and close the GitHub issue"
   - F13: "Repeat: go to F3 until no ready tasks remain or MaxIssues is reached"
@@ -35,32 +35,21 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Ready tasks are picked and claimed one at a time
+    criterion: The full task lifecycle (pick, claim, worktree create, Claude invoke, merge, cleanup, close) completes as an unbroken sequence for each ready task in a single stitch run
     traces:
       - prd003-cobbler-workflows AC2
   - id: S2
-    criterion: Each task runs in its own isolated worktree
+    criterion: On Claude failure or timeout, the task is reset to ready and the worktree is cleaned up so the task can be retried in a subsequent run
     traces:
       - prd003-cobbler-workflows AC2
+      - prd003-cobbler-workflows AC5
   - id: S3
-    criterion: Task branches are merged back to the base branch after completion
-    traces:
-      - prd003-cobbler-workflows AC2
-  - id: S4
-    criterion: Worktrees and task branches are cleaned up after merge
-    traces:
-      - prd003-cobbler-workflows AC2
-  - id: S5
-    criterion: Token usage and diff stats are recorded in history
+    criterion: Token usage, LOC deltas, and diff stats are recorded in history for every stitch invocation, linking metrics to the specific GitHub issue
     traces:
       - prd005-metrics-collection AC1
       - prd005-metrics-collection AC5
-  - id: S6
-    criterion: GitHub issues are closed after successful execution
-    traces:
-      - prd003-cobbler-workflows AC2
-  - id: S7
-    criterion: Stitch stops when no ready tasks remain or MaxIssues is reached
+  - id: S4
+    criterion: Stitch stops when no ready tasks remain or MaxStitchIssuesPerCycle is reached, whichever comes first
     traces:
       - prd003-cobbler-workflows AC2
 

--- a/docs/specs/use-cases/rel01.0-uc005-resume-recovery.yaml
+++ b/docs/specs/use-cases/rel01.0-uc005-resume-recovery.yaml
@@ -13,14 +13,14 @@ trigger: Running mage generator:resume after an interrupted generator:run
 
 flow:
   - F1: "Resolve branch: determine the generation branch from Config.GenerationBranch or auto-detect"
-  - F2: "Save state: commit any uncommitted work on the current branch"
-  - F3: "Switch: check out the generation branch"
+  - F2: "Save state: commit any uncommitted work on the current branch (must complete before branch switch in F3)"
+  - F3: "Switch: check out the generation branch (requires branch resolution from F1)"
   - F4: "Prune worktrees: remove stale git worktrees and the worktree base directory"
-  - F5: "Recover tasks: scan for stale task branches, remove them, reset their issues to ready"
-  - F6: "Reset orphans: find in_progress issues without task branches and reset them to ready"
+  - F5: "Recover tasks: scan for stale task branches, remove them, reset their issues to ready (requires worktree pruning from F4)"
+  - F6: "Reset orphans: find in_progress issues without task branches and reset them to ready (requires task recovery from F5)"
   - F7: "Reset scratch: clear the cobbler scratch directory"
-  - F8: "Drain ready: execute stitch on any existing ready issues before starting new cycles"
-  - F9: "Continue: run the requested number of measure+stitch cycles"
+  - F8: "Drain ready: execute stitch on any existing ready issues before starting new cycles (requires orphan reset from F6 so recovered tasks are eligible)"
+  - F9: "Continue: run the requested number of measure+stitch cycles (requires drain from F8 to avoid duplicate proposals)"
 
 touchpoints:
   - T1: "GeneratorResume: prd002-generation-lifecycle R4"
@@ -30,30 +30,19 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Resume resolves the correct generation branch
+    criterion: Resume resolves the correct generation branch using explicit Config, auto-detect from a single generation branch, or current-branch fallback
     traces:
       - prd002-generation-lifecycle AC4
       - prd002-generation-lifecycle AC10
   - id: S2
-    criterion: Uncommitted work is saved before switching branches
+    criterion: Existing ready issues are drained via stitch before new measure+stitch cycles begin, preventing duplicate task proposals
     traces:
       - prd002-generation-lifecycle AC4
   - id: S3
-    criterion: Stale worktrees and task branches are removed
-    traces:
-      - prd003-cobbler-workflows AC3
-  - id: S4
-    criterion: Orphaned in_progress issues are reset to ready
-    traces:
-      - prd003-cobbler-workflows AC3
-  - id: S5
-    criterion: Existing ready issues are executed before new cycles start
+    criterion: After recovery, the generation continues from the last committed state without data loss (no orphaned worktrees, no stuck in_progress issues, no stale scratch files)
     traces:
       - prd002-generation-lifecycle AC4
-  - id: S6
-    criterion: Generation continues without data loss
-    traces:
-      - prd002-generation-lifecycle AC4
+      - prd003-cobbler-workflows AC3
 
 out_of_scope:
   - Initial generation start (see rel01.0-uc002)

--- a/docs/specs/use-cases/rel01.0-uc006-scaffold-operations.yaml
+++ b/docs/specs/use-cases/rel01.0-uc006-scaffold-operations.yaml
@@ -18,11 +18,11 @@ flow:
   - F2: "Write constitutions: copy design.yaml, planning.yaml, execution.yaml, and go-style.yaml to docs/constitutions/"
   - F3: "Write prompts: copy measure.yaml and stitch.yaml to docs/prompts/"
   - F4: "Write phase context files: write measure_context.yaml and stitch_context.yaml to .cobbler/"
-  - F5: "Detect structure: read go.mod for module path; scan for main package, source directories, and binary name"
-  - F6: "Generate configuration.yaml: write a Config with detected values and constitution/prompt path references"
-  - F7: "Write seed template: if a main package is found, write a version.go seed template to magefiles/ and reference it in SeedFiles"
-  - F8: "Wire go.mod: update magefiles/go.mod with the orchestrator module dependency"
-  - F9: "Verify: run mage -l to confirm the wired magefiles compile; retry with a local replace directive if verification fails"
+  - F5: "Detect structure: read go.mod for module path; scan for main package, source directories, and binary name (requires magefiles from F1)"
+  - F6: "Generate configuration.yaml: write a Config with detected values and constitution/prompt path references (requires detected structure from F5)"
+  - F7: "Write seed template: if a main package is found, write a version.go seed template to magefiles/ and reference it in SeedFiles (requires detected structure from F5)"
+  - F8: "Wire go.mod: update magefiles/go.mod with the orchestrator module dependency (requires magefiles from F1)"
+  - F9: "Verify: run mage -l to confirm the wired magefiles compile; retry with a local replace directive if verification fails (requires all artifacts from F1-F8)"
   - F10: "Uninstall: remove magefiles/orchestrator.go, docs/constitutions/, docs/prompts/, and configuration.yaml; remove orchestrator replace directive from magefiles/go.mod; run go mod tidy"
 
 touchpoints:
@@ -32,31 +32,18 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Scaffold writes magefiles/orchestrator.go from the embedded template
-    traces:
-      - prd001-orchestrator-core AC7
-  - id: S2
-    criterion: docs/constitutions/ contains design.yaml, planning.yaml, execution.yaml, and go-style.yaml
-    traces:
-      - prd001-orchestrator-core AC4
-  - id: S3
-    criterion: docs/prompts/ contains measure.yaml and stitch.yaml
-    traces:
-      - prd001-orchestrator-core AC4
-  - id: S4
-    criterion: configuration.yaml exists at the repository root with detected values filled in
-    traces:
-      - prd001-orchestrator-core AC3
-  - id: S5
-    criterion: magefiles/go.mod references the orchestrator module
+    criterion: After scaffold, mage -l succeeds in the target repository, confirming that magefiles/orchestrator.go, magefiles/go.mod, configuration.yaml, constitutions, and prompts are all correctly wired
     traces:
       - prd001-orchestrator-core AC1
-  - id: S6
-    criterion: mage -l succeeds in the target repository after scaffolding
+      - prd001-orchestrator-core AC3
+      - prd001-orchestrator-core AC4
+      - prd001-orchestrator-core AC7
+  - id: S2
+    criterion: configuration.yaml contains auto-detected values for module_path, binary_name, main_package, and go_source_dirs derived from the target repository structure
     traces:
       - prd001-orchestrator-core AC3
-  - id: S7
-    criterion: Uninstall removes all scaffold artifacts and mage -l succeeds without orchestrator targets
+  - id: S3
+    criterion: Uninstall removes all scaffold artifacts (orchestrator.go, constitutions, prompts, configuration.yaml) and mage -l succeeds without orchestrator targets
     traces:
       - prd001-orchestrator-core AC6
 

--- a/docs/specs/use-cases/rel01.0-uc007-build-tooling.yaml
+++ b/docs/specs/use-cases/rel01.0-uc007-build-tooling.yaml
@@ -23,27 +23,15 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Build produces a binary at {BinaryDir}/{BinaryName} when MainPackage is set
+    criterion: Build produces a binary at {BinaryDir}/{BinaryName} when MainPackage is set, and propagates go build errors on failure
     traces:
       - prd001-orchestrator-core AC1
   - id: S2
-    criterion: Build exits zero on success and propagates go build errors on failure
+    criterion: Build and Install skip silently and return nil when MainPackage is empty, avoiding errors for library-only projects
     traces:
       - prd001-orchestrator-core AC1
   - id: S3
-    criterion: Lint runs golangci-lint and exits zero when no lint errors are found
-    traces:
-      - prd001-orchestrator-core AC1
-  - id: S4
-    criterion: Install places the binary in GOPATH/bin and exits zero on success
-    traces:
-      - prd001-orchestrator-core AC1
-  - id: S5
-    criterion: Clean removes BinaryDir without error, including when it does not exist
-    traces:
-      - prd001-orchestrator-core AC1
-  - id: S6
-    criterion: Build and Install skip silently and return nil when MainPackage is empty
+    criterion: Clean followed by Build produces a fresh binary (no stale artifacts from previous builds)
     traces:
       - prd001-orchestrator-core AC1
 

--- a/docs/specs/use-cases/rel01.0-uc008-performance-benchmarks.yaml
+++ b/docs/specs/use-cases/rel01.0-uc008-performance-benchmarks.yaml
@@ -29,16 +29,13 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Benchmarks complete without error for each limit value
+    criterion: Wall-clock time and issue counts are reported per sub-benchmark via testing.B, enabling regression detection across limit values
     traces:
       - prd003-cobbler-workflows AC1
       - prd003-cobbler-workflows AC2
-  - id: S2
-    criterion: Wall-clock time and issue counts are reported per sub-benchmark
-    traces:
       - prd005-metrics-collection AC1
-  - id: S3
-    criterion: Benchmarks are isolated from functional tests (run via separate mage target)
+  - id: S2
+    criterion: Benchmarks are gated behind the benchmark build tag and run only via mage test:benchmark, preventing interference with functional tests
     traces:
       - prd003-cobbler-workflows AC1
 

--- a/docs/specs/use-cases/rel01.0-uc009-phase-context-files.yaml
+++ b/docs/specs/use-cases/rel01.0-uc009-phase-context-files.yaml
@@ -17,10 +17,10 @@ trigger: Running mage cobbler:measure or mage cobbler:stitch
 
 flow:
   - F1: "Resolve context file path: join CobblerConfig.Dir with measure_context.yaml or stitch_context.yaml"
-  - F2: "Load context file: call loadPhaseContext with the resolved path"
+  - F2: "Load context file: call loadPhaseContext with the resolved path (requires path from F1)"
   - F3: "Handle missing file: if loadPhaseContext returns nil, proceed with ProjectConfig defaults"
   - F4: "Handle malformed file: if loadPhaseContext returns an error, abort the invocation and report the error"
-  - F5: "Override context settings: pass the PhaseContext to buildProjectContext, which uses non-empty PhaseContext fields instead of the corresponding ProjectConfig fields"
+  - F5: "Override context settings: pass the PhaseContext to buildProjectContext, which uses non-empty PhaseContext fields instead of the corresponding ProjectConfig fields (requires parsed PhaseContext from F2)"
   - F6: "Assemble context: buildProjectContext expands globs, applies excludes, loads documents and source code using the effective settings"
   - F7: "Log context source: log whether a phase context file was used or fallback to Config applied"
   - F8: "Continue phase: measure or stitch proceeds with the assembled ProjectContext"
@@ -35,29 +35,22 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: When measure_context.yaml exists, measure uses its include, exclude, sources, and release fields instead of ProjectConfig equivalents
+    criterion: When context files do not exist, both measure and stitch use ProjectConfig fields unchanged (backward compatible with pre-context-file projects)
     traces:
-      - prd003-cobbler-workflows AC8
+      - prd003-cobbler-workflows AC9
   - id: S2
-    criterion: When stitch_context.yaml exists, stitch uses its include, exclude, sources, and release fields instead of ProjectConfig equivalents
+    criterion: When a context file is malformed YAML, the invocation aborts with a descriptive error rather than silently falling back to defaults
     traces:
       - prd003-cobbler-workflows AC8
   - id: S3
-    criterion: When context files do not exist, both phases use ProjectConfig fields unchanged (backward compatible)
+    criterion: Modifying a context file between two consecutive measure invocations changes the assembled ProjectContext on the second invocation (invocation-time loading, not cached)
     traces:
-      - prd003-cobbler-workflows AC9
+      - prd003-cobbler-workflows AC8
   - id: S4
-    criterion: When a context file is malformed, the invocation aborts with a descriptive error
+    criterion: PhaseContext SourceMode and SummarizeCommand fields override the config-level MeasureSourceMode when present, enabling per-invocation summarization control
     traces:
       - prd003-cobbler-workflows AC8
-  - id: S5
-    criterion: Log output indicates which context source was used for each invocation
-    traces:
-      - prd003-cobbler-workflows AC8
-  - id: S6
-    criterion: Changes to context files between invocations are visible to the next invocation (invocation-time loading)
-    traces:
-      - prd003-cobbler-workflows AC8
+      - prd003-cobbler-workflows AC12
 
 out_of_scope:
   - Auto-updating context files after stitch creates new files

--- a/docs/specs/use-cases/rel01.0-uc010-worktree-based-invocation.yaml
+++ b/docs/specs/use-cases/rel01.0-uc010-worktree-based-invocation.yaml
@@ -21,8 +21,8 @@ flow:
   - F1: "Create worktree: developer runs git worktree add .claude/worktrees/feature-branch -b feature-branch from the main repo"
   - F2: "Chdir into worktree: developer opens a terminal in the worktree directory"
   - F3: "Run stitch: developer invokes mage cobbler:stitch from inside the worktree"
-  - F4: "Resolve base path: worktreeBasePath runs git rev-parse --git-common-dir, resolves the shared .git directory, derives the repo root, and returns filepath.Join(os.TempDir(), repoName+'-worktrees')"
-  - F5: "Create task worktrees: stitch creates task worktrees under the stable base path derived from the repo name, not the worktree directory name"
+  - F4: "Resolve base path: worktreeBasePath runs git rev-parse --git-common-dir, resolves the shared .git directory, derives the repo root, and returns filepath.Join(os.TempDir(), repoName+'-worktrees') (must resolve before task worktree creation in F5)"
+  - F5: "Create task worktrees: stitch creates task worktrees under the stable base path derived from the repo name, not the worktree directory name (requires base path from F4)"
   - F6: "Complete stitch: tasks execute, merge, and task worktrees are cleaned up"
   - F7: "Run resume from worktree: developer invokes mage generator:resume from inside the worktree"
   - F8: "Find stale worktrees: GeneratorResume calls worktreeBasePath, resolves the same stable base path, and finds any stale task worktrees left from interrupted runs"
@@ -36,19 +36,15 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: worktreeBasePath returns the same temp directory path when called from the main repo root and from any of its git worktrees
+    criterion: worktreeBasePath returns the same temp directory path when called from the main repo root and from any of its git worktrees, ensuring task worktrees land under a single stable location
     traces:
       - prd003-cobbler-workflows AC2
   - id: S2
-    criterion: Task worktrees created by stitch invoked from a git worktree land under the same base path as a main-repo stitch run
-    traces:
-      - prd003-cobbler-workflows AC2
-  - id: S3
-    criterion: mage generator:resume invoked from a git worktree finds and removes stale task worktrees created by a previous run from a different directory
+    criterion: mage generator:resume invoked from a git worktree finds and removes stale task worktrees created by a previous run from a different directory (cross-directory recovery)
     traces:
       - prd003-cobbler-workflows AC3
-  - id: S4
-    criterion: worktreeBasePath falls back to filepath.Base(os.Getwd()) when git rev-parse --git-common-dir fails
+  - id: S3
+    criterion: worktreeBasePath falls back to filepath.Base(os.Getwd()) when git rev-parse --git-common-dir fails, maintaining functionality outside git repositories
     traces:
       - prd003-cobbler-workflows AC2
 

--- a/docs/specs/use-cases/rel02.0-uc001-lifecycle-commands.yaml
+++ b/docs/specs/use-cases/rel02.0-uc001-lifecycle-commands.yaml
@@ -18,9 +18,9 @@ trigger: Developer invokes a lifecycle command from VS Code Command Palette (Cmd
 flow:
   - F1: "Open Command Palette: developer presses Cmd+Shift+P and types 'Mage Orchestrator'"
   - F2: "Select command: developer chooses one of the lifecycle commands (Start, Run, Resume, Stop, Reset, Switch)"
-  - F3: "Validate state: extension checks git state and disables invalid commands (e.g., Start is disabled when already on a generation branch)"
-  - F4: "Confirm if destructive: commands that alter state (Start, Stop, Reset) show a confirmation dialog before proceeding"
-  - F5: "Execute mage target: extension creates or reuses an integrated terminal and runs the corresponding mage command (e.g., 'mage generator:start')"
+  - F3: "Validate state: extension checks git state and disables invalid commands (must complete before command execution in F5)"
+  - F4: "Confirm if destructive: commands that alter state (Start, Stop, Reset) show a confirmation dialog before proceeding (must complete before execution in F5)"
+  - F5: "Execute mage target: extension creates or reuses an integrated terminal and runs the corresponding mage command (requires validation from F3 and confirmation from F4)"
   - F6: "Show output: terminal output appears in the integrated terminal panel"
   - F7: "Refresh views: extension refreshes generation browser and issue tracker views after command completes"
 
@@ -35,34 +35,18 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: All six lifecycle commands appear in Command Palette when configuration.yaml exists in workspace
+    criterion: Destructive commands (Start, Stop, Reset) show a confirmation dialog and abort when the developer cancels, preventing accidental state changes
     traces:
       - prd006-vscode-extension AC1
-      - prd006-vscode-extension AC10
   - id: S2
-    criterion: Each command executes the correct mage target in an integrated terminal
+    criterion: Commands that are invalid for the current git state are disabled (e.g., Start disabled on a generation branch, Resume disabled on main), preventing confusing error messages
     traces:
       - prd006-vscode-extension AC1
   - id: S3
-    criterion: Start, Stop, and Reset commands show confirmation dialogs before executing
+    criterion: All extension views (generation browser, issue tracker, metrics dashboard) refresh automatically after a lifecycle command completes, keeping the UI consistent with git state
     traces:
       - prd006-vscode-extension AC1
-  - id: S4
-    criterion: Switch command shows a quick-pick list of available generation branches
-    traces:
-      - prd006-vscode-extension AC1
-  - id: S5
-    criterion: Invalid commands are disabled (e.g., Start disabled when on generation branch, Resume disabled when not on generation branch)
-    traces:
-      - prd006-vscode-extension AC1
-  - id: S6
-    criterion: All extension views refresh automatically after a command completes
-    traces:
       - prd006-vscode-extension AC9
-  - id: S7
-    criterion: Terminal output is visible and can be interacted with (scroll, copy)
-    traces:
-      - prd006-vscode-extension AC1
 
 out_of_scope:
   - Real-time streaming of Claude agent output (see prd006 non-goals)

--- a/docs/specs/use-cases/rel02.0-uc002-generation-browser.yaml
+++ b/docs/specs/use-cases/rel02.0-uc002-generation-browser.yaml
@@ -41,31 +41,16 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Tree lists all generations discovered from git tags matching {GenPrefix}*-start
+    criterion: Tree discovers all generations from git tags, derives lifecycle state from tag suffixes, and displays version tags when present, combining git tag parsing with VS Code tree rendering
     traces:
       - prd006-vscode-extension AC2
   - id: S2
-    criterion: Each generation node displays the correct lifecycle state (started, finished, merged, or abandoned)
+    criterion: The generation matching the active git branch is visually distinct, and the indicator updates when branches change
     traces:
       - prd006-vscode-extension AC2
+      - prd006-vscode-extension AC9
   - id: S3
-    criterion: Version tags appear on generation nodes when a v[REL].[DATE].[REVISION] tag exists for that generation
-    traces:
-      - prd006-vscode-extension AC2
-  - id: S4
-    criterion: The generation matching the active git branch is visually distinct from inactive generations
-    traces:
-      - prd006-vscode-extension AC2
-  - id: S5
-    criterion: Expanding a generation node reveals child nodes for lifecycle tags and version tags
-    traces:
-      - prd006-vscode-extension AC2
-  - id: S6
-    criterion: The Switch to Generation context menu action changes the active branch to the selected generation
-    traces:
-      - prd006-vscode-extension AC2
-  - id: S7
-    criterion: The tree refreshes automatically when git refs change (new tags, branch switches, merges)
+    criterion: The tree refreshes automatically when git refs change (new tags, branch switches, merges) via FileSystemWatcher on .git/refs/
     traces:
       - prd006-vscode-extension AC9
 

--- a/docs/specs/use-cases/rel02.0-uc003-branch-comparison.yaml
+++ b/docs/specs/use-cases/rel02.0-uc003-branch-comparison.yaml
@@ -17,9 +17,9 @@ trigger: Developer invokes the Compare Tags command from the Command Palette, or
 flow:
   - F1: "Invoke comparison command: developer opens the Command Palette and selects Mage Orchestrator Compare Tags"
   - F2: "Select first tag: extension presents a quick-pick list of all version tags matching v[REL].[DATE].[REVISION] and the developer selects one"
-  - F3: "Select second tag: extension presents the same list (minus the first selection) and the developer selects the second tag"
-  - F4: "Compute diff: extension runs git diff --name-status between the two selected refs"
-  - F5: "Display file summary: extension opens a TreeDataProvider view showing added, modified, and deleted files grouped by directory"
+  - F3: "Select second tag: extension presents the same list (minus the first selection) and the developer selects the second tag (requires first selection from F2)"
+  - F4: "Compute diff: extension runs git diff --name-status between the two selected refs (requires both tags from F2 and F3)"
+  - F5: "Display file summary: extension opens a TreeDataProvider view showing added, modified, and deleted files grouped by directory (requires diff output from F4)"
   - F6: "Open diff editor: developer clicks a file node and VS Code opens a diff editor showing the file-level changes between the two refs"
   - F7: "Generation branch comparison: developer selects two generation nodes in the Generation Browser tree and invokes the compare context menu action"
   - F8: "Resolve branch refs: extension resolves each generation to its branch ref and repeats F4 through F6"
@@ -37,26 +37,14 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Quick-pick list displays all version tags matching the v[REL].[DATE].[REVISION] pattern
+    criterion: Clicking a file in the summary tree opens a VS Code diff editor showing changes between the two refs (cross-component integration between git diff, TreeDataProvider, and VS Code diff API)
     traces:
       - prd006-vscode-extension AC3
   - id: S2
-    criterion: File summary tree shows added, modified, and deleted files grouped by directory after selecting two tags
+    criterion: Comparison works when one or both refs have been merged or abandoned, using tag refs rather than branches so deleted generation branches do not break the workflow
     traces:
       - prd006-vscode-extension AC3
   - id: S3
-    criterion: Clicking a file in the summary opens a VS Code diff editor showing changes between the two refs
-    traces:
-      - prd006-vscode-extension AC3
-  - id: S4
-    criterion: Generation-to-generation comparison resolves each generation to its branch ref and displays the same file summary
-    traces:
-      - prd006-vscode-extension AC4
-  - id: S5
-    criterion: Comparison works when one or both refs have been merged or abandoned (uses tag refs, not branches)
-    traces:
-      - prd006-vscode-extension AC3
-  - id: S6
     criterion: Empty diff (identical refs) displays an informational message instead of an empty tree
     traces:
       - prd006-vscode-extension AC3

--- a/docs/specs/use-cases/rel02.0-uc004-issue-tracker-view.yaml
+++ b/docs/specs/use-cases/rel02.0-uc004-issue-tracker-view.yaml
@@ -19,7 +19,7 @@ trigger: Developer opens the Issue Tracker panel in the VS Code sidebar
 flow:
   - F1: "Open Issue Tracker: developer clicks the mageOrchestrator.issues view in the VS Code sidebar"
   - F2: "Fetch issues: extension calls the GitHub Issues API and builds a tree of all issues"
-  - F3: "Group by status: tree displays three collapsible parent nodes (Open, In Progress, Closed) with issues sorted under the matching group"
+  - F3: "Group by status: tree displays three collapsible parent nodes (Open, In Progress, Closed) with issues sorted under the matching group (requires fetched issues from F2)"
   - F4: "Browse issue list: each issue node displays its title, type (task or epic), and ID"
   - F5: "Expand issue: developer expands an issue node to see child nodes for description, dependencies, and comments"
   - F6: "View InvocationRecord metrics: comments containing InvocationRecord JSON render as formatted child nodes showing tokens (input and output), LOC delta (production and test before/after), duration, and diff stats (files changed, insertions, deletions)"
@@ -39,31 +39,19 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Issue Tracker tree displays Open, In Progress, and Closed as collapsible parent nodes
+    criterion: Expanding an issue reveals description, dependencies, and comments as child nodes, providing multi-layer navigation without leaving the sidebar
     traces:
       - prd006-vscode-extension AC5
   - id: S2
-    criterion: Each issue node shows its title, type, and ID
-    traces:
-      - prd006-vscode-extension AC5
-  - id: S3
-    criterion: Expanding an issue reveals description, dependencies, and comments as child nodes
-    traces:
-      - prd006-vscode-extension AC5
-  - id: S4
-    criterion: InvocationRecord comments display tokens, LOC delta, duration, and diff stats as formatted child nodes
+    criterion: InvocationRecord JSON embedded in issue comments is parsed and displayed as formatted child nodes showing tokens, LOC delta, duration, and diff stats (cross-PRD data from prd005 rendered in prd006 UI)
     traces:
       - prd006-vscode-extension AC6
-  - id: S5
-    criterion: Tree refreshes automatically on the configured polling interval
+  - id: S3
+    criterion: Tree refreshes automatically on the configured polling interval via GitHub Issues API polling
     traces:
       - prd006-vscode-extension AC9
-  - id: S6
-    criterion: Context menu action opens a read-only editor panel with the full issue details
-    traces:
-      - prd006-vscode-extension AC6
-  - id: S7
-    criterion: Tree handles an empty issue list or API error without crashing
+  - id: S4
+    criterion: Tree handles an empty issue list or GitHub API error without crashing, displaying an informational message
     traces:
       - prd006-vscode-extension AC11
 

--- a/docs/specs/use-cases/rel02.0-uc005-metrics-dashboard.yaml
+++ b/docs/specs/use-cases/rel02.0-uc005-metrics-dashboard.yaml
@@ -19,8 +19,8 @@ flow:
   - F1: "Open Command Palette: developer presses Cmd+Shift+P and selects 'Mage Orchestrator: Cobbler Measure' or accesses the dashboard directly"
   - F2: "Show dashboard: extension creates a webview panel titled 'Metrics Dashboard' in the active editor column"
   - F3: "Fetch invocation records: GitHubStore fetches GitHub issues and extracts InvocationRecord data from issue comments"
-  - F4: "Aggregate metrics: aggregateMetrics computes totals for tokens (input, output, cache creation, cache read), cost, duration, and diff stats across all records"
-  - F5: "Render HTML: renderDashboardHtml produces an HTML document with a summary table and a per-invocation details table styled with VS Code theme variables"
+  - F4: "Aggregate metrics: aggregateMetrics computes totals for tokens (input, output, cache creation, cache read), cost, duration, and diff stats across all records (requires fetched records from F3)"
+  - F5: "Render HTML: renderDashboardHtml produces an HTML document with a summary table and a per-invocation details table styled with VS Code theme variables (requires aggregated data from F4)"
   - F6: "Display summary: the summary section shows invocation count, token breakdown, estimated cost, total duration, and diff statistics (files changed, insertions, deletions)"
   - F7: "Display per-invocation details: a table lists each invocation with caller, date, duration, input/output/total tokens, LOC progression (production and test), diff stats, and issue ID"
   - F8: "Handle empty state: when no invocation records exist, the dashboard shows an informational message instead of empty tables"
@@ -40,35 +40,23 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Dashboard command opens a webview panel with aggregated metrics from GitHub issue comments
+    criterion: Dashboard aggregates InvocationRecord data from multiple GitHub issue comments into a summary showing total token breakdown, cost, duration, and diff statistics (cross-PRD data aggregation)
     traces:
       - prd006-vscode-extension AC7
   - id: S2
-    criterion: Summary section shows total invocation count, token breakdown (input, output, cache creation, cache read), estimated cost, and total duration
+    criterion: Per-invocation table shows caller, date, duration, tokens, LOC progression, diff stats, and issue ID, enabling developers to trace metrics back to specific tasks
     traces:
       - prd006-vscode-extension AC7
   - id: S3
-    criterion: Summary section shows diff statistics (files changed, insertions, deletions) when records contain diff data
+    criterion: When no invocation records exist, an informational empty-state message appears instead of empty tables
     traces:
       - prd006-vscode-extension AC7
   - id: S4
-    criterion: Per-invocation table shows caller, date, duration, input/output/total tokens, LOC progression, diff stats, and issue ID for each record
+    criterion: Re-invoking the dashboard command when the panel is visible refreshes content rather than creating a new panel (singleton behavior)
     traces:
       - prd006-vscode-extension AC7
   - id: S5
-    criterion: Dashboard renders with VS Code theme colors (foreground, background, borders)
-    traces:
-      - prd006-vscode-extension AC7
-  - id: S6
-    criterion: When no invocation records exist, an informational empty-state message appears
-    traces:
-      - prd006-vscode-extension AC7
-  - id: S7
-    criterion: Re-invoking the dashboard command when the panel is visible refreshes content rather than creating a new panel
-    traces:
-      - prd006-vscode-extension AC7
-  - id: S8
-    criterion: Dashboard refreshes automatically on the configured polling interval
+    criterion: Dashboard refreshes automatically on the configured polling interval, keeping metrics current during active generation runs
     traces:
       - prd006-vscode-extension AC9
 

--- a/docs/specs/use-cases/rel02.0-uc006-specification-browser.yaml
+++ b/docs/specs/use-cases/rel02.0-uc006-specification-browser.yaml
@@ -19,8 +19,8 @@ trigger: Developer opens the Specification Browser panel in the VS Code sidebar,
 flow:
   - F1: "Open Specification Browser: developer clicks the mageOrchestrator.specs view in the VS Code sidebar"
   - F2: "Browse top-level nodes: tree displays three parent nodes (Use Cases, PRDs, Test Suites) listing files from docs/specs/"
-  - F3: "Expand use case: developer expands a use case node to see its PRD touchpoints as child nodes, derived from the touchpoints field in the use case YAML"
-  - F4: "Expand PRD requirement: developer expands a touchpoint node to see Go source files under pkg/ that reference the PRD ID"
+  - F3: "Expand use case: developer expands a use case node to see its PRD touchpoints as child nodes, derived from the touchpoints field in the use case YAML (requires YAML parsing of the use case file)"
+  - F4: "Expand PRD requirement: developer expands a touchpoint node to see Go source files under pkg/ that reference the PRD ID (requires source file scanning triggered by node expansion)"
   - F5: "Open file: developer clicks a node to open the corresponding YAML (for specs) or Go file (for source references) in the editor"
   - F6: "Auto-refresh: tree refreshes when files under docs/specs/ change, detected via FileSystemWatcher"
   - F7: "Open annotated Go file: developer opens a Go source file containing // prd: or // uc: comments"
@@ -43,35 +43,19 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Specification Browser tree displays Use Cases, PRDs, and Test Suites as top-level nodes populated from docs/specs/
+    criterion: Expanding a use case node shows PRD touchpoints, and expanding a touchpoint shows Go source files under pkg/ that reference the PRD ID, providing three-level spec-to-code navigation
     traces:
       - prd006-vscode-extension AC13
   - id: S2
-    criterion: Expanding a use case node shows its PRD touchpoints as child nodes
+    criterion: Expanding a PRD requirement node discovers implementing source files by searching for the pattern prd[NNN] in Go files (cross-artifact discovery between spec YAML and Go source)
     traces:
       - prd006-vscode-extension AC13
   - id: S3
-    criterion: Expanding a PRD requirement node shows Go source files under pkg/ that reference the PRD ID
-    traces:
-      - prd006-vscode-extension AC13
-  - id: S4
-    criterion: Clicking any tree node opens the corresponding YAML or Go file in the editor
-    traces:
-      - prd006-vscode-extension AC13
-  - id: S5
-    criterion: Tree refreshes automatically when files under docs/specs/ are added, modified, or deleted
+    criterion: Tree refreshes automatically when files under docs/specs/ are added, modified, or deleted via FileSystemWatcher
     traces:
       - prd006-vscode-extension AC9
-  - id: S6
-    criterion: CodeLens appears above prd-annotation comments in Go files with a View Requirement action
-    traces:
-      - prd006-vscode-extension AC14
-  - id: S7
-    criterion: CodeLens appears above uc-annotation comments in Go files with a View Requirement action
-    traces:
-      - prd006-vscode-extension AC14
-  - id: S8
-    criterion: Activating a CodeLens opens the correct specification YAML in the editor
+  - id: S4
+    criterion: CodeLens appears above both prd-annotation and uc-annotation comments in Go files, and activating the CodeLens opens the correct specification YAML resolved from docs/specs/
     traces:
       - prd006-vscode-extension AC14
 

--- a/docs/specs/use-cases/rel03.0-uc001-cross-generation-comparison.yaml
+++ b/docs/specs/use-cases/rel03.0-uc001-cross-generation-comparison.yaml
@@ -15,13 +15,13 @@ trigger: Running mage compare:run <tagA> <tagB> with optional UTILITY environmen
 
 flow:
   - F1: "Parse arguments: resolve tagA and tagB into BinaryResolver instances via ResolverFromArg"
-  - F2: "Load test cases: read YAML test suite files from the specs directory, filter to cases with concrete inputs and expected outputs"
+  - F2: "Load test cases: read YAML test suite files from the specs directory, filter to cases with concrete inputs and expected outputs (requires resolvers from F1 to determine available utilities)"
   - F3: "Filter by utility: if UTILITY is set, restrict test cases to that utility"
-  - F4: "Discover utilities: list available utilities from both resolvers and intersect to find the common set"
-  - F5: "For each common utility: resolve binary paths from both resolvers"
-  - F6: "For each test case: execute both binaries with identical stdin, arguments, and environment"
-  - F7: "Compare outputs: check stdout byte-for-byte, stderr, and exit code; record TestResult"
-  - F8: "Format results: produce structured text output with pass/fail per test case and summary counts"
+  - F4: "Discover utilities: list available utilities from both resolvers and intersect to find the common set (requires both resolvers from F1)"
+  - F5: "For each common utility: resolve binary paths from both resolvers (requires utility intersection from F4)"
+  - F6: "For each test case: execute both binaries with identical stdin, arguments, and environment (requires resolved binary paths from F5)"
+  - F7: "Compare outputs: check stdout byte-for-byte, stderr, and exit code; record TestResult (requires execution output from F6)"
+  - F8: "Format results: produce structured text output with pass/fail per test case and summary counts (requires all TestResults from F7)"
   - F9: "Clean up: invoke cleanup functions for both resolvers (worktrees, temp directories)"
   - F10: "Report: return success if all tests passed, error if any failed"
 
@@ -37,31 +37,17 @@ touchpoints:
 
 success_criteria:
   - id: S1
-    criterion: Two generation tags can be compared with mage compare:run and produce pass/fail results
+    criterion: The full comparison pipeline (resolve binaries, load test cases, execute both binaries, compare outputs, format results, clean up) completes end-to-end for two git tags
     traces:
       - prd004-differential-comparison AC1
+      - prd004-differential-comparison AC4
+      - prd004-differential-comparison AC5
   - id: S2
-    criterion: The gnu pseudo-tag resolves Homebrew reference binaries with correct g-prefix mapping
+    criterion: The gnu pseudo-tag resolves Homebrew coreutils with g-prefix mapping and moreutils with unprefixed names, enabling comparison against reference implementations
     traces:
       - prd004-differential-comparison AC2
   - id: S3
-    criterion: A directory path resolves pre-built binaries via PathResolver
-    traces:
-      - prd004-differential-comparison AC6
-  - id: S4
-    criterion: Test cases are loaded from YAML spec test suites, not from _test.go files
-    traces:
-      - prd004-differential-comparison AC3
-  - id: S5
-    criterion: Output shows pass/fail per utility per test case with summary counts
-    traces:
-      - prd004-differential-comparison AC4
-  - id: S6
-    criterion: Worktrees and temporary directories are removed after comparison completes
-    traces:
-      - prd004-differential-comparison AC5
-  - id: S7
-    criterion: A single utility can be tested by setting the UTILITY environment variable
+    criterion: A single utility can be tested by setting the UTILITY environment variable, filtering the test case set before execution
     traces:
       - prd004-differential-comparison AC3
 

--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -5,6 +5,7 @@ package orchestrator
 
 import (
 	ctx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
+	"gopkg.in/yaml.v3"
 )
 
 // ---------------------------------------------------------------------------
@@ -286,6 +287,10 @@ func summarizeCustom(command, filePath, fullContent string) string {
 
 func loadOODPromptContext() ([]OODPackageContractRef, []ArchSharedProtocol) {
 	return ctx.LoadOODPromptContext()
+}
+
+func loadPRDSemanticModel() *yaml.Node {
+	return ctx.LoadPRDSemanticModel()
 }
 
 // safeCountLines stays in prompt_files.go (not delegated here).

--- a/pkg/orchestrator/internal/context/context.go
+++ b/pkg/orchestrator/internal/context/context.go
@@ -548,6 +548,40 @@ func LoadOODPromptContext() (contracts []OODPackageContractRef, sharedProtocols 
 	return contracts, sharedProtocols
 }
 
+// LoadPRDSemanticModel reads all PRDs under docs/specs/product-requirements/
+// and returns the semantic_model yaml.Node from the first PRD that has one.
+// Returns nil when no PRD contains a semantic_model field.
+//
+// We parse the raw YAML node tree rather than unmarshaling into PRDDoc
+// because yaml.v3 does not populate *yaml.Node fields when unmarshaling
+// into a struct (the node ends up with Kind=0).
+func LoadPRDSemanticModel() *yaml.Node {
+	prdFiles, _ := filepath.Glob("docs/specs/product-requirements/prd*.yaml")
+	for _, path := range prdFiles {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var doc yaml.Node
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			continue
+		}
+		if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+			continue
+		}
+		root := doc.Content[0]
+		if root.Kind != yaml.MappingNode {
+			continue
+		}
+		for i := 0; i < len(root.Content)-1; i += 2 {
+			if root.Content[i].Value == "semantic_model" {
+				return root.Content[i+1]
+			}
+		}
+	}
+	return nil
+}
+
 // ---------------------------------------------------------------------------
 // Test suite
 // ---------------------------------------------------------------------------

--- a/pkg/orchestrator/internal/context/context_test.go
+++ b/pkg/orchestrator/internal/context/context_test.go
@@ -999,3 +999,58 @@ func TestApplyContextBudget_DefaultBudget(t *testing.T) {
 		t.Errorf("expected default budget to remove files, still have %d", len(ctx.SourceCode))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// LoadPRDSemanticModel tests
+// ---------------------------------------------------------------------------
+
+func TestLoadPRDSemanticModel_Present(t *testing.T) {
+	tmp := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(tmp)
+	defer os.Chdir(orig)
+
+	os.MkdirAll("docs/specs/product-requirements", 0o755)
+	os.WriteFile(filepath.Join("docs/specs/product-requirements", "prd001-core.yaml"), []byte(`id: prd001-core
+title: Core
+semantic_model:
+  entities:
+    - name: Widget
+`), 0o644)
+
+	node := LoadPRDSemanticModel()
+	if node == nil {
+		t.Fatal("expected non-nil semantic model node")
+	}
+}
+
+func TestLoadPRDSemanticModel_Absent(t *testing.T) {
+	tmp := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(tmp)
+	defer os.Chdir(orig)
+
+	os.MkdirAll("docs/specs/product-requirements", 0o755)
+	os.WriteFile(filepath.Join("docs/specs/product-requirements", "prd001-plain.yaml"), []byte(`id: prd001-plain
+title: Plain
+`), 0o644)
+
+	node := LoadPRDSemanticModel()
+	if node != nil {
+		t.Errorf("expected nil for PRD without semantic_model, got non-nil")
+	}
+}
+
+func TestLoadPRDSemanticModel_NoPRDs(t *testing.T) {
+	tmp := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(tmp)
+	defer os.Chdir(orig)
+
+	os.MkdirAll("docs/specs/product-requirements", 0o755)
+
+	node := LoadPRDSemanticModel()
+	if node != nil {
+		t.Errorf("expected nil when no PRD files exist, got non-nil")
+	}
+}

--- a/pkg/orchestrator/internal/context/prompt.go
+++ b/pkg/orchestrator/internal/context/prompt.go
@@ -39,6 +39,7 @@ type StitchPromptDoc struct {
 	Task                  string                   `yaml:"task"`
 	Constraints           string                   `yaml:"constraints"`
 	Description           string                   `yaml:"description"`
+	SemanticModel         *yaml.Node              `yaml:"semantic_model,omitempty"`
 	SharedProtocols       []ArchSharedProtocol     `yaml:"shared_protocols,omitempty"`
 	PackageContracts      []OODPackageContractRef  `yaml:"package_contracts,omitempty"`
 }

--- a/pkg/orchestrator/prompt_test.go
+++ b/pkg/orchestrator/prompt_test.go
@@ -535,6 +535,65 @@ package_contract:
 	}
 }
 
+// --- Semantic model injection in buildStitchPrompt ---
+
+func TestBuildStitchPrompt_SemanticModelPresent(t *testing.T) {
+	// Not parallel: uses os.Chdir.
+	// When a PRD has a semantic_model, the stitch prompt includes it.
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	os.MkdirAll("docs/specs/product-requirements", 0o755)
+	os.WriteFile(filepath.Join("docs/specs/product-requirements", "prd001-core.yaml"), []byte(`id: prd001-core
+title: Core
+semantic_model:
+  entities:
+    - name: Widget
+      attributes:
+        - name: id
+          type: string
+`), 0o644)
+
+	o := New(Config{})
+	task := stitchTask{ID: "t-sm-1", Title: "impl widget", IssueType: "code"}
+	out, err := o.buildStitchPrompt(task)
+	if err != nil {
+		t.Fatalf("buildStitchPrompt: %v", err)
+	}
+	if !strings.Contains(out, "semantic_model:") {
+		t.Errorf("stitch prompt missing semantic_model key; output:\n%s", out)
+	}
+	if !strings.Contains(out, "Widget") {
+		t.Errorf("stitch prompt missing Widget entity from semantic_model; output:\n%s", out)
+	}
+}
+
+func TestBuildStitchPrompt_SemanticModelAbsent(t *testing.T) {
+	// Not parallel: uses os.Chdir.
+	// When no PRD has a semantic_model, the field is omitted from the prompt.
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	os.MkdirAll("docs/specs/product-requirements", 0o755)
+	os.WriteFile(filepath.Join("docs/specs/product-requirements", "prd001-plain.yaml"), []byte(`id: prd001-plain
+title: Plain PRD
+`), 0o644)
+
+	o := New(Config{})
+	task := stitchTask{ID: "t-sm-2", Title: "impl plain", IssueType: "code"}
+	out, err := o.buildStitchPrompt(task)
+	if err != nil {
+		t.Fatalf("buildStitchPrompt: %v", err)
+	}
+	if strings.Contains(out, "semantic_model:") {
+		t.Errorf("stitch prompt should omit semantic_model when no PRD has one; output:\n%s", out)
+	}
+}
+
 // --- OOD injection in buildMeasurePrompt ---
 
 func TestBuildMeasurePrompt_OODContractsHeaders(t *testing.T) {

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -460,6 +460,12 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 		logf("buildStitchPrompt: injecting %d package_contracts", len(oodContracts))
 	}
 
+	// Load semantic model from PRD (informational context for stitch).
+	semanticModel := loadPRDSemanticModel()
+	if semanticModel != nil {
+		logf("buildStitchPrompt: injecting semantic_model from PRD")
+	}
+
 	doc := StitchPromptDoc{
 		Role:                  tmpl.Role,
 		RepositoryFiles:       repoFiles,
@@ -470,6 +476,7 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 		Task:                  tmpl.Task,
 		Constraints:           tmpl.Constraints,
 		Description:           task.Description,
+		SemanticModel:         semanticModel,
 		SharedProtocols:       oodProtocols,
 		PackageContracts:      oodContracts,
 	}


### PR DESCRIPTION
## Summary

Implements the actionable recommendations from two evaluation issues. Injects PRD semantic_model fields into stitch prompts as behavioral context for code generation. Tightens UC S-items by 44.8% (105 → 58) by removing items that restate PRD ACs without integration value, and strengthens F-item rationale with sequencing dependencies.

## Changes

- Added `SemanticModel *yaml.Node` to `StitchPromptDoc` and `LoadPRDSemanticModel()` to scan PRDs
- Wired semantic model injection into `buildStitchPrompt` with logging
- Tests for both present and absent semantic model cases
- Tightened S-items across all 17 UCs (105 → 58, 44.8% reduction)
- Added F-item sequencing rationale to 14 of 17 UCs

## Stats

- Go LOC: 47,080 (prod: 17,646 / test: 29,434)
- Spec words: PRD 9,484 | UC 7,711 (-112) | Test suites 3,676
- 23 files changed, +297 / -309

## Test plan

- [x] `mage analyze` passes
- [x] All 12 test packages pass
- [x] Semantic model injection tested (present + absent cases)

Closes #1324