### PR TITLE
GH-1386: Measure duplicate prevention programmatic validation

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -200,7 +200,7 @@ func filterImplementedRelease(release string) string {
 	return generate.FilterImplementedRelease(release)
 }
 
-func validateMeasureOutput(issues []proposedIssue, maxReqs int, subItemCounts map[string]map[string]int) validationResult {
+func validateMeasureOutput(issues []proposedIssue, maxReqs int, subItemCounts map[string]map[string]int, reqStates map[string]map[string]generate.RequirementState) validationResult {
 	// Convert proposedIssue (from internal/github) to generate.ProposedIssue.
 	genIssues := make([]generate.ProposedIssue, len(issues))
 	for i, iss := range issues {
@@ -211,7 +211,7 @@ func validateMeasureOutput(issues []proposedIssue, maxReqs int, subItemCounts ma
 			Dependency:  iss.Dependency,
 		}
 	}
-	return generate.ValidateMeasureOutput(genIssues, maxReqs, subItemCounts)
+	return generate.ValidateMeasureOutput(genIssues, maxReqs, subItemCounts, reqStates)
 }
 
 func expandedRequirementCount(reqs []issueDescItem, subItemCounts map[string]map[string]int) int {
@@ -220,6 +220,10 @@ func expandedRequirementCount(reqs []issueDescItem, subItemCounts map[string]map
 
 func loadPRDSubItemCounts() map[string]map[string]int {
 	return generate.LoadPRDSubItemCounts()
+}
+
+func loadRequirementStates(cobblerDir string) map[string]map[string]generate.RequirementState {
+	return generate.LoadRequirementStates(cobblerDir)
 }
 
 func warnOversizedGroups(maxReqs int) {

--- a/pkg/orchestrator/internal/generate/measure.go
+++ b/pkg/orchestrator/internal/generate/measure.go
@@ -113,7 +113,9 @@ var PRDRefPattern = regexp.MustCompile(`(prd\d+[-\w]*)\s+R(\d+)(?:\.(\d+))?`)
 // PRD stems to group IDs to sub-item counts; when a task requirement
 // references a PRD group, the expanded sub-item count is used instead of 1.
 // Expanded-count violations are logged as warnings (best-effort), not errors.
-func ValidateMeasureOutput(issues []ProposedIssue, maxReqs int, subItemCounts map[string]map[string]int) ValidationResult {
+// reqStates, when non-nil, cross-references proposed R-items against
+// requirements.yaml and rejects proposals targeting completed R-items (GH-1386).
+func ValidateMeasureOutput(issues []ProposedIssue, maxReqs int, subItemCounts map[string]map[string]int, reqStates map[string]map[string]RequirementState) ValidationResult {
 	var result ValidationResult
 	for _, issue := range issues {
 		var desc IssueDescription
@@ -183,8 +185,74 @@ func ValidateMeasureOutput(issues []ProposedIssue, maxReqs int, subItemCounts ma
 				}
 			}
 		}
+
+		// Check for completed R-items: proposals must not target R-items
+		// already marked complete in requirements.yaml (GH-1386).
+		if len(reqStates) > 0 {
+			for _, req := range desc.Requirements {
+				matches := PRDRefPattern.FindAllStringSubmatch(req.Text, -1)
+				for _, m := range matches {
+					prdStem := m[1]
+					groupNum := m[2]
+					subItem := m[3]
+					prdReqs := findPRDReqStates(reqStates, prdStem)
+					if prdReqs == nil {
+						continue
+					}
+					if subItem != "" {
+						key := fmt.Sprintf("R%s.%s", groupNum, subItem)
+						if st, ok := prdReqs[key]; ok && st.Status == "complete" {
+							msg := fmt.Sprintf("[%d] %q: requirement %s %s is already complete (issue #%d)",
+								issue.Index, issue.Title, prdStem, key, st.Issue)
+							Log("validateMeasureOutput: %s", msg)
+							result.Errors = append(result.Errors, msg)
+						}
+					} else {
+						// Group reference — check if ALL sub-items are complete.
+						prefix := fmt.Sprintf("R%s.", groupNum)
+						allComplete := true
+						for k, st := range prdReqs {
+							if strings.HasPrefix(k, prefix) && st.Status != "complete" {
+								allComplete = false
+								break
+							}
+						}
+						if allComplete {
+							// Check there are actually sub-items.
+							hasItems := false
+							for k := range prdReqs {
+								if strings.HasPrefix(k, prefix) {
+									hasItems = true
+									break
+								}
+							}
+							if hasItems {
+								msg := fmt.Sprintf("[%d] %q: requirement group %s R%s is already fully complete",
+									issue.Index, issue.Title, prdStem, groupNum)
+								Log("validateMeasureOutput: %s", msg)
+								result.Errors = append(result.Errors, msg)
+							}
+						}
+					}
+				}
+			}
+		}
 	}
 	return result
+}
+
+// findPRDReqStates looks up requirement states for a PRD stem, trying exact
+// match and prefix match (e.g. "prd001" matches "prd001-core").
+func findPRDReqStates(states map[string]map[string]RequirementState, stem string) map[string]RequirementState {
+	if r, ok := states[stem]; ok {
+		return r
+	}
+	for key, r := range states {
+		if strings.HasPrefix(key, stem+"-") {
+			return r
+		}
+	}
+	return nil
 }
 
 // ExpandedRequirementCount computes the effective requirement count by

--- a/pkg/orchestrator/internal/generate/measure_test.go
+++ b/pkg/orchestrator/internal/generate/measure_test.go
@@ -6,6 +6,7 @@ package generate
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -164,7 +165,7 @@ files:
   - path: pkg/foo/bar.go`
 
 	issues := []ProposedIssue{{Index: 1, Title: "test", Description: desc}}
-	result := ValidateMeasureOutput(issues, 0, nil)
+	result := ValidateMeasureOutput(issues, 0, nil, nil)
 	if result.HasErrors() {
 		t.Errorf("expected no errors for valid code issue, got: %v", result.Errors)
 	}
@@ -195,7 +196,7 @@ design_decisions:
     text: dd3`
 
 	issues := []ProposedIssue{{Index: 1, Title: "test", Description: desc}}
-	result := ValidateMeasureOutput(issues, 0, nil)
+	result := ValidateMeasureOutput(issues, 0, nil, nil)
 	if !result.HasErrors() {
 		t.Error("expected error for code issue with 1 requirement")
 	}
@@ -236,7 +237,7 @@ files:
   - path: pkg/foo/foo.go`
 
 	issues := []ProposedIssue{{Index: 1, Title: "test", Description: desc}}
-	result := ValidateMeasureOutput(issues, 0, nil)
+	result := ValidateMeasureOutput(issues, 0, nil, nil)
 	if !result.HasErrors() {
 		t.Error("expected P7 violation error for foo/foo.go")
 	}
@@ -270,7 +271,7 @@ design_decisions:
 		"prd003": {"R2": 10},
 	}
 	issues := []ProposedIssue{{Index: 1, Title: "test", Description: desc}}
-	result := ValidateMeasureOutput(issues, 5, subItems)
+	result := ValidateMeasureOutput(issues, 5, subItems, nil)
 	if !result.HasErrors() {
 		t.Error("expected error for expanded count exceeding max")
 	}
@@ -278,7 +279,7 @@ design_decisions:
 
 func TestValidateMeasureOutput_UnparseableDescription(t *testing.T) {
 	issues := []ProposedIssue{{Index: 1, Title: "bad", Description: ":::not yaml"}}
-	result := ValidateMeasureOutput(issues, 0, nil)
+	result := ValidateMeasureOutput(issues, 0, nil, nil)
 	if result.HasErrors() {
 		t.Error("unparseable descriptions should produce warnings, not errors")
 	}
@@ -288,7 +289,7 @@ func TestValidateMeasureOutput_UnparseableDescription(t *testing.T) {
 }
 
 func TestValidateMeasureOutput_EmptyIssues(t *testing.T) {
-	result := ValidateMeasureOutput(nil, 0, nil)
+	result := ValidateMeasureOutput(nil, 0, nil, nil)
 	if result.HasErrors() {
 		t.Error("expected no errors for empty issue list")
 	}
@@ -312,9 +313,166 @@ acceptance_criteria:
     text: ac3`
 
 	issues := []ProposedIssue{{Index: 1, Title: "doc", Description: desc}}
-	result := ValidateMeasureOutput(issues, 0, nil)
+	result := ValidateMeasureOutput(issues, 0, nil, nil)
 	if result.HasErrors() {
 		t.Errorf("expected no errors for valid doc issue, got: %v", result.Errors)
+	}
+}
+
+func TestValidateMeasureOutput_CompletedRItemRejected(t *testing.T) {
+	desc := `deliverable_type: code
+requirements:
+  - id: R1
+    text: "Implement config per prd001 R1.2"
+  - id: R2
+    text: "Add validation per prd001 R2.1"
+  - id: R3
+    text: "Add logging per prd001 R3.1"
+  - id: R4
+    text: "Format output"
+  - id: R5
+    text: "Error handling"
+acceptance_criteria:
+  - id: AC1
+    text: ac1
+  - id: AC2
+    text: ac2
+  - id: AC3
+    text: ac3
+  - id: AC4
+    text: ac4
+  - id: AC5
+    text: ac5
+design_decisions:
+  - id: DD1
+    text: dd1
+  - id: DD2
+    text: dd2
+  - id: DD3
+    text: dd3
+files:
+  - path: pkg/foo/bar.go`
+
+	reqStates := map[string]map[string]RequirementState{
+		"prd001-core": {
+			"R1.1": {Status: "ready"},
+			"R1.2": {Status: "complete", Issue: 42},
+			"R2.1": {Status: "ready"},
+			"R3.1": {Status: "ready"},
+		},
+	}
+
+	issues := []ProposedIssue{{Index: 0, Title: "test", Description: desc}}
+	result := ValidateMeasureOutput(issues, 0, nil, reqStates)
+	if !result.HasErrors() {
+		t.Fatal("expected errors for proposal targeting completed R-item")
+	}
+	found := false
+	for _, e := range result.Errors {
+		if strings.Contains(e, "R1.2") && strings.Contains(e, "already complete") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error mentioning R1.2 as complete, got: %v", result.Errors)
+	}
+}
+
+func TestValidateMeasureOutput_CompletedGroupRejected(t *testing.T) {
+	desc := `deliverable_type: code
+requirements:
+  - id: R1
+    text: "Implement group per prd002 R1"
+  - id: R2
+    text: "Other work"
+  - id: R3
+    text: "More work"
+  - id: R4
+    text: "Even more"
+  - id: R5
+    text: "Last one"
+acceptance_criteria:
+  - id: AC1
+    text: ac1
+  - id: AC2
+    text: ac2
+  - id: AC3
+    text: ac3
+  - id: AC4
+    text: ac4
+  - id: AC5
+    text: ac5
+design_decisions:
+  - id: DD1
+    text: dd1
+  - id: DD2
+    text: dd2
+  - id: DD3
+    text: dd3
+files:
+  - path: pkg/foo/bar.go`
+
+	reqStates := map[string]map[string]RequirementState{
+		"prd002-lifecycle": {
+			"R1.1": {Status: "complete", Issue: 10},
+			"R1.2": {Status: "complete", Issue: 11},
+		},
+	}
+
+	issues := []ProposedIssue{{Index: 0, Title: "test", Description: desc}}
+	result := ValidateMeasureOutput(issues, 0, nil, reqStates)
+	if !result.HasErrors() {
+		t.Fatal("expected errors for proposal targeting fully complete group")
+	}
+	found := false
+	for _, e := range result.Errors {
+		if strings.Contains(e, "R1") && strings.Contains(e, "fully complete") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected error mentioning R1 group as fully complete, got: %v", result.Errors)
+	}
+}
+
+func TestValidateMeasureOutput_NilReqStatesNoCheck(t *testing.T) {
+	desc := `deliverable_type: code
+requirements:
+  - id: R1
+    text: "Implement per prd001 R1.2"
+  - id: R2
+    text: r2
+  - id: R3
+    text: r3
+  - id: R4
+    text: r4
+  - id: R5
+    text: r5
+acceptance_criteria:
+  - id: AC1
+    text: ac1
+  - id: AC2
+    text: ac2
+  - id: AC3
+    text: ac3
+  - id: AC4
+    text: ac4
+  - id: AC5
+    text: ac5
+design_decisions:
+  - id: DD1
+    text: dd1
+  - id: DD2
+    text: dd2
+  - id: DD3
+    text: dd3
+files:
+  - path: pkg/foo/bar.go`
+
+	issues := []ProposedIssue{{Index: 0, Title: "test", Description: desc}}
+	result := ValidateMeasureOutput(issues, 0, nil, nil)
+	if result.HasErrors() {
+		t.Errorf("expected no errors when reqStates is nil, got: %v", result.Errors)
 	}
 }
 

--- a/pkg/orchestrator/internal/generate/requirements.go
+++ b/pkg/orchestrator/internal/generate/requirements.go
@@ -29,6 +29,20 @@ type RequirementsFile struct {
 // the cobbler directory.
 const RequirementsFileName = "requirements.yaml"
 
+// LoadRequirementStates reads requirements.yaml and returns the state map.
+// Returns nil if the file does not exist or cannot be parsed.
+func LoadRequirementStates(cobblerDir string) map[string]map[string]RequirementState {
+	data, err := os.ReadFile(filepath.Join(cobblerDir, RequirementsFileName))
+	if err != nil {
+		return nil
+	}
+	var rf RequirementsFile
+	if err := yaml.Unmarshal(data, &rf); err != nil {
+		return nil
+	}
+	return rf.Requirements
+}
+
 // GenerateRequirementsFile scans all PRD YAML files in the given directory
 // for R-items and writes a requirements state file where every item starts
 // with status "ready". Returns the path written, or an error.

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -487,9 +487,10 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 		logf("importIssues: [%d] title=%q dep=%d", i, issue.Title, issue.Dependency)
 	}
 
-	// Validate proposed issues against P9/P7 rules.
+	// Validate proposed issues against P9/P7 rules and completed R-items (GH-1386).
 	subItemCounts := loadPRDSubItemCounts()
-	vr := validateMeasureOutput(issues, o.cfg.Cobbler.MaxRequirementsPerTask, subItemCounts)
+	reqStates := loadRequirementStates(o.cfg.Cobbler.Dir)
+	vr := validateMeasureOutput(issues, o.cfg.Cobbler.MaxRequirementsPerTask, subItemCounts, reqStates)
 	if len(vr.Warnings) > 0 {
 		logf("importIssues: %d warning(s)", len(vr.Warnings))
 	}

--- a/pkg/orchestrator/measure_test.go
+++ b/pkg/orchestrator/measure_test.go
@@ -51,7 +51,7 @@ design_decisions:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0, nil)
+	vr := validateMeasureOutput(issues, 0, nil, nil)
 	if vr.HasErrors() {
 		t.Errorf("expected no errors for valid code task, got: %v", vr.Errors)
 	}
@@ -89,7 +89,7 @@ design_decisions:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0, nil)
+	vr := validateMeasureOutput(issues, 0, nil, nil)
 	if !vr.HasErrors() {
 		t.Error("expected errors for code task with 2 requirements (P9 range 5-8)")
 	}
