### PR TITLE
GH-1387: Fix greedy prefix matching in findPRDRequirements

### DIFF
--- a/pkg/orchestrator/internal/generate/requirements.go
+++ b/pkg/orchestrator/internal/generate/requirements.go
@@ -190,17 +190,24 @@ func extractPRDRefsFromDescription(description string) []prdRef {
 }
 
 // findPRDRequirements looks up the requirement map for a PRD stem, trying
-// both exact match and prefix match (e.g. "prd001" matches "prd001-core").
+// exact match first, then dash-delimited prefix match (e.g. "prd001" matches
+// "prd001-core" but not "prd0011-other"). When multiple candidates match,
+// the longest (most specific) key wins.
 func findPRDRequirements(reqs map[string]map[string]RequirementState, stem string) map[string]RequirementState {
 	if r, ok := reqs[stem]; ok {
 		return r
 	}
+	var bestKey string
+	var bestReqs map[string]RequirementState
 	for key, r := range reqs {
-		if strings.HasPrefix(key, stem+"-") || strings.HasPrefix(key, stem) {
-			return r
+		if strings.HasPrefix(key, stem+"-") {
+			if bestKey == "" || len(key) > len(bestKey) {
+				bestKey = key
+				bestReqs = r
+			}
 		}
 	}
-	return nil
+	return bestReqs
 }
 
 // UCRequirementsComplete checks whether all R-items cited by a use case's

--- a/pkg/orchestrator/internal/generate/requirements_test.go
+++ b/pkg/orchestrator/internal/generate/requirements_test.go
@@ -437,6 +437,57 @@ func TestExtractTouchpointCitations(t *testing.T) {
 	})
 }
 
+func TestFindPRDRequirements(t *testing.T) {
+	reqs := map[string]map[string]RequirementState{
+		"prd001-core":      {"R1.1": {Status: "ready"}},
+		"prd010-ext":       {"R2.1": {Status: "ready"}},
+		"prd053-logname":   {"R3.1": {Status: "ready"}},
+		"prd053-sort":      {"R3.2": {Status: "ready"}},
+	}
+
+	t.Run("exact match", func(t *testing.T) {
+		r := findPRDRequirements(reqs, "prd001-core")
+		if r == nil || r["R1.1"].Status != "ready" {
+			t.Errorf("expected exact match for prd001-core, got %v", r)
+		}
+	})
+
+	t.Run("dash-prefix match", func(t *testing.T) {
+		r := findPRDRequirements(reqs, "prd001")
+		if r == nil || r["R1.1"].Status != "ready" {
+			t.Errorf("expected prd001 to match prd001-core, got %v", r)
+		}
+	})
+
+	t.Run("greedy prefix rejected", func(t *testing.T) {
+		// "prd01" must NOT match "prd010-ext" — the numeric portions differ.
+		r := findPRDRequirements(reqs, "prd01")
+		if r != nil {
+			t.Errorf("prd01 should not match prd010-ext, got %v", r)
+		}
+	})
+
+	t.Run("no match returns nil", func(t *testing.T) {
+		r := findPRDRequirements(reqs, "prd999")
+		if r != nil {
+			t.Errorf("expected nil for nonexistent stem, got %v", r)
+		}
+	})
+
+	t.Run("ambiguous prefix picks longest key", func(t *testing.T) {
+		// Both "prd053-logname" and "prd053-sort" match "prd053".
+		// Longest key is "prd053-logname" (14 chars vs 10).
+		r := findPRDRequirements(reqs, "prd053")
+		if r == nil {
+			t.Fatal("expected a match for prd053")
+		}
+		// Should pick prd053-logname (longest key).
+		if _, ok := r["R3.1"]; !ok {
+			t.Errorf("expected prd053 to match prd053-logname (longest), got %v", r)
+		}
+	})
+}
+
 func readReqFile(t *testing.T, path string) RequirementsFile {
 	t.Helper()
 	data, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary

Fixes `findPRDRequirements` to use dash-delimited prefix matching only, preventing "prd01" from matching "prd010-ext". When multiple candidates match a stem, the longest (most specific) key wins.

## Changes

- Removed bare `strings.HasPrefix(key, stem)` fallback from `findPRDRequirements`
- Added longest-match-wins logic for ambiguous prefix matches
- Added 5 tests covering exact match, dash-prefix, greedy rejection, no match, and ambiguous prefix

## Stats

- Production LOC: 18511 (+7)
- Test LOC: 31559 (+51)
- Documentation: 20871 (+0)

## Test plan

- [x] All 12 packages pass
- [x] New tests verify greedy prefix is rejected
- [x] Existing tests unchanged

Closes #1387