### PR TITLE
GH-1359: fix generation branch cleanup and stats branch selection

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -892,8 +892,8 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 	cleanupMsg := fmt.Sprintf("Reset %s to specs-only after v1 tag\n\nGenerated code preserved at version tags. Branch restored to documentation-only state.", baseBranch)
 	_ = gitCommit(cleanupMsg, ".") // best-effort; may be empty if nothing changed
 
-	logf("generator:stop: deleting branch")
-	_ = gitDeleteBranch(branch, ".") // best-effort; branch may already be deleted
+	logf("generator:stop: deleting branch %s", branch)
+	_ = gitForceDeleteBranch(branch, ".") // force-delete: safe -d fails after specs-only reset
 	return nil
 }
 

--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -19,10 +19,12 @@ type stitchCommentData = st.StitchCommentData
 
 // GeneratorStats prints a status report for the current generation run.
 func (o *Orchestrator) GeneratorStats() error {
+	currentBranch, _ := gitCurrentBranch(".")
 	return st.PrintGeneratorStats(st.GeneratorStatsDeps{
 		Log:                    logf,
 		ListGenerationBranches: o.listGenerationBranches,
 		GenerationBranch:       o.cfg.Generation.Branch,
+		CurrentBranch:          currentBranch,
 		DetectGitHubRepo: func() (string, error) {
 			return detectGitHubRepo(".", o.cfg)
 		},

--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -40,6 +40,7 @@ type GeneratorStatsDeps struct {
 	Log                    Logger
 	ListGenerationBranches func() []string
 	GenerationBranch       string // from config, "" means auto-detect
+	CurrentBranch          string // current git branch, used to prefer the active generation
 	DetectGitHubRepo       func() (string, error)
 	ListAllIssues          func(repo, generation string) ([]gh.CobblerIssue, error)
 	FetchIssueComments     func(repo string, number int) ([]string, error)
@@ -85,8 +86,16 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		return nil
 	}
 
-	// Prefer the configured branch; fall back to the first detected branch.
+	// Prefer: configured branch > current branch (if generation) > first detected.
 	genBranch := deps.GenerationBranch
+	if genBranch == "" && deps.CurrentBranch != "" {
+		for _, b := range branches {
+			if b == deps.CurrentBranch {
+				genBranch = b
+				break
+			}
+		}
+	}
 	if genBranch == "" {
 		genBranch = branches[0]
 	}


### PR DESCRIPTION
## Summary

generator:stop now properly deletes the generation branch using force-delete, and stats:generator prefers the current git branch over alphabetical sorting when selecting which generation to report on.

## Changes

- Changed `gitDeleteBranch` to `gitForceDeleteBranch` in `mergeGeneration` — safe `-d` fails silently after specs-only reset
- Added `CurrentBranch` field to `GeneratorStatsDeps`
- Stats branch selection: configured > current branch (if generation) > first detected

## Stats

- go_loc_prod: 18030
- go_loc_test: 30720

## Test plan

- [ ] `mage analyze` passes
- [ ] All tests pass
- [ ] Documentation reviewed for consistency

Closes #1359