### PR TITLE
GH-1375: consistent issue number formatting in stats

### DIFF
--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -428,7 +428,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	for i, m := range measureEntries {
 		mid := fmt.Sprintf("M%d", i+1)
 		if m.TaskID != "" {
-			mid = "#" + m.TaskID
+			mid = m.TaskID
 		}
 		tr := tableRow{
 			ID:       mid,
@@ -466,7 +466,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	// Add in-progress measure rows from active [measuring] GitHub issues (GH-1365).
 	for _, iss := range activeMeasureIssues {
 		tr := tableRow{
-			ID:     fmt.Sprintf("#%d", iss.Number),
+			ID:     strconv.Itoa(iss.Number),
 			Status: "in-progress",
 			Rel:    "-",
 			Reqs:   "-",


### PR DESCRIPTION
## Summary

Remove `#` prefix from measure row IDs in stats:generator so they match stitch rows. Both now use bare issue numbers.

## Changes

- Removed `#` prefix from measure history row IDs (line 431)
- Removed `#` prefix from in-progress measure row IDs (line 469)

## Test plan

- [x] All tests pass
- [x] Build passes

Closes #1375