### PR TITLE
GH-1366: unify stats data sources via history files

### DIFF
--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -31,9 +31,6 @@ func (o *Orchestrator) GeneratorStats() error {
 		ListAllIssues: func(repo, generation string) ([]gh.CobblerIssue, error) {
 			return listAllCobblerIssues(repo, generation)
 		},
-		FetchIssueComments: func(repo string, number int) ([]string, error) {
-			return fetchIssueComments(repo, number)
-		},
 		HistoryDir: o.historyDir(),
 	})
 }

--- a/pkg/orchestrator/generator_stats_test.go
+++ b/pkg/orchestrator/generator_stats_test.go
@@ -257,21 +257,13 @@ func TestExtractPRDRefs(t *testing.T) {
 	}
 }
 
-// --- listAllCobblerIssues / fetchIssueComments (delegation, kept in parent) ---
+// --- listAllCobblerIssues (delegation, kept in parent) ---
 
 func TestListAllCobblerIssues_FakeRepo_Error(t *testing.T) {
 	t.Parallel()
 	_, err := listAllCobblerIssues("fake/repo-that-does-not-exist", "gen-test")
 	if err == nil {
 		t.Error("listAllCobblerIssues with fake repo must return an error")
-	}
-}
-
-func TestFetchIssueComments_FakeRepo_Error(t *testing.T) {
-	t.Parallel()
-	_, err := fetchIssueComments("fake/repo-that-does-not-exist", 99999)
-	if err == nil {
-		t.Error("fetchIssueComments with fake repo must return an error")
 	}
 }
 

--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -18,7 +18,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// GeneratorIssueStats holds per-issue stats derived from labels and comments.
+// GeneratorIssueStats holds per-issue stats derived from history files.
 type GeneratorIssueStats struct {
 	gh.CobblerIssue
 	Status       string  // "done", "failed", "in-progress", "pending"
@@ -28,9 +28,8 @@ type GeneratorIssueStats struct {
 	LocDeltaProd int
 	LocDeltaTest int
 	NumReqs      int // number of requirements in the task description
-	PromptBytes  int // prompt size in bytes from "Stitch started" comment
-	InputTokens  int // total input tokens from stitch completion comments
-	OutputTokens int // total output tokens from stitch completion comments
+	InputTokens  int // total input tokens from history stats
+	OutputTokens int // total output tokens from history stats
 	PRDs         []string
 	Release      string // roadmap release version, e.g. "01.0"
 }
@@ -43,8 +42,7 @@ type GeneratorStatsDeps struct {
 	CurrentBranch          string // current git branch, used to prefer the active generation
 	DetectGitHubRepo       func() (string, error)
 	ListAllIssues          func(repo, generation string) ([]gh.CobblerIssue, error)
-	FetchIssueComments     func(repo string, number int) ([]string, error)
-	HistoryDir             string // path to .cobbler/history for local stats files
+	HistoryDir string // path to .cobbler/history for local stats files
 }
 
 // LoadHistoryStats reads all *-stats.yaml files from dir and returns the
@@ -191,7 +189,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	// Collect per-issue stats.
 	rows := make([]GeneratorIssueStats, 0, len(stitchIssues))
 	var totalStitchCost float64
-	var totalTurns, totalLocProd, totalLocTest, totalReqs, totalPromptBytes int
+	var totalTurns, totalLocProd, totalLocTest, totalReqs int
 	var totalInputTokens, totalOutputTokens int
 	var nDone, nFailed, nInProgress, nPending int
 	prdStatus := make(map[string]string) // prd name → highest-priority status
@@ -215,7 +213,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 			nPending++
 		}
 
-		// Prefer local history data over comment parsing.
+		// Use local history data as the single source of truth (GH-1366).
 		taskID := fmt.Sprintf("%d", iss.Number)
 		if agg, ok := stitchByTask[taskID]; ok {
 			s.CostUSD = agg.CostUSD
@@ -225,42 +223,11 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 			s.OutputTokens = agg.OutputTokens
 			s.LocDeltaProd = agg.LocDeltaProd
 			s.LocDeltaTest = agg.LocDeltaTest
-			// PromptBytes is not in history stats; parse comments for it.
-			comments, _ := deps.FetchIssueComments(repo, iss.Number)
-			for _, c := range comments {
-				p := ParseStitchComment(c)
-				if p.PromptBytes > 0 {
-					s.PromptBytes = p.PromptBytes
-				}
-			}
-		} else {
-			// Fallback: parse stitch progress comments.
-			comments, _ := deps.FetchIssueComments(repo, iss.Number)
-			for _, c := range comments {
-				p := ParseStitchComment(c)
-				if p.CostUSD > 0 {
-					s.CostUSD += p.CostUSD
-				}
-				if p.DurationS > 0 {
-					s.DurationS = p.DurationS
-				}
-				if p.NumTurns > 0 {
-					s.NumTurns += p.NumTurns
-				}
-				s.LocDeltaProd += p.LocDeltaProd
-				s.LocDeltaTest += p.LocDeltaTest
-				if p.PromptBytes > 0 {
-					s.PromptBytes = p.PromptBytes
-				}
-				s.InputTokens += p.InputTokens
-				s.OutputTokens += p.OutputTokens
-			}
 		}
 		totalStitchCost += s.CostUSD
 		totalTurns += s.NumTurns
 		totalLocProd += s.LocDeltaProd
 		totalLocTest += s.LocDeltaTest
-		totalPromptBytes += s.PromptBytes
 		totalInputTokens += s.InputTokens
 		totalOutputTokens += s.OutputTokens
 
@@ -325,9 +292,6 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	fmt.Printf(", %d turns\n", totalTurns)
 	fmt.Printf("LOC created: %+d prod, %+d test\n", totalLocProd, totalLocTest)
 	fmt.Printf("Requirements: %d total in tasks\n", totalReqs)
-	if totalPromptBytes > 0 {
-		fmt.Printf("Prompt total: %s\n", FormatBytes(totalPromptBytes))
-	}
 	combinedIn := totalInputTokens + totalMeasureIn
 	combinedOut := totalOutputTokens + totalMeasureOut
 	if combinedIn > 0 || combinedOut > 0 {
@@ -389,7 +353,6 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		Status   string
 		Rel      string
 		Reqs     string
-		Prompt   string
 		Cost     string
 		Dur      string
 		Turns    string
@@ -410,10 +373,6 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		}
 		if tr.Rel == "" {
 			tr.Rel = "-"
-		}
-		tr.Prompt = "-"
-		if r.PromptBytes > 0 {
-			tr.Prompt = FormatBytes(r.PromptBytes)
 		}
 		tr.Cost = "-"
 		if r.CostUSD > 0 {
@@ -476,7 +435,6 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 			Status:   "done",
 			Rel:      "-",
 			Reqs:     "-",
-			Prompt:   "-",
 			Prod:     "-",
 			Test:     "-",
 			Title:    "measure",
@@ -512,7 +470,6 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 			Status: "in-progress",
 			Rel:    "-",
 			Reqs:   "-",
-			Prompt: "-",
 			Prod:   "-",
 			Test:   "-",
 			Cost:   "-",
@@ -540,10 +497,10 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	})
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "#\tStatus\tRel\tReqs\tPrompt\tCost\tDuration\tTurns\tTokIn\tTokOut\tProd\tTest\tTitle")
+	fmt.Fprintln(w, "#\tStatus\tRel\tReqs\tCost\tDuration\tTurns\tTokIn\tTokOut\tProd\tTest\tTitle")
 	for _, tr := range tableRows {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			tr.ID, tr.Status, tr.Rel, tr.Reqs, tr.Prompt, tr.Cost, tr.Dur, tr.Turns, tr.TokIn, tr.TokOut, tr.Prod, tr.Test, tr.Title)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			tr.ID, tr.Status, tr.Rel, tr.Reqs, tr.Cost, tr.Dur, tr.Turns, tr.TokIn, tr.TokOut, tr.Prod, tr.Test, tr.Title)
 	}
 	if err := w.Flush(); err != nil {
 		return err

--- a/pkg/orchestrator/internal/stats/generator_stats_test.go
+++ b/pkg/orchestrator/internal/stats/generator_stats_test.go
@@ -716,7 +716,6 @@ num_turns: 15
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(dir)
 
-	commentCalledForCost := false
 	deps := GeneratorStatsDeps{
 		Log: func(format string, args ...any) {},
 		ListGenerationBranches: func() []string { return []string{"generation-main"} },
@@ -727,61 +726,12 @@ num_turns: 15
 				{Number: 100, Title: "implement feature", State: "closed", Labels: []string{"cobbler-task"}},
 			}, nil
 		},
-		FetchIssueComments: func(repo string, number int) ([]string, error) {
-			// Comments are still fetched for PromptBytes even when history
-			// exists. Return a "Stitch started" comment with prompt bytes
-			// but no cost — cost should come from history, not comments.
-			commentCalledForCost = false
-			return []string{"Stitch started. Branch: `generation-main`, prompt: 524288 bytes."}, nil
-		},
 		HistoryDir: histDir,
 	}
 
 	err := PrintGeneratorStats(deps)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
-	}
-	if commentCalledForCost {
-		t.Error("expected cost to come from history, not comments")
-	}
-}
-
-func TestPrintGeneratorStats_FallsBackToComments(t *testing.T) {
-	// Uses os.Chdir — do NOT use t.Parallel()
-	dir := t.TempDir()
-
-	// Empty history dir — no matching stats for any issue.
-	histDir := filepath.Join(dir, "history")
-	os.MkdirAll(histDir, 0o755)
-
-	orig, _ := os.Getwd()
-	t.Cleanup(func() { os.Chdir(orig) })
-	os.Chdir(dir)
-
-	commentCalled := false
-	deps := GeneratorStatsDeps{
-		Log: func(format string, args ...any) {},
-		ListGenerationBranches: func() []string { return []string{"generation-main"} },
-		GenerationBranch:       "generation-main",
-		DetectGitHubRepo:       func() (string, error) { return "owner/repo", nil },
-		ListAllIssues: func(repo, generation string) ([]gh.CobblerIssue, error) {
-			return []gh.CobblerIssue{
-				{Number: 200, Title: "other feature", State: "closed", Labels: []string{"cobbler-task"}},
-			}, nil
-		},
-		FetchIssueComments: func(repo string, number int) ([]string, error) {
-			commentCalled = true
-			return []string{"Stitch completed in 2m 0s. Cost: $0.30. Turns: 5."}, nil
-		},
-		HistoryDir: histDir,
-	}
-
-	err := PrintGeneratorStats(deps)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if !commentCalled {
-		t.Error("expected FetchIssueComments to be called as fallback when no history data matches")
 	}
 }
 
@@ -819,9 +769,6 @@ num_turns: 3
 			return []gh.CobblerIssue{
 				{Number: 300, Title: "test task", State: "open", Labels: []string{"cobbler-task"}},
 			}, nil
-		},
-		FetchIssueComments: func(repo string, number int) ([]string, error) {
-			return nil, nil
 		},
 		HistoryDir: histDir,
 	}


### PR DESCRIPTION
## Summary

Remove the comment-parsing fallback from stats:generator, making history files (.cobbler/history/*-stats.yaml) the single source of truth for both measure and stitch statistics. This eliminates GitHub API calls for issue comments during stats collection.

## Changes

- Removed `FetchIssueComments` from `GeneratorStatsDeps` struct
- Removed comment-parsing fallback path (lines 236-257 of generator_stats.go)
- Removed `PromptBytes` field from `GeneratorIssueStats` (no longer populated)
- Removed Prompt column from stats table output
- Removed `TestPrintGeneratorStats_FallsBackToComments` test
- Removed `TestFetchIssueComments_FakeRepo_Error` test
- Net: -107 lines

## Stats

- go_loc_prod: 17972
- go_loc_test: 30659

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)
- [x] Build passes (`go build ./pkg/orchestrator/`)

Closes #1366