### PR TITLE
crumbs#37: Add DependsOn field to RoadmapRelease

### DIFF
--- a/pkg/orchestrator/internal/analysis/analyze.go
+++ b/pkg/orchestrator/internal/analysis/analyze.go
@@ -175,22 +175,29 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 	}
 	deps.Log("analyze: found %d test suites", len(testSuiteIDs))
 
-	// 4. Load road-map.yaml — collect release IDs and use case IDs
+	// 4. Load road-map.yaml — collect release IDs, use case IDs, and depends_on
 	roadmapUCs := make(map[string]bool)
 	roadmapReleaseIDs := make(map[string]bool)
+	roadmapAllVersions := make(map[string]bool)             // all release versions (including those without UCs)
+	releaseDependsOn := make(map[string][]string)            // release version -> depends_on entries
 	if data, err := os.ReadFile("docs/road-map.yaml"); err == nil {
 		var roadmap struct {
 			Releases []struct {
-				ID       string `yaml:"version"`
-				UseCases []struct {
+				ID        string   `yaml:"version"`
+				DependsOn []string `yaml:"depends_on"`
+				UseCases  []struct {
 					ID string `yaml:"id"`
 				} `yaml:"use_cases"`
 			} `yaml:"releases"`
 		}
 		if err := yaml.Unmarshal(data, &roadmap); err == nil {
 			for _, release := range roadmap.Releases {
+				roadmapAllVersions[release.ID] = true
 				if len(release.UseCases) > 0 {
 					roadmapReleaseIDs[release.ID] = true
+				}
+				if len(release.DependsOn) > 0 {
+					releaseDependsOn[release.ID] = release.DependsOn
 				}
 				for _, uc := range release.UseCases {
 					roadmapUCs[uc.ID] = true
@@ -205,6 +212,16 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 		if !roadmapReleaseIDs[r] {
 			result.InvalidReleases = append(result.InvalidReleases,
 				fmt.Sprintf("configured release %q not found in road-map.yaml", r))
+		}
+	}
+
+	// Check 0b: Release depends_on references must be valid release versions.
+	for version, depVersions := range releaseDependsOn {
+		for _, dep := range depVersions {
+			if !roadmapAllVersions[dep] {
+				result.InvalidReleases = append(result.InvalidReleases,
+					fmt.Sprintf("release %s: depends_on references non-existent release %q", version, dep))
+			}
 		}
 	}
 

--- a/pkg/orchestrator/internal/analysis/types.go
+++ b/pkg/orchestrator/internal/analysis/types.go
@@ -25,10 +25,11 @@ type RoadmapDoc struct {
 
 // RoadmapRelease is a single release entry in the roadmap.
 type RoadmapRelease struct {
-	Version  string           `yaml:"version"`
-	Name     string           `yaml:"name"`
-	Status   string           `yaml:"status"`
-	UseCases []RoadmapUseCase `yaml:"use_cases"`
+	Version   string           `yaml:"version"`
+	Name      string           `yaml:"name"`
+	Status    string           `yaml:"status"`
+	DependsOn []string         `yaml:"depends_on,omitempty"`
+	UseCases  []RoadmapUseCase `yaml:"use_cases"`
 }
 
 // RoadmapUseCase is a use case entry within a roadmap release.

--- a/pkg/orchestrator/internal/context/context.go
+++ b/pkg/orchestrator/internal/context/context.go
@@ -374,6 +374,7 @@ type RoadmapRelease struct {
 	Name        string           `yaml:"name"`
 	Status      string           `yaml:"status"`
 	Description string           `yaml:"description,omitempty"`
+	DependsOn   []string         `yaml:"depends_on,omitempty"`
 	UseCases    []RoadmapUseCase `yaml:"use_cases"`
 }
 


### PR DESCRIPTION
## Summary

Adds a `DependsOn []string` field to both `RoadmapRelease` structs (analysis and context packages) so consuming repos like crumbs can declare release dependencies in `road-map.yaml` without schema errors. Adds validation in `mage analyze` that `depends_on` entries reference existing release versions.

## Changes

- `internal/analysis/types.go`: Added `DependsOn []string` with `yaml:"depends_on,omitempty"` to `RoadmapRelease`
- `internal/context/context.go`: Added `DependsOn []string` with `yaml:"depends_on,omitempty"` to `RoadmapRelease`
- `internal/analysis/analyze.go`: Updated roadmap loader to capture `depends_on`; added Check 0b to validate references

## Test plan

- [x] All 12 packages pass (`go test ./pkg/orchestrator/... -count=1 -short`)
- [x] `mage analyze` passes
- [x] Invalid `depends_on` references produce errors in `InvalidReleases`

Addresses petar-djukic/crumbs#37