### PR TITLE
GH-1373: file-based dedup for measure proposals

### DIFF
--- a/pkg/orchestrator/internal/github/issues.go
+++ b/pkg/orchestrator/internal/github/issues.go
@@ -16,6 +16,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // Logger is a function that formats and emits log messages.
@@ -248,6 +250,27 @@ func NormalizeIssueTitle(title string) string {
 		t = strings.TrimPrefix(t, prefix)
 	}
 	return strings.TrimSpace(t)
+}
+
+// ExtractDescriptionFiles parses the files section from a YAML task description
+// and returns the set of file paths. Returns nil if parsing fails or no files
+// are found. Works with both CobblerIssue.Description and ProposedIssue.Description.
+func ExtractDescriptionFiles(description string) []string {
+	var parsed struct {
+		Files []struct {
+			Path string `yaml:"path"`
+		} `yaml:"files"`
+	}
+	if err := yaml.Unmarshal([]byte(description), &parsed); err != nil {
+		return nil
+	}
+	var paths []string
+	for _, f := range parsed.Files {
+		if f.Path != "" {
+			paths = append(paths, f.Path)
+		}
+	}
+	return paths
 }
 
 // HasLabel returns true if the issue has the given label.

--- a/pkg/orchestrator/internal/github/issues_test.go
+++ b/pkg/orchestrator/internal/github/issues_test.go
@@ -828,6 +828,60 @@ func TestNormalizeIssueTitle(t *testing.T) {
 	}
 }
 
