### PR TITLE
GH-1368: reset roadmap statuses at generator:start

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -694,6 +694,11 @@ func (o *Orchestrator) GeneratorStart() error {
 		if err := o.resetGoSources(genName); err != nil {
 			return fmt.Errorf("resetting Go sources: %w", err)
 		}
+		// Reset roadmap statuses so measure does not skip releases whose
+		// code was just deleted (GH-1368).
+		if err := o.resetImplementedReleases(); err != nil {
+			logf("generator:start: warning resetting releases: %v", err)
+		}
 	}
 
 	// Squash intermediate commits into one clean commit.


### PR DESCRIPTION
## Summary

generator:start now resets roadmap release/UC statuses to spec_complete after deleting Go sources, so measure proposes tasks for all releases instead of skipping ones marked implemented from a previous run.

## Changes

- Call `resetImplementedReleases()` after `resetGoSources()` in `GeneratorStart` (only when `preserve_sources` is false)

## Test plan

- [ ] `mage analyze` passes
- [ ] All tests pass
- [ ] Documentation reviewed for consistency

Closes #1368