### PR TITLE
GH-1360: track measure invocations as GitHub issues

### DIFF
--- a/pkg/orchestrator/internal/github/issues.go
+++ b/pkg/orchestrator/internal/github/issues.go
@@ -61,6 +61,7 @@ type WorkTracker interface {
 	CloseCobblerIssue(repo string, number int, generation string) error
 	CloseMeasuringPlaceholder(repo string, number int)
 	CloseMeasuringPlaceholderWithComment(repo string, number int, comment string)
+	FinalizeMeasurePlaceholder(repo string, number int, generation, comment string, childIssues []int)
 	EditIssueTitle(repo string, number int, title string) error
 	CommentCobblerIssue(repo string, number int, body string)
 	CloseGenerationIssues(repo, generation string) error
@@ -502,6 +503,45 @@ func (t *GitHubTracker) CloseMeasuringPlaceholderWithComment(repo string, number
 		t.Log("closeMeasuringPlaceholderWithComment: comment on #%d warning: %v", number, err)
 	}
 	t.CloseMeasuringPlaceholder(repo, number)
+}
+
+// FinalizeMeasurePlaceholder converts the measuring placeholder into a
+// permanent [measure] issue, adds a summary comment, links created stitch
+// issues as sub-issues, adds the generation label, and closes it (GH-1360).
+func (t *GitHubTracker) FinalizeMeasurePlaceholder(repo string, number int, generation, comment string, childIssues []int) {
+	title := fmt.Sprintf("[measure] %s #%d", generation, number)
+	if err := exec.Command(t.GhBin, "issue", "edit",
+		"--repo", repo,
+		fmt.Sprintf("%d", number),
+		"--title", title,
+	).Run(); err != nil {
+		t.Log("finalizeMeasurePlaceholder: edit title #%d warning: %v", number, err)
+	}
+
+	// Add generation label so the issue appears in generation queries.
+	if err := t.AddIssueLabel(repo, number, GenLabel(generation)); err != nil {
+		t.Log("finalizeMeasurePlaceholder: add label #%d warning: %v", number, err)
+	}
+
+	// Link created stitch issues as sub-issues of this measure issue.
+	for _, child := range childIssues {
+		if err := t.LinkSubIssue(repo, number, child); err != nil {
+			t.Log("finalizeMeasurePlaceholder: linkSubIssue #%d -> #%d warning: %v", child, number, err)
+		}
+	}
+
+	if comment != "" {
+		if err := exec.Command(t.GhBin, "issue", "comment",
+			"--repo", repo,
+			fmt.Sprintf("%d", number),
+			"--body", comment,
+		).Run(); err != nil {
+			t.Log("finalizeMeasurePlaceholder: comment #%d warning: %v", number, err)
+		}
+	}
+
+	t.CloseMeasuringPlaceholder(repo, number)
+	t.Log("finalizeMeasurePlaceholder: finalized #%d with %d child issue(s)", number, len(childIssues))
 }
 
 // UpgradeMeasuringPlaceholder converts the transient measuring placeholder

--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -442,8 +442,12 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		return measureEntries[i].StartedAt < measureEntries[j].StartedAt
 	})
 	for i, m := range measureEntries {
+		mid := fmt.Sprintf("M%d", i+1)
+		if m.TaskID != "" {
+			mid = "#" + m.TaskID
+		}
 		tr := tableRow{
-			ID:       fmt.Sprintf("M%d", i+1),
+			ID:       mid,
 			Status:   "done",
 			Rel:      "-",
 			Reqs:     "-",

--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -90,6 +90,10 @@ func closeMeasuringPlaceholderWithComment(repo string, number int, comment strin
 	ghTrackerNoCfg().CloseMeasuringPlaceholderWithComment(repo, number, comment)
 }
 
+func finalizeMeasurePlaceholder(repo string, number int, generation, comment string, childIssues []int) {
+	ghTrackerNoCfg().FinalizeMeasurePlaceholder(repo, number, generation, comment, childIssues)
+}
+
 func upgradeMeasuringPlaceholder(repo string, number int, generation string, issue proposedIssue) error {
 	return ghTrackerNoCfg().UpgradeMeasuringPlaceholder(repo, number, generation, issue)
 }

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -224,6 +224,7 @@ func (o *Orchestrator) RunMeasure() error {
 				o.saveHistoryLog(historyTS, "measure", tokens.RawOutput)
 				o.saveHistoryStats(historyTS, "measure", HistoryStats{
 					Caller:        "measure",
+					TaskID:        fmt.Sprintf("%d", placeholderNum),
 					Status:        "failed",
 					Error:         fmt.Sprintf("claude failure (iteration %d/%d): %v", i+1, totalIssues, err),
 					StartedAt:     iterStart.UTC().Format(time.RFC3339),
@@ -245,6 +246,7 @@ func (o *Orchestrator) RunMeasure() error {
 			o.saveHistory(historyTS, tokens.RawOutput, outputFile)
 			o.saveHistoryStats(historyTS, "measure", HistoryStats{
 				Caller:        "measure",
+				TaskID:        fmt.Sprintf("%d", placeholderNum),
 				Status:        "success",
 				StartedAt:     iterStart.UTC().Format(time.RFC3339),
 				Duration:      iterDuration.Round(time.Second).String(),
@@ -307,10 +309,26 @@ func (o *Orchestrator) RunMeasure() error {
 			}
 		}
 
-		// Close the placeholder only when it was not upgraded in-place (GH-578).
+		// Finalize the placeholder as a permanent [measure] issue (GH-1360).
+		// When upgraded in-place (single issue), the placeholder became the
+		// stitch task — no finalization needed.
 		placeholderResolved = true
 		if placeholderNum > 0 && !placeholderUpgraded {
-			closeMeasuringPlaceholder(repo, placeholderNum)
+			// Parse created IDs as ints for sub-issue linking.
+			var childNums []int
+			for _, id := range createdIDs {
+				if n, err := fmt.Sscanf(id, "%d", new(int)); n == 1 && err == nil {
+					var v int
+					fmt.Sscanf(id, "%d", &v)
+					childNums = append(childNums, v)
+				}
+			}
+			comment := fmt.Sprintf("Measure completed. Created %d issue(s).", len(createdIDs))
+			if totalTokens.CostUSD > 0 {
+				comment += fmt.Sprintf("\nCost: $%.2f, Tokens: %din %dout",
+					totalTokens.CostUSD, totalTokens.InputTokens, totalTokens.OutputTokens)
+			}
+			finalizeMeasurePlaceholder(repo, placeholderNum, generation, comment, childNums)
 		}
 
 		allCreatedIDs = append(allCreatedIDs, createdIDs...)


### PR DESCRIPTION
## Summary

Measure placeholders are now finalized as permanent [measure] issues instead of being silently closed. Created stitch issues are linked as sub-issues, and the measure issue number is stored in history stats so the stats table shows real issue numbers instead of synthetic labels.

## Changes

- Added `FinalizeMeasurePlaceholder` to `WorkTracker` interface and `GitHubTracker` implementation
- Measure placeholder is renamed to `[measure] <generation> #N`, labeled with generation label, linked to child stitch issues, commented with cost summary, then closed
- `TaskID` field in measure history stats now stores the placeholder issue number
- Stats table displays `#NNN` (real issue number) instead of `M1`/`M2` for measure rows

## Stats

- go_loc_prod: 17914
- go_loc_test: 30711

## Test plan

- [ ] `mage analyze` passes
- [ ] All tests pass
- [ ] Documentation reviewed for consistency

Closes #1360