@@ -144,7 +144,7 @@ design_decisions:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0, nil)
+	vr := validateMeasureOutput(issues, 0, nil, nil)
 	if !vr.HasErrors() {
 		t.Error("expected errors for code task with 9 requirements (P9 range 5-8)")
 	}
@@ -173,7 +173,7 @@ acceptance_criteria:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0, nil)
+	vr := validateMeasureOutput(issues, 0, nil, nil)
 	if vr.HasErrors() {
 		t.Errorf("expected no errors for valid doc task, got: %v", vr.Errors)
 	}
@@ -206,7 +206,7 @@ acceptance_criteria:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0, nil)
+	vr := validateMeasureOutput(issues, 0, nil, nil)
 	if !vr.HasErrors() {
 		t.Error("expected errors for doc task with 5 requirements (P9 range 2-4)")
 	}
@@ -252,7 +252,7 @@ design_decisions:
 `,
 	}}
 
-	vr := validateMeasureOutput(issues, 0, nil)
+	vr := validateMeasureOutput(issues, 0, nil, nil)
 	if !vr.HasErrors() {
 		t.Error("expected errors for file named after package (P7 violation)")
 	}
@@ -310,7 +310,7 @@ design_decisions:
 
 	// runner.go in pkg/difftest/ is NOT a P7 violation because
 	// the file name does not match the parent directory name.
-	vr := validateMeasureOutput(issues, 0, nil)
+	vr := validateMeasureOutput(issues, 0, nil, nil)
 	p7Errors := 0
 	for _, e := range vr.Errors {
 		if contains(e, "P7 violation") {
@@ -330,7 +330,7 @@ func TestValidateMeasureOutput_UnparseableDescription(t *testing.T) {
 		Description: `{{{not valid yaml`,
 	}}
 
-	vr := validateMeasureOutput(issues, 0, nil)
+	vr := validateMeasureOutput(issues, 0, nil, nil)
 	if len(vr.Warnings) == 0 {
 		t.Error("expected warning for unparseable description")
 	}
@@ -388,7 +388,7 @@ acceptance_criteria:
 		},
 	}
 
-	vr := validateMeasureOutput(issues, 0, nil)
+	vr := validateMeasureOutput(issues, 0, nil, nil)
 	if !vr.HasErrors() {
 		t.Error("expected errors from invalid second issue")
 	}
@@ -428,7 +428,7 @@ func TestValidateMeasureOutput_MaxReqs_ZeroIsUnlimited(t *testing.T) {
 		Title:       "Huge task",
 		Description: "deliverable_type: code\nrequirements:\n" + reqs,
 	}}
-	vr := validateMeasureOutput(issues, 0, nil)
+	vr := validateMeasureOutput(issues, 0, nil, nil)
 	for _, e := range vr.Errors {
 		if contains(e, "max is") {
 			t.Errorf("maxReqs=0 should not produce max-requirements error, got: %s", e)
@@ -456,7 +456,7 @@ requirements:
     text: req
 `,
 	}}
-	vr := validateMeasureOutput(issues, 5, nil)
+	vr := validateMeasureOutput(issues, 5, nil, nil)
 	for _, e := range vr.Errors {
 		if contains(e, "max is") {
 			t.Errorf("5 requirements at maxReqs=5 should not error, got: %s", e)
@@ -486,7 +486,7 @@ requirements:
     text: req
 `,
 	}}
-	vr := validateMeasureOutput(issues, 5, nil)
+	vr := validateMeasureOutput(issues, 5, nil, nil)
 	found := false
 	for _, e := range vr.Errors {
 		if contains(e, "max is") {
@@ -525,7 +525,7 @@ requirements:
     text: req
 `,
 	}}
-	vr := validateMeasureOutput(issues, 5, nil)
+	vr := validateMeasureOutput(issues, 5, nil, nil)
 	found := false
 	for _, e := range vr.Errors {
 		if contains(e, "8") && contains(e, "5") && contains(e, "Task Title") {
@@ -655,7 +655,7 @@ design_decisions:
     text: d3
 `,
 	}}
-	vr := validateMeasureOutput(issues, 8, subItems)
+	vr := validateMeasureOutput(issues, 8, subItems, nil)
 	found := false
 	for _, e := range vr.Errors {
 		if contains(e, "expanded sub-item count") && contains(e, "max is") {
@@ -710,7 +710,7 @@ design_decisions:
 `,
 	}}
 	// expanded = 2+4 = 6, maxReqs = 8 → no expanded-count error.
-	vr := validateMeasureOutput(issues, 8, subItems)
+	vr := validateMeasureOutput(issues, 8, subItems, nil)
 	for _, e := range vr.Errors {
 		if contains(e, "expanded sub-item count") {
 			t.Errorf("should not error when expanded count under limit, got: %s", e)
@@ -759,7 +759,7 @@ design_decisions:
 `,
 	}}
 	// 5 listed, expanded = 2+4 = 6. maxReqs = 8. Under limit — no error.
-	vr := validateMeasureOutput(issues, 8, subItems)
+	vr := validateMeasureOutput(issues, 8, subItems, nil)
 	for _, e := range vr.Errors {
 		if contains(e, "expanded sub-item count") {
 			t.Errorf("should not error when expanded count under limit, got: %s", e)


### PR DESCRIPTION
## Summary

Adds programmatic validation to `ValidateMeasureOutput` that rejects measure proposals referencing already-completed R-items. Previously this was LLM-instruction-only (prompt constraint in measure.yaml); now the validation function enforces it with hard errors.

## Changes

- Extended `ValidateMeasureOutput` to accept requirement states and check proposed R-items against completed state
- Added `LoadRequirementStates` helper to load `.cobbler/requirements.yaml`
- Added `findPRDReqStates` for fuzzy PRD stem matching against state map
- Updated all call sites (production and test) for the new 4-arg signature
- Added 3 new tests covering completed R-item rejection, completed group rejection, and nil-states passthrough

## Stats

- Production LOC: 18504 (+45)
- Test LOC: 31508 (+60)
- Documentation: 20871 (+0)

## Test plan

- [x] `go test ./pkg/orchestrator/... -count=1` — all 12 packages pass
- [x] New tests verify completed R-item and R-group rejection
- [x] Existing tests unchanged in behavior (nil reqStates = no check)

Closes #1386