### PR TITLE
GH-1367: separate measure and stitch issues

### DIFF
--- a/pkg/orchestrator/internal/github/issues.go
+++ b/pkg/orchestrator/internal/github/issues.go
@@ -57,7 +57,6 @@ type WorkTracker interface {
 	// Issue CRUD
 	CreateCobblerIssue(repo, generation string, issue ProposedIssue) (int, error)
 	CreateMeasuringPlaceholder(repo, generation string, iteration int) (int, error)
-	UpgradeMeasuringPlaceholder(repo string, number int, generation string, issue ProposedIssue) error
 	CloseCobblerIssue(repo string, number int, generation string) error
 	CloseMeasuringPlaceholder(repo string, number int)
 	CloseMeasuringPlaceholderWithComment(repo string, number int, comment string)
@@ -542,42 +541,6 @@ func (t *GitHubTracker) FinalizeMeasurePlaceholder(repo string, number int, gene
 
 	t.CloseMeasuringPlaceholder(repo, number)
 	t.Log("finalizeMeasurePlaceholder: finalized #%d with %d child issue(s)", number, len(childIssues))
-}
-
-// UpgradeMeasuringPlaceholder converts the transient measuring placeholder
-// into the task issue in-place. It edits the placeholder's title and body
-// to match the proposed issue, adds the cobbler-gen label so stitch can
-// pick it up, and links it as a sub-issue of the parent generation issue
-// if the generation name encodes one (GH-578).
-func (t *GitHubTracker) UpgradeMeasuringPlaceholder(repo string, number int, generation string, issue ProposedIssue) error {
-	body := FormatIssueFrontMatter(generation, issue.Index, issue.Dependency) + issue.Description
-	title := "[measure] " + issue.Title
-
-	// Edit title and body in one command.
-	if err := exec.Command(t.GhBin, "issue", "edit",
-		"--repo", repo,
-		fmt.Sprintf("%d", number),
-		"--title", title,
-		"--body", body,
-	).Run(); err != nil {
-		return fmt.Errorf("gh issue edit placeholder #%d: %w", number, err)
-	}
-
-	// Add cobbler-gen label so stitch can pick it up.
-	if err := t.AddIssueLabel(repo, number, GenLabel(generation)); err != nil {
-		return fmt.Errorf("adding gen label to #%d: %w", number, err)
-	}
-
-	t.Log("upgradeMeasuringPlaceholder: upgraded #%d %q gen=%s index=%d dep=%d",
-		number, title, generation, issue.Index, issue.Dependency)
-
-	// Link as sub-issue of the parent if the generation name encodes one.
-	if parentNumber := ExtractParentIssueNumber(generation); parentNumber > 0 {
-		if err := t.LinkSubIssue(repo, parentNumber, number); err != nil {
-			t.Log("upgradeMeasuringPlaceholder: linkSubIssue warning for #%d -> parent #%d: %v", number, parentNumber, err)
-		}
-	}
-	return nil
 }
 
 // CreateCobblerIssue creates a GitHub issue on repo for the given generation

--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -94,10 +94,6 @@ func finalizeMeasurePlaceholder(repo string, number int, generation, comment str
 	ghTrackerNoCfg().FinalizeMeasurePlaceholder(repo, number, generation, comment, childIssues)
 }
 
-func upgradeMeasuringPlaceholder(repo string, number int, generation string, issue proposedIssue) error {
-	return ghTrackerNoCfg().UpgradeMeasuringPlaceholder(repo, number, generation, issue)
-}
-
 func createCobblerIssue(repo, generation string, issue proposedIssue) (int, error) {
 	return ghTrackerNoCfg().CreateCobblerIssue(repo, generation, issue)
 }

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -184,7 +184,6 @@ func (o *Orchestrator) RunMeasure() error {
 		var createdIDs []string
 		var lastOutputFile string
 		var lastValidationErrors []string // errors from previous attempt, fed back into retry prompt
-		placeholderUpgraded := false     // set when importIssues upgraded the placeholder in-place
 
 		// Attempt loop: try Claude + import, retrying on validation failure.
 		for attempt := 0; attempt <= maxRetries; attempt++ {
@@ -300,20 +299,10 @@ func (o *Orchestrator) RunMeasure() error {
 
 		logf("iteration %d imported %d issue(s)", i+1, len(createdIDs))
 
-		// Track whether the placeholder was upgraded in-place (GH-578).
-		phStr := fmt.Sprintf("%d", placeholderNum)
-		for _, id := range createdIDs {
-			if id == phStr {
-				placeholderUpgraded = true
-				break
-			}
-		}
-
 		// Finalize the placeholder as a permanent [measure] issue (GH-1360).
-		// When upgraded in-place (single issue), the placeholder became the
-		// stitch task — no finalization needed.
+		// The placeholder is always separate from stitch tasks (GH-1367).
 		placeholderResolved = true
-		if placeholderNum > 0 && !placeholderUpgraded {
+		if placeholderNum > 0 {
 			// Parse created IDs as ints for sub-issue linking.
 			var childNums []int
 			for _, id := range createdIDs {
@@ -537,27 +526,17 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 	}
 	issues = filtered
 
-	// Create all issues on GitHub.
+	// Create all issues on GitHub as separate stitch tasks (GH-1367).
+	// The measure placeholder remains a distinct [measure] issue.
 	var ids []string
-	upgraded := false
-	if ph > 0 && len(issues) == 1 {
-		if err := upgradeMeasuringPlaceholder(repo, ph, generation, issues[0]); err != nil {
-			logf("importIssues: upgradeMeasuringPlaceholder #%d failed, falling back to createCobblerIssue: %v", ph, err)
-		} else {
-			ids = append(ids, fmt.Sprintf("%d", ph))
-			upgraded = true
+	for _, issue := range issues {
+		logf("importIssues: creating task %d: %s (dep=%d)", issue.Index, issue.Title, issue.Dependency)
+		ghNum, err := createCobblerIssue(repo, generation, issue)
+		if err != nil {
+			logf("importIssues: createCobblerIssue failed for %q: %v", issue.Title, err)
+			continue
 		}
-	}
-	if !upgraded {
-		for _, issue := range issues {
-			logf("importIssues: creating task %d: %s (dep=%d)", issue.Index, issue.Title, issue.Dependency)
-			ghNum, err := createCobblerIssue(repo, generation, issue)
-			if err != nil {
-				logf("importIssues: createCobblerIssue failed for %q: %v", issue.Title, err)
-				continue
-			}
-			ids = append(ids, fmt.Sprintf("%d", ghNum))
-		}
+		ids = append(ids, fmt.Sprintf("%d", ghNum))
 	}
 
 	if len(ids) > 0 {


### PR DESCRIPTION
## Summary

Measure no longer reuses the measuring placeholder as the stitch task issue. Stitch tasks are always created as separate issues, and the measuring placeholder is finalized as a distinct [measure] issue. This eliminates double-counting in stats.

## Changes

- Removed upgrade-in-place path from `importIssues` (always creates new stitch issues)
- Removed `placeholderUpgraded` tracking from measure loop
- Removed `UpgradeMeasuringPlaceholder` from `WorkTracker` interface, `GitHubTracker`, and wrapper
- Net -62 lines

## Test plan

- [ ] `mage analyze` passes
- [ ] All tests pass
- [ ] Documentation reviewed for consistency

Closes #1367