### PR TITLE
GH-1389: Preserve requirement state across generator runs

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -735,7 +735,7 @@ func (o *Orchestrator) GeneratorStart() error {
 
 	// Generate requirements state file from PRD R-items (GH-1378).
 	prdDir := "docs/specs/product-requirements"
-	if _, err := generate.GenerateRequirementsFile(prdDir, o.cfg.Cobbler.Dir); err != nil {
+	if _, err := generate.GenerateRequirementsFile(prdDir, o.cfg.Cobbler.Dir, o.cfg.Generation.PreserveSources); err != nil {
 		logf("generator:start: warning generating requirements file: %v", err)
 	}
 

--- a/pkg/orchestrator/internal/generate/requirements.go
+++ b/pkg/orchestrator/internal/generate/requirements.go
@@ -44,12 +44,20 @@ func LoadRequirementStates(cobblerDir string) map[string]map[string]RequirementS
 }
 
 // GenerateRequirementsFile scans all PRD YAML files in the given directory
-// for R-items and writes a requirements state file where every item starts
-// with status "ready". Returns the path written, or an error.
-func GenerateRequirementsFile(prdDir, cobblerDir string) (string, error) {
+// for R-items and writes a requirements state file. When preserveExisting is
+// false, all items start with status "ready" (full regeneration). When true,
+// existing requirement states are preserved for items still present in PRDs,
+// and only new items default to "ready" (incremental generation).
+func GenerateRequirementsFile(prdDir, cobblerDir string, preserveExisting bool) (string, error) {
 	paths, err := filepath.Glob(filepath.Join(prdDir, "prd*.yaml"))
 	if err != nil {
 		return "", fmt.Errorf("globbing PRDs in %s: %w", prdDir, err)
+	}
+
+	// Load existing states when preserving.
+	var existing map[string]map[string]RequirementState
+	if preserveExisting {
+		existing = LoadRequirementStates(cobblerDir)
 	}
 
 	allReqs := make(map[string]map[string]RequirementState)
@@ -62,6 +70,14 @@ func GenerateRequirementsFile(prdDir, cobblerDir string) (string, error) {
 		}
 		group := make(map[string]RequirementState, len(items))
 		for _, id := range items {
+			if existing != nil {
+				if prev, ok := existing[slug]; ok {
+					if st, ok := prev[id]; ok {
+						group[id] = st
+						continue
+					}
+				}
+			}
 			group[id] = RequirementState{Status: "ready"}
 		}
 		allReqs[slug] = group
@@ -87,10 +103,24 @@ func GenerateRequirementsFile(prdDir, cobblerDir string) (string, error) {
 
 	// Count total R-items for logging.
 	total := 0
-	for _, g := range allReqs {
+	preserved := 0
+	for slug, g := range allReqs {
 		total += len(g)
+		if existing != nil {
+			if prev, ok := existing[slug]; ok {
+				for id := range g {
+					if _, ok := prev[id]; ok {
+						preserved++
+					}
+				}
+			}
+		}
 	}
-	Log("generateRequirementsFile: wrote %d R-items from %d PRDs to %s", total, len(allReqs), outPath)
+	if preserveExisting && preserved > 0 {
+		Log("generateRequirementsFile: wrote %d R-items (%d preserved) from %d PRDs to %s", total, preserved, len(allReqs), outPath)
+	} else {
+		Log("generateRequirementsFile: wrote %d R-items from %d PRDs to %s", total, len(allReqs), outPath)
+	}
 	return outPath, nil
 }
 

--- a/pkg/orchestrator/internal/generate/requirements_test.go
+++ b/pkg/orchestrator/internal/generate/requirements_test.go
@@ -31,7 +31,7 @@ func TestGenerateRequirementsFile(t *testing.T) {
 `
 		os.WriteFile(filepath.Join(prdDir, "prd001-core.yaml"), []byte(prd), 0o644)
 
-		path, err := GenerateRequirementsFile(prdDir, cobblerDir)
+		path, err := GenerateRequirementsFile(prdDir, cobblerDir, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -74,7 +74,7 @@ func TestGenerateRequirementsFile(t *testing.T) {
 		cobblerDir := filepath.Join(tmp, ".cobbler")
 		os.MkdirAll(prdDir, 0o755)
 
-		path, err := GenerateRequirementsFile(prdDir, cobblerDir)
+		path, err := GenerateRequirementsFile(prdDir, cobblerDir, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -107,7 +107,7 @@ func TestGenerateRequirementsFile(t *testing.T) {
 `
 		os.WriteFile(filepath.Join(prdDir, "prd002-empty.yaml"), []byte(prd), 0o644)
 
-		path, err := GenerateRequirementsFile(prdDir, cobblerDir)
+		path, err := GenerateRequirementsFile(prdDir, cobblerDir, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -150,7 +150,7 @@ func TestGenerateRequirementsFile(t *testing.T) {
 		os.WriteFile(filepath.Join(prdDir, "prd001-alpha.yaml"), []byte(prd1), 0o644)
 		os.WriteFile(filepath.Join(prdDir, "prd002-beta.yaml"), []byte(prd2), 0o644)
 
-		path, err := GenerateRequirementsFile(prdDir, cobblerDir)
+		path, err := GenerateRequirementsFile(prdDir, cobblerDir, false)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -174,6 +174,154 @@ func TestGenerateRequirementsFile(t *testing.T) {
 		if len(rf.Requirements["prd002-beta"]) != 2 {
 			t.Errorf("prd002-beta: expected 2 items, got %d", len(rf.Requirements["prd002-beta"]))
 		}
+	})
+}
+
+func TestGenerateRequirementsFile_PreserveExisting(t *testing.T) {
+	t.Run("preserves completed states from previous run", func(t *testing.T) {
+		tmp := t.TempDir()
+		prdDir := filepath.Join(tmp, "prds")
+		cobblerDir := filepath.Join(tmp, ".cobbler")
+		os.MkdirAll(prdDir, 0o755)
+		os.MkdirAll(cobblerDir, 0o755)
+
+		prd := `requirements:
+  R1:
+    title: "Config"
+    items:
+      - R1.1: "first item"
+      - R1.2: "second item"
+  R2:
+    title: "Other"
+    items:
+      - R2.1: "third item"
+`
+		os.WriteFile(filepath.Join(prdDir, "prd001-core.yaml"), []byte(prd), 0o644)
+
+		// Seed existing requirements with R1.1 complete.
+		existing := RequirementsFile{
+			Requirements: map[string]map[string]RequirementState{
+				"prd001-core": {
+					"R1.1": {Status: "complete", Issue: 42},
+					"R1.2": {Status: "ready"},
+					"R2.1": {Status: "ready"},
+				},
+			},
+		}
+		data, _ := yaml.Marshal(existing)
+		os.WriteFile(filepath.Join(cobblerDir, RequirementsFileName), data, 0o644)
+
+		path, err := GenerateRequirementsFile(prdDir, cobblerDir, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		result := readReqFile(t, path)
+		// R1.1 should retain its complete state.
+		assertReqState(t, result, "prd001-core", "R1.1", "complete", 42)
+		// R1.2 and R2.1 should remain ready.
+		assertReqState(t, result, "prd001-core", "R1.2", "ready", 0)
+		assertReqState(t, result, "prd001-core", "R2.1", "ready", 0)
+	})
+
+	t.Run("new R-items default to ready", func(t *testing.T) {
+		tmp := t.TempDir()
+		prdDir := filepath.Join(tmp, "prds")
+		cobblerDir := filepath.Join(tmp, ".cobbler")
+		os.MkdirAll(prdDir, 0o755)
+		os.MkdirAll(cobblerDir, 0o755)
+
+		prd := `requirements:
+  R1:
+    title: "Config"
+    items:
+      - R1.1: "existing"
+      - R1.2: "new item"
+`
+		os.WriteFile(filepath.Join(prdDir, "prd001-core.yaml"), []byte(prd), 0o644)
+
+		// Existing file only has R1.1.
+		existing := RequirementsFile{
+			Requirements: map[string]map[string]RequirementState{
+				"prd001-core": {
+					"R1.1": {Status: "complete", Issue: 10},
+				},
+			},
+		}
+		data, _ := yaml.Marshal(existing)
+		os.WriteFile(filepath.Join(cobblerDir, RequirementsFileName), data, 0o644)
+
+		path, err := GenerateRequirementsFile(prdDir, cobblerDir, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		result := readReqFile(t, path)
+		assertReqState(t, result, "prd001-core", "R1.1", "complete", 10)
+		assertReqState(t, result, "prd001-core", "R1.2", "ready", 0)
+	})
+
+	t.Run("removed R-items are dropped", func(t *testing.T) {
+		tmp := t.TempDir()
+		prdDir := filepath.Join(tmp, "prds")
+		cobblerDir := filepath.Join(tmp, ".cobbler")
+		os.MkdirAll(prdDir, 0o755)
+		os.MkdirAll(cobblerDir, 0o755)
+
+		// PRD now only has R1.1.
+		prd := `requirements:
+  R1:
+    title: "Config"
+    items:
+      - R1.1: "kept"
+`
+		os.WriteFile(filepath.Join(prdDir, "prd001-core.yaml"), []byte(prd), 0o644)
+
+		// Existing file has R1.1 and R1.2 (R1.2 was removed from PRD).
+		existing := RequirementsFile{
+			Requirements: map[string]map[string]RequirementState{
+				"prd001-core": {
+					"R1.1": {Status: "complete", Issue: 5},
+					"R1.2": {Status: "complete", Issue: 6},
+				},
+			},
+		}
+		data, _ := yaml.Marshal(existing)
+		os.WriteFile(filepath.Join(cobblerDir, RequirementsFileName), data, 0o644)
+
+		path, err := GenerateRequirementsFile(prdDir, cobblerDir, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		result := readReqFile(t, path)
+		assertReqState(t, result, "prd001-core", "R1.1", "complete", 5)
+		if _, ok := result.Requirements["prd001-core"]["R1.2"]; ok {
+			t.Error("R1.2 should have been dropped (removed from PRD)")
+		}
+	})
+
+	t.Run("no existing file behaves like fresh generation", func(t *testing.T) {
+		tmp := t.TempDir()
+		prdDir := filepath.Join(tmp, "prds")
+		cobblerDir := filepath.Join(tmp, ".cobbler")
+		os.MkdirAll(prdDir, 0o755)
+
+		prd := `requirements:
+  R1:
+    title: "Config"
+    items:
+      - R1.1: "item"
+`
+		os.WriteFile(filepath.Join(prdDir, "prd001-core.yaml"), []byte(prd), 0o644)
+
+		path, err := GenerateRequirementsFile(prdDir, cobblerDir, true)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		result := readReqFile(t, path)
+		assertReqState(t, result, "prd001-core", "R1.1", "ready", 0)
 	})
 }
 


### PR DESCRIPTION
## Summary

When `preserve_sources: true`, `GenerateRequirementsFile` now merges with existing requirement states instead of resetting all to "ready". Completed R-items retain their state, new items default to "ready", and removed items are dropped.

## Changes

- Added `preserveExisting` parameter to `GenerateRequirementsFile`
- When true, loads existing `requirements.yaml` and preserves completed states for items still in PRDs
- Updated call site in `generator.go` to pass `PreserveSources` config flag
- Added 4 new tests covering preserve, new items, dropped items, and missing file scenarios
- Updated 4 existing test calls for new 3-arg signature

## Stats

- Production LOC: 18541 (+37)
- Test LOC: 31707 (+148)
- Documentation: 20871 (+0)

## Test plan

- [x] All 12 packages pass
- [x] New tests verify preserve/merge behavior
- [x] Existing tests verify reset behavior unchanged

Closes #1389