### PR TITLE
GH-1385: commit requirements.yaml after stitch updates

### DIFF
--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -508,6 +508,10 @@ func (o *Orchestrator) closeStitchTask(task stitchTask, rec InvocationRecord) {
 	// Update requirement states before closing (GH-1378).
 	if err := generate.UpdateRequirementsFile(o.cfg.Cobbler.Dir, task.Description, task.GhNumber); err != nil {
 		logf("closeStitchTask: warning updating requirements: %v", err)
+	} else if gitHasChanges(".") {
+		// Commit requirement state immediately so it survives interruptions (GH-1385).
+		_ = gitStageAll(".")
+		_ = gitCommit(fmt.Sprintf("Update requirement states after #%d", task.GhNumber), ".")
 	}
 
 	if err := closeCobblerIssue(task.Repo, task.GhNumber, task.Generation); err != nil {


### PR DESCRIPTION
## Summary

Fixes requirement state loss on generator interruption by committing `.cobbler/requirements.yaml` immediately after stitch updates it, rather than waiting for the next UC validation commit.

## Changes

- Add `gitStageAll` + `gitCommit` after `UpdateRequirementsFile` in `closeStitchTask`
- Guarded by `gitHasChanges` to avoid empty commits

## Stats

- Lines of code (Go, production): 49763 (+3)

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] Documentation reviewed for consistency

Closes #1385