### PR TITLE
GH-1355: include measure tokens in header token totals

### DIFF
--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -303,8 +303,17 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	if totalPromptBytes > 0 {
 		fmt.Printf("Prompt total: %s\n", FormatBytes(totalPromptBytes))
 	}
-	if totalInputTokens > 0 || totalOutputTokens > 0 {
-		fmt.Printf("Tokens: %s in, %s out\n", FormatTokens(totalInputTokens), FormatTokens(totalOutputTokens))
+	combinedIn := totalInputTokens + totalMeasureIn
+	combinedOut := totalOutputTokens + totalMeasureOut
+	if combinedIn > 0 || combinedOut > 0 {
+		if totalMeasureIn > 0 {
+			fmt.Printf("Tokens: %s in, %s out (stitch %s in, %s out + measure %s in, %s out)\n",
+				FormatTokens(combinedIn), FormatTokens(combinedOut),
+				FormatTokens(totalInputTokens), FormatTokens(totalOutputTokens),
+				FormatTokens(totalMeasureIn), FormatTokens(totalMeasureOut))
+		} else {
+			fmt.Printf("Tokens: %s in, %s out\n", FormatTokens(combinedIn), FormatTokens(combinedOut))
+		}
 	}
 
 	// Per-release breakdown.


### PR DESCRIPTION
## Summary

The header Tokens line now shows combined stitch + measure token counts with a breakdown when measure tokens are present.

## Changes

- Combined stitch + measure input/output tokens in header
- Shows breakdown: `Tokens: 2.3M in, 133K out (stitch 516K in, 7K out + measure 1.8M in, 126K out)`
- Falls back to simple format when no measure tokens exist

## Test plan

- [x] All tests pass

Closes #1355