### PR TITLE
GH-1349: count sub-requirements for max_requirements_per_task

### DIFF
--- a/docs/prompts/measure.yaml
+++ b/docs/prompts/measure.yaml
@@ -29,6 +29,7 @@ constraints: |
   - Do NOT duplicate existing issues. Review the issues in the project_context above before proposing.
   - Do NOT exceed {limit} tasks. If more work is needed, create additional tasks in a future session.
   - Do NOT create tasks larger than {lines_max} lines of production code. Target {lines_min}-{lines_max} lines per task, touching 5-7 files. Split aggressively: a task that creates a struct and implements its methods is two tasks.
+  - PRD requirements use a two-level structure: R-groups (R1, R2, R3) contain sub-requirements (R1.1, R1.2, R2.1). When referencing requirements, always use sub-requirement IDs (e.g., "prd003 R2.1, R2.2, R2.3"), not group IDs. A reference to "prd003 R2" means ALL sub-requirements under R2, which may be 10+ items. Each task must contain at most {max_requirements} PRD sub-requirements total. Count every sub-requirement individually: "prd003 R2.1, R2.2, R2.3" is 3 sub-requirements, while "prd003 R2" expands to however many items R2 contains. Split tasks that would exceed the limit.
   - Each task MUST be independently executable by an agent that has no context beyond the task description and the execution constitution.
   - Do NOT assume the stitch agent has access to your analysis, the existing issues list, or any context from this conversation.
   - Do NOT propose tasks that require human judgment or manual testing. Each task must have checkable acceptance criteria.
@@ -59,8 +60,9 @@ output_format: |
             note: ExampleType implementation
 
         requirements:
-          - "R1: Implement ExampleType per prd001-feature R2"
-          - "R2: Add Get and Set operations"
+          - "R1: Implement ExampleType struct per prd001-feature R2.1, R2.2"
+          - "R2: Add Get operation per prd001-feature R2.3"
+          - "R3: Add Set operation per prd001-feature R2.4"
 
         design_decisions:
           - Use table accessor pattern from prd001-cupboard-core

--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -624,18 +624,51 @@ func ParseStitchComment(body string) StitchCommentData {
 	return d
 }
 
-// CountDescriptionReqs counts the number of requirements in a task description
-// by parsing the YAML requirements list.
+// reSubReq matches individual sub-requirement references like R1.2, R2.3.
+var reSubReq = regexp.MustCompile(`R\d+\.\d+`)
+
+// CountDescriptionReqs counts the number of sub-requirements in a task
+// description. It counts explicit sub-requirement references (R1.1, R2.3)
+// across all requirement lines. When no sub-requirement references are
+// found, falls back to counting requirement lines.
 func CountDescriptionReqs(description string) int {
 	var parsed struct {
 		Requirements []struct {
-			ID string `yaml:"id"`
+			Text string `yaml:"text"`
 		} `yaml:"requirements"`
 	}
 	if err := yaml.Unmarshal([]byte(description), &parsed); err != nil {
-		return 0
+		// Fallback: try list-of-strings format.
+		var alt struct {
+			Requirements []string `yaml:"requirements"`
+		}
+		if err2 := yaml.Unmarshal([]byte(description), &alt); err2 != nil {
+			return 0
+		}
+		total := 0
+		for _, r := range alt.Requirements {
+			refs := reSubReq.FindAllString(r, -1)
+			if len(refs) > 0 {
+				total += len(refs)
+			} else {
+				total++
+			}
+		}
+		return total
 	}
-	return len(parsed.Requirements)
+	total := 0
+	for _, r := range parsed.Requirements {
+		refs := reSubReq.FindAllString(r.Text, -1)
+		if len(refs) > 0 {
+			total += len(refs)
+		} else {
+			total++
+		}
+	}
+	if total == 0 {
+		return len(parsed.Requirements)
+	}
+	return total
 }
 
 // reRelease matches release patterns like "rel01.0" or "rel02.1" in text.

--- a/pkg/orchestrator/internal/stats/generator_stats_test.go
+++ b/pkg/orchestrator/internal/stats/generator_stats_test.go
@@ -347,9 +347,24 @@ func TestCountDescriptionReqs(t *testing.T) {
 		want int
 	}{
 		{
-			name: "three requirements",
+			name: "three requirements no subreqs",
 			desc: "title: some task\nrequirements:\n  - id: R1\n    text: first\n  - id: R2\n    text: second\n  - id: R3\n    text: third\n",
 			want: 3,
+		},
+		{
+			name: "sub-requirement references counted",
+			desc: "requirements:\n  - \"R1: Implement per prd003 R2.1, R2.2, R2.3\"\n  - \"R2: Add tests per prd003 R3.1\"\n",
+			want: 4,
+		},
+		{
+			name: "mixed lines with and without subreq refs",
+			desc: "requirements:\n  - \"R1: Implement per prd003 R1.1\"\n  - \"R2: General cleanup\"\n",
+			want: 2,
+		},
+		{
+			name: "structured format with subreq refs",
+			desc: "requirements:\n  - id: R1\n    text: \"Implement per prd003 R2.1, R2.2\"\n  - id: R2\n    text: \"Add per prd003 R3.1, R3.2, R3.3\"\n",
+			want: 5,
 		},
 		{
 			name: "no requirements key",


### PR DESCRIPTION
## Summary

The measure prompt now explains the R-group / sub-requirement structure and enforces the `{max_requirements}` limit on sub-requirements. `CountDescriptionReqs` in stats counts sub-requirement references (R1.1, R2.3) instead of requirement lines.

## Changes

- Added sub-requirement constraint to measure prompt template with `{max_requirements}` placeholder
- Updated prompt example to show sub-requirement references instead of R-group references
- `CountDescriptionReqs` now counts `R\d+.\d+` patterns in requirement text; falls back to line count
- Added test cases for sub-requirement counting

## Stats

- 3 files changed, +58/-8 lines
- LOC: 17,946 prod, 30,696 test

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] CountDescriptionReqs tested with sub-requirement refs, mixed, and legacy formats

Closes #1349