+func TestExtractDescriptionFiles(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		desc string
+		want []string
+	}{
+		{
+			"standard files section",
+			"deliverable_type: code\n\nfiles:\n  - path: pkg/types/example.go\n    action: create\n  - path: internal/example/impl.go\n    action: create\n",
+			[]string{"pkg/types/example.go", "internal/example/impl.go"},
+		},
+		{
+			"no files section",
+			"deliverable_type: code\n\nrequirements:\n  - id: R1\n    text: Do something\n",
+			nil,
+		},
+		{
+			"empty files list",
+			"files: []\n",
+			nil,
+		},
+		{
+			"invalid yaml",
+			"not: [valid: yaml: {{{",
+			nil,
+		},
+		{
+			"empty string",
+			"",
+			nil,
+		},
+		{
+			"files with empty path",
+			"files:\n  - path: \"\"\n    action: create\n  - path: pkg/foo.go\n    action: create\n",
+			[]string{"pkg/foo.go"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := ExtractDescriptionFiles(tc.desc)
+			if len(got) != len(tc.want) {
+				t.Fatalf("ExtractDescriptionFiles() = %v, want %v", got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("ExtractDescriptionFiles()[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
 // --- NewGitHubTracker ---
 
 func TestNewGitHubTracker(t *testing.T) {

--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -150,6 +150,10 @@ func normalizeIssueTitle(title string) string {
 	return gh.NormalizeIssueTitle(title)
 }
 
+func extractDescriptionFiles(description string) []string {
+	return gh.ExtractDescriptionFiles(description)
+}
+
 func closeCobblerIssue(repo string, number int, generation string) error {
 	return ghTrackerNoCfg().CloseCobblerIssue(repo, number, generation)
 }

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -499,8 +499,10 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 	}
 
 	// Deduplicate: fetch existing issues for this generation and skip any
-	// proposed issue whose normalized title matches an existing one (GH-1026, GH-1352).
+	// proposed issue whose normalized title or output files match an existing
+	// one (GH-1026, GH-1352, GH-1373).
 	existingTitles := make(map[string]int) // normalized title → issue number
+	existingFiles := make(map[string]int)  // file path → issue number
 	if existing, err := listAllCobblerIssues(repo, generation); err == nil {
 		hasOpen := false
 		for _, ex := range existing {
@@ -512,6 +514,9 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 		if hasOpen {
 			for _, ex := range existing {
 				existingTitles[normalizeIssueTitle(ex.Title)] = ex.Number
+				for _, fp := range extractDescriptionFiles(ex.Description) {
+					existingFiles[fp] = ex.Number
+				}
 			}
 		}
 	}
@@ -519,7 +524,12 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 	for _, issue := range issues {
 		norm := normalizeIssueTitle(issue.Title)
 		if dup, ok := existingTitles[norm]; ok {
-			logf("importIssues: skipping duplicate %q — already exists as #%d", issue.Title, dup)
+			logf("importIssues: skipping duplicate %q — title matches #%d", issue.Title, dup)
+			continue
+		}
+		// Check if any proposed output file overlaps with an existing issue (GH-1373).
+		if dup := fileOverlap(extractDescriptionFiles(issue.Description), existingFiles); dup > 0 {
+			logf("importIssues: skipping duplicate %q — output files overlap with #%d", issue.Title, dup)
 			continue
 		}
 		filtered = append(filtered, issue)
@@ -551,6 +561,17 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 	appendMeasureLog(o.cfg.Cobbler.Dir, issues)
 
 	return ids, nil, nil
+}
+
+// fileOverlap returns the issue number of the first existing issue whose files
+// overlap with the proposed file list. Returns 0 if no overlap is found.
+func fileOverlap(proposedFiles []string, existingFiles map[string]int) int {
+	for _, fp := range proposedFiles {
+		if dup, ok := existingFiles[fp]; ok {
+			return dup
+		}
+	}
+	return 0
 }
 
 // saveHistory persists measure artifacts (log, issues YAML) to the configured

--- a/pkg/orchestrator/measure_test.go
+++ b/pkg/orchestrator/measure_test.go
@@ -1185,6 +1185,43 @@ func TestBuildMeasurePrompt_GoldenExample(t *testing.T) {
 	}
 }
 
+// --- fileOverlap ---
+
+func TestFileOverlap_NoOverlap(t *testing.T) {
+	t.Parallel()
+	existing := map[string]int{"pkg/foo.go": 100, "pkg/bar.go": 101}
+	got := fileOverlap([]string{"pkg/baz.go"}, existing)
+	if got != 0 {
+		t.Errorf("fileOverlap() = %d, want 0", got)
+	}
+}
+
+func TestFileOverlap_HasOverlap(t *testing.T) {
+	t.Parallel()
+	existing := map[string]int{"pkg/foo.go": 100, "pkg/bar.go": 101}
+	got := fileOverlap([]string{"pkg/new.go", "pkg/foo.go"}, existing)
+	if got != 100 {
+		t.Errorf("fileOverlap() = %d, want 100", got)
+	}
+}
+
+func TestFileOverlap_EmptyProposed(t *testing.T) {
+	t.Parallel()
+	existing := map[string]int{"pkg/foo.go": 100}
+	got := fileOverlap(nil, existing)
+	if got != 0 {
+		t.Errorf("fileOverlap() = %d, want 0", got)
+	}
+}
+
+func TestFileOverlap_EmptyExisting(t *testing.T) {
+	t.Parallel()
+	got := fileOverlap([]string{"pkg/foo.go"}, map[string]int{})
+	if got != 0 {
+		t.Errorf("fileOverlap() = %d, want 0", got)
+	}
+}
+
 // --- importIssuesImpl YAML parsing ---
 
 func TestImportIssuesImpl_NonexistentFile(t *testing.T) {


### PR DESCRIPTION
## Summary

Add file-based deduplication to measure import so that proposals targeting the same output files are skipped even when Claude names them differently across invocations. This prevents duplicate stitch tasks like prd001 vs prd-testutils for the same work.

## Changes

- Added `ExtractDescriptionFiles` to `internal/github/issues.go` — parses `files:` section from YAML descriptions
- Added `extractDescriptionFiles` wrapper to `issues_gh.go`
- Added `fileOverlap` helper to `measure.go`
- Updated dedup block in `importIssuesImpl` to build file→issue map and check proposed files against it
- Added 10 tests (6 for ExtractDescriptionFiles, 4 for fileOverlap)

## Stats

- +141 lines across 5 files

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] New tests cover: standard files, no files, empty files, invalid YAML, empty path, overlap/no-overlap/empty cases

Closes #1373