### PR TITLE
GH-1361: validate UC implementation before marking as implemented

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -14,6 +14,9 @@ import (
 	"text/template"
 	"time"
 
+	"os/exec"
+
+	an "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/analysis"
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/generate"
 )
 
@@ -437,18 +440,6 @@ func (o *Orchestrator) RunCycles(label string) error {
 			consecutiveZeroLOC = 0
 		}
 
-		// Mark UCs as implemented when no open issues remain (GH-1187).
-		// Only check after stitch has completed at least one task to avoid
-		// false positives on the first cycle before measure creates issues.
-		if totalStitched > 0 {
-			o.markCompletedReleaseUCs()
-		}
-
-		// Check if the current release is complete and auto-advance if so.
-		if advanced, ver := o.checkAutoAdvanceRelease(); advanced {
-			logf("generator %s: cycle %d — auto-advanced release %s", label, cycle, ver)
-		}
-
 		// Skip measure if open issues remain — stitch should drain them first (GH-1352).
 		if openBefore, err := o.hasOpenIssues(); err == nil && openBefore {
 			logf("generator %s: cycle %d — skipping measure, open issues remain", label, cycle)
@@ -457,6 +448,20 @@ func (o *Orchestrator) RunCycles(label string) error {
 			if err := o.RunMeasure(); err != nil {
 				return fmt.Errorf("cycle %d measure: %w", cycle, err)
 			}
+		}
+
+		// Validate UC implementation after measure has had a chance to propose
+		// remaining work. Only mark individual UCs whose tests exist and pass
+		// (GH-1361). Previous code marked ALL UCs when no open issues remained,
+		// which was premature — a single completed task would mark the entire
+		// release as done before measure could propose work for other UCs.
+		if totalStitched > 0 {
+			o.validateAndMarkUCs()
+		}
+
+		// Check if the current release is complete and auto-advance if so.
+		if advanced, ver := o.checkAutoAdvanceRelease(); advanced {
+			logf("generator %s: cycle %d — auto-advanced release %s", label, cycle, ver)
 		}
 
 		open, err := o.hasOpenIssues()
@@ -530,22 +535,12 @@ func (o *Orchestrator) checkAutoAdvanceRelease() (bool, string) {
 	return true, target.Version
 }
 
-// markCompletedReleaseUCs checks whether all cobbler issues for the current
-// generation are closed. If so, it marks the first non-implemented release's
-// use cases as "implemented" in road-map.yaml so that checkAutoAdvanceRelease
-// can detect the completion and advance the release (GH-1187).
-func (o *Orchestrator) markCompletedReleaseUCs() {
-	open, err := o.hasOpenIssues()
-	if err != nil || open {
-		return
-	}
-	o.markActiveReleaseUCsDone()
-}
-
-// markActiveReleaseUCsDone finds the first non-implemented release in
-// road-map.yaml and marks all its UCs as "implemented". Commits the change.
-// Separated from markCompletedReleaseUCs for testability (no GitHub API).
-func (o *Orchestrator) markActiveReleaseUCsDone() {
+// validateAndMarkUCs finds the first non-implemented release in road-map.yaml
+// and validates each UC individually. A UC is marked "implemented" only when
+// its test files exist and pass. Replaces the former markCompletedReleaseUCs /
+// markActiveReleaseUCsDone pair that blindly marked all UCs when no open issues
+// remained (GH-1361).
+func (o *Orchestrator) validateAndMarkUCs() {
 	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
 	if rm == nil {
 		return
@@ -564,29 +559,57 @@ func (o *Orchestrator) markActiveReleaseUCsDone() {
 		return
 	}
 
-	// Check if any UCs still need marking.
-	allDone := true
+	var marked []string
 	for _, uc := range target.UseCases {
-		if !ucStatusDone(uc.Status) {
-			allDone = false
-			break
+		if ucStatusDone(uc.Status) {
+			continue
 		}
-	}
-	if allDone {
-		return
+		if !validateUCImplemented(uc.ID) {
+			logf("validateAndMarkUCs: UC %s not yet implemented (tests missing or failing)", uc.ID)
+			continue
+		}
+		logf("validateAndMarkUCs: UC %s validated — marking as implemented", uc.ID)
+		if err := updateRoadmapSingleUCStatus(target.Version, uc.ID, "implemented"); err != nil {
+			logf("validateAndMarkUCs: failed to mark %s: %v", uc.ID, err)
+			continue
+		}
+		marked = append(marked, uc.ID)
 	}
 
-	logf("markActiveReleaseUCsDone: marking release %s UCs as implemented", target.Version)
-	if err := updateRoadmapUCStatuses(target.Version, "implemented"); err != nil {
-		logf("markActiveReleaseUCsDone: failed: %v", err)
+	if len(marked) == 0 {
 		return
 	}
 
 	_ = gitStageAll(".")
-	msg := fmt.Sprintf("Mark release %s use cases as implemented\n\nAll cobbler issues closed; UCs updated in road-map.yaml.", target.Version)
+	msg := fmt.Sprintf("Mark validated UCs as implemented in release %s\n\nUCs with passing tests: %s",
+		target.Version, strings.Join(marked, ", "))
 	if err := gitCommit(msg, "."); err != nil {
-		logf("markActiveReleaseUCsDone: commit failed: %v", err)
+		logf("validateAndMarkUCs: commit failed: %v", err)
 	}
+}
+
+// validateUCImplemented checks whether a use case has test files and whether
+// those tests pass. Returns true only if both conditions are met.
+func validateUCImplemented(ucID string) bool {
+	testDir := an.TestDirForUC(ucID)
+	if testDir == "" {
+		return false
+	}
+	testCount := an.CountTestFiles(testDir)
+	if testCount == 0 {
+		logf("validateUCImplemented: %s — no test files in %s", ucID, testDir)
+		return false
+	}
+
+	// Run the UC's tests. Use -count=1 to disable caching.
+	cmd := exec.Command("go", "test", "-tags=usecase", "-count=1", "-timeout", "300s", "./"+testDir+"/...")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		logf("validateUCImplemented: %s — tests failed: %v\n%s", ucID, err, string(out))
+		return false
+	}
+	logf("validateUCImplemented: %s — %d test file(s) pass", ucID, testCount)
+	return true
 }
 
 // GeneratorStart begins a new generation trail.

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -1390,13 +1390,11 @@ func TestResolveStopTarget_CallerOnCustomBase_UsesCustomBase(t *testing.T) {
 	}
 }
 
-// --- markActiveReleaseUCsDone (GH-1187) ---
+// --- validateAndMarkUCs (GH-1361, replaces GH-1187 markActiveReleaseUCsDone) ---
 
-func TestMarkActiveReleaseUCsDone(t *testing.T) {
+func TestValidateAndMarkUCs_OnlyMarksUCsWithPassingTests(t *testing.T) {
 	dir := initTestGitRepo(t)
 
-	// Release 00.0 has spec_complete UCs (stitch has finished all tasks but
-	// UC statuses were never updated — the bug this fixes).
 	roadmapContent := `id: rm1
 title: Test Roadmap
 releases:
@@ -1420,26 +1418,38 @@ releases:
 `
 	writeRoadmapFile(t, dir, roadmapContent)
 
-	o := &Orchestrator{cfg: Config{}}
-	o.markActiveReleaseUCsDone()
+	// Create go.mod so `go test` can run in this directory.
+	goMod := "module testmod\n\ngo 1.23\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatal(err)
+	}
 
-	// Verify 00.0 UCs are now "implemented".
+	// Create test directory for uc001 only (uc002 has no tests).
+	testDir := filepath.Join(dir, "tests", "rel00.0", "uc001")
+	if err := os.MkdirAll(testDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Write a minimal passing test file.
+	testContent := "package uc001_test\n\nimport \"testing\"\n\nfunc TestPlaceholder(t *testing.T) {}\n"
+	if err := os.WriteFile(filepath.Join(testDir, "format_test.go"), []byte(testContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	o := &Orchestrator{cfg: Config{}}
+	o.validateAndMarkUCs()
+
 	rmPath := filepath.Join(dir, "docs", "road-map.yaml")
-	relStatus, err := roadmapReleaseStatus(rmPath, "00.0")
-	if err != nil {
-		t.Fatalf("read release status for 00.0: %v", err)
-	}
-	if relStatus != "implemented" {
-		t.Errorf("release 00.0 status: want implemented, got %q", relStatus)
-	}
 	statuses, err := roadmapUCStatuses(rmPath, "00.0")
 	if err != nil {
 		t.Fatalf("read UC statuses for 00.0: %v", err)
 	}
-	for id, status := range statuses {
-		if status != "implemented" {
-			t.Errorf("UC %s: want implemented, got %q", id, status)
-		}
+	// uc001 has tests → should be implemented.
+	if statuses["rel00.0-uc001-format"] != "implemented" {
+		t.Errorf("UC rel00.0-uc001-format: want implemented, got %q", statuses["rel00.0-uc001-format"])
+	}
+	// uc002 has no tests → should remain spec_complete.
+	if statuses["rel00.0-uc002-build"] != "spec_complete" {
+		t.Errorf("UC rel00.0-uc002-build: want spec_complete, got %q", statuses["rel00.0-uc002-build"])
 	}
 
 	// Verify 01.0 is unchanged.
@@ -1454,10 +1464,9 @@ releases:
 	}
 }
 
-func TestMarkActiveReleaseUCsDone_AlreadyImplemented(t *testing.T) {
+func TestValidateAndMarkUCs_SkipsAlreadyImplemented(t *testing.T) {
 	dir := initTestGitRepo(t)
 
-	// Release 00.0 is already implemented — should be a no-op.
 	roadmapContent := `id: rm1
 title: Test Roadmap
 releases:
@@ -1479,27 +1488,27 @@ releases:
 	writeRoadmapFile(t, dir, roadmapContent)
 
 	o := &Orchestrator{cfg: Config{}}
-	o.markActiveReleaseUCsDone()
+	o.validateAndMarkUCs()
 
-	// 01.0 should now be marked as implemented (it's the first non-done release).
+	// 01.0 UC has no tests → should remain spec_complete (not blindly marked).
 	rmPath := filepath.Join(dir, "docs", "road-map.yaml")
 	statuses, err := roadmapUCStatuses(rmPath, "01.0")
 	if err != nil {
 		t.Fatalf("read UC statuses for 01.0: %v", err)
 	}
 	for id, status := range statuses {
-		if status != "implemented" {
-			t.Errorf("UC %s (rel 01.0): want implemented, got %q", id, status)
+		if status != "spec_complete" {
+			t.Errorf("UC %s (rel 01.0): want spec_complete, got %q", id, status)
 		}
 	}
 }
 
-func TestMarkActiveReleaseUCsDone_NoRoadmap(t *testing.T) {
+func TestValidateAndMarkUCs_NoRoadmap(t *testing.T) {
 	initTestGitRepo(t)
 
 	o := &Orchestrator{cfg: Config{}}
 	// Should be a no-op, no panic.
-	o.markActiveReleaseUCsDone()
+	o.validateAndMarkUCs()
 }
 
 // --- checkAutoAdvanceRelease (GH-1006) ---

--- a/pkg/orchestrator/internal/release/release.go
+++ b/pkg/orchestrator/internal/release/release.go
@@ -177,6 +177,94 @@ func SetRoadmapUCStatuses(root *yaml.Node, version, newStatus string) error {
 	return fmt.Errorf("version %q not found in releases node tree", version)
 }
 
+// UpdateRoadmapSingleUCStatus loads docs/road-map.yaml, finds the release
+// matching version, sets the status of the single use case identified by ucID
+// to newStatus, and writes the file back. Does not modify the release-level
+// status or other use cases.
+func UpdateRoadmapSingleUCStatus(version, ucID, newStatus string) error {
+	const path = "docs/road-map.yaml"
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("release update single UC: read %s: %w", path, err)
+	}
+
+	var doc roadmapDoc
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return fmt.Errorf("release update single UC: parse %s: %w", path, err)
+	}
+	found := false
+	for _, rel := range doc.Releases {
+		if rel.Version == version {
+			for _, uc := range rel.UseCases {
+				if uc.ID == ucID {
+					found = true
+					break
+				}
+			}
+			break
+		}
+	}
+	if !found {
+		return fmt.Errorf("release update single UC: version %q UC %q not found in %s", version, ucID, path)
+	}
+
+	var root yaml.Node
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return fmt.Errorf("release update single UC: node parse %s: %w", path, err)
+	}
+
+	if err := SetRoadmapSingleUCStatus(&root, version, ucID, newStatus); err != nil {
+		return fmt.Errorf("release update single UC: mutate %s: %w", path, err)
+	}
+
+	out, err := yaml.Marshal(&root)
+	if err != nil {
+		return fmt.Errorf("release update single UC: marshal %s: %w", path, err)
+	}
+	if err := os.WriteFile(path, out, 0o644); err != nil {
+		return fmt.Errorf("release update single UC: write %s: %w", path, err)
+	}
+	Log("release update: set UC %s status to %q for release %s in %s", ucID, newStatus, version, path)
+	return nil
+}
+
+// SetRoadmapSingleUCStatus mutates the yaml.Node tree of road-map.yaml,
+// finding the release with the given version and setting the status of the
+// use case matching ucID to newStatus. Does not modify the release-level
+// status or other use cases.
+func SetRoadmapSingleUCStatus(root *yaml.Node, version, ucID, newStatus string) error {
+	doc := root
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) == 1 {
+		doc = doc.Content[0]
+	}
+	releases := MappingValue(doc, "releases")
+	if releases == nil || releases.Kind != yaml.SequenceNode {
+		return fmt.Errorf("releases key not found or not a sequence")
+	}
+	for _, relNode := range releases.Content {
+		versionNode := MappingValue(relNode, "version")
+		if versionNode == nil || versionNode.Value != version {
+			continue
+		}
+		ucSeq := MappingValue(relNode, "use_cases")
+		if ucSeq == nil || ucSeq.Kind != yaml.SequenceNode {
+			return fmt.Errorf("use_cases not found for release %s", version)
+		}
+		for _, ucNode := range ucSeq.Content {
+			idNode := MappingValue(ucNode, "id")
+			if idNode != nil && idNode.Value == ucID {
+				statusNode := MappingValue(ucNode, "status")
+				if statusNode != nil {
+					statusNode.Value = newStatus
+				}
+				return nil
+			}
+		}
+		return fmt.Errorf("UC %q not found in release %s", ucID, version)
+	}
+	return fmt.Errorf("version %q not found in releases node tree", version)
+}
+
 // ---------------------------------------------------------------------------
 // Config release list manipulation
 // ---------------------------------------------------------------------------

--- a/pkg/orchestrator/release.go
+++ b/pkg/orchestrator/release.go
@@ -50,6 +50,11 @@ func updateRoadmapUCStatuses(version, newStatus string) error {
 	return rel.UpdateRoadmapUCStatuses(version, newStatus)
 }
 
+// updateRoadmapSingleUCStatus delegates to the internal/release package.
+func updateRoadmapSingleUCStatus(version, ucID, newStatus string) error {
+	return rel.UpdateRoadmapSingleUCStatus(version, ucID, newStatus)
+}
+
 // setRoadmapUCStatuses delegates to the internal/release package.
 func setRoadmapUCStatuses(root *yaml.Node, version, newStatus string) error {
 	return rel.SetRoadmapUCStatuses(root, version, newStatus)


### PR DESCRIPTION
## Summary

Stitch was marking all use cases in a release as "implemented" when no open issues remained, even if only one task was completed. Now each UC is validated individually — tests must exist and pass before it's marked. The check runs after measure so remaining work can be proposed first.

## Changes

- Added `UpdateRoadmapSingleUCStatus` / `SetRoadmapSingleUCStatus` for per-UC roadmap updates
- Added `validateUCImplemented`: checks test file existence + runs `go test` on the UC's test directory
- Replaced `markCompletedReleaseUCs` / `markActiveReleaseUCsDone` with `validateAndMarkUCs`
- Reordered generator cycle: stitch → measure → validate UCs → check auto-advance
- Rewrote tests to verify per-UC validation (UC with passing tests → marked; UC without tests → unchanged)

## Stats

- go_loc_prod: 18030 (+116)
- go_loc_test: 30720 (+9)

## Test plan

- [ ] `mage analyze` passes
- [ ] All tests pass
- [ ] Documentation reviewed for consistency

Closes #1361