### PR TITLE
GH-1434: stitch-time dedup for completed R-items

### DIFF
--- a/pkg/orchestrator/internal/generate/requirements.go
+++ b/pkg/orchestrator/internal/generate/requirements.go
@@ -203,6 +203,47 @@ func isRequirementComplete(status string) bool {
 	return status == "complete" || status == "complete_with_failures"
 }
 
+// AllRefsAlreadyComplete checks whether every PRD requirement reference in
+// a task description is already marked complete in the given requirement
+// states. Returns true only when at least one reference is found and all
+// are complete. Used by stitch to skip tasks whose R-items were completed
+// by an earlier task in the same measure batch (GH-1434).
+func AllRefsAlreadyComplete(description string, reqStates map[string]map[string]RequirementState) bool {
+	refs := extractPRDRefsFromDescription(description)
+	if len(refs) == 0 || len(reqStates) == 0 {
+		return false
+	}
+	for _, ref := range refs {
+		prdReqs := findPRDRequirements(reqStates, ref.PRDStem)
+		if prdReqs == nil {
+			return false // unknown PRD — cannot verify
+		}
+		if ref.SubItem != "" {
+			key := fmt.Sprintf("R%s.%s", ref.Group, ref.SubItem)
+			st, ok := prdReqs[key]
+			if !ok || !isRequirementComplete(st.Status) {
+				return false
+			}
+		} else {
+			// Group reference — all sub-items must be complete.
+			prefix := fmt.Sprintf("R%s.", ref.Group)
+			found := false
+			for k, st := range prdReqs {
+				if strings.HasPrefix(k, prefix) {
+					found = true
+					if !isRequirementComplete(st.Status) {
+						return false
+					}
+				}
+			}
+			if !found {
+				return false // group has no sub-items
+			}
+		}
+	}
+	return true
+}
+
 // prdRef holds a parsed PRD requirement reference.
 type prdRef struct {
 	PRDStem string // e.g. "prd001" or "prd001-orchestrator-core"

--- a/pkg/orchestrator/internal/generate/requirements_test.go
+++ b/pkg/orchestrator/internal/generate/requirements_test.go
@@ -1105,6 +1105,96 @@ func countStates(items map[string]RequirementState) (ready, complete int) {
 	return
 }
 
+func TestAllRefsAlreadyComplete(t *testing.T) {
+	// Build requirement states: prd003-config has R1.1, R1.2 complete and R2.1 ready.
+	states := map[string]map[string]RequirementState{
+		"prd003-config": {
+			"R1.1": {Status: "complete", Issue: 100},
+			"R1.2": {Status: "complete", Issue: 100},
+			"R2.1": {Status: "ready"},
+			"R2.2": {Status: "ready"},
+		},
+		"prd001-core": {
+			"R1.1": {Status: "complete", Issue: 101},
+			"R1.2": {Status: "complete_with_failures", Issue: 102},
+		},
+	}
+
+	makeDesc := func(reqText string) string {
+		return "requirements:\n  - text: \"" + reqText + "\"\n    source: test\n"
+	}
+
+	t.Run("all refs complete returns true", func(t *testing.T) {
+		desc := makeDesc("prd003-config R1.1")
+		if !AllRefsAlreadyComplete(desc, states) {
+			t.Error("expected true: R1.1 is complete")
+		}
+	})
+
+	t.Run("partial complete returns false", func(t *testing.T) {
+		desc := makeDesc("prd003-config R2.1")
+		if AllRefsAlreadyComplete(desc, states) {
+			t.Error("expected false: R2.1 is ready")
+		}
+	})
+
+	t.Run("no refs returns false", func(t *testing.T) {
+		desc := "requirements:\n  - text: \"no prd refs here\"\n    source: test\n"
+		if AllRefsAlreadyComplete(desc, states) {
+			t.Error("expected false: no PRD refs")
+		}
+	})
+
+	t.Run("nil states returns false", func(t *testing.T) {
+		desc := makeDesc("prd003-config R1.1")
+		if AllRefsAlreadyComplete(desc, nil) {
+			t.Error("expected false: nil states")
+		}
+	})
+
+	t.Run("group reference all complete", func(t *testing.T) {
+		desc := makeDesc("prd001-core R1")
+		if !AllRefsAlreadyComplete(desc, states) {
+			t.Error("expected true: all R1.x in prd001-core are complete")
+		}
+	})
+
+	t.Run("group reference partial complete", func(t *testing.T) {
+		desc := makeDesc("prd003-config R2")
+		if AllRefsAlreadyComplete(desc, states) {
+			t.Error("expected false: R2 group has ready items")
+		}
+	})
+
+	t.Run("complete_with_failures counts as complete", func(t *testing.T) {
+		desc := makeDesc("prd001-core R1.2")
+		if !AllRefsAlreadyComplete(desc, states) {
+			t.Error("expected true: complete_with_failures is still complete")
+		}
+	})
+
+	t.Run("unknown PRD returns false", func(t *testing.T) {
+		desc := makeDesc("prd999-unknown R1.1")
+		if AllRefsAlreadyComplete(desc, states) {
+			t.Error("expected false: PRD not in states")
+		}
+	})
+
+	t.Run("multiple refs all complete", func(t *testing.T) {
+		desc := "requirements:\n  - text: \"prd003-config R1.1\"\n    source: test\n  - text: \"prd001-core R1.2\"\n    source: test\n"
+		if !AllRefsAlreadyComplete(desc, states) {
+			t.Error("expected true: both refs are complete")
+		}
+	})
+
+	t.Run("multiple refs one incomplete", func(t *testing.T) {
+		desc := "requirements:\n  - text: \"prd003-config R1.1\"\n    source: test\n  - text: \"prd003-config R2.1\"\n    source: test\n"
+		if AllRefsAlreadyComplete(desc, states) {
+			t.Error("expected false: R2.1 is ready")
+		}
+	})
+}
+
 func readReqFile(t *testing.T, path string) RequirementsFile {
 	t.Helper()
 	data, err := os.ReadFile(path)

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -183,6 +183,19 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 
 	logf("doOneTask: task #%d claimed via pickReadyIssue label", task.GhNumber)
 
+	// Pre-execution dedup: skip tasks whose R-items were already completed
+	// by an earlier task in the same measure batch (GH-1434).
+	reqStates := generate.LoadRequirementStates(o.cfg.Cobbler.Dir)
+	if generate.AllRefsAlreadyComplete(task.Description, reqStates) {
+		logf("doOneTask: all R-items for #%d already complete, closing as duplicate", task.GhNumber)
+		commentCobblerIssue(task.Repo, task.GhNumber,
+			"Stitch skipped: all targeted R-items are already complete (duplicate from same measure batch).")
+		if err := closeCobblerIssue(task.Repo, task.GhNumber, task.Generation); err != nil {
+			logf("doOneTask: warning closing duplicate #%d: %v", task.GhNumber, err)
+		}
+		return nil
+	}
+
 	// Create worktree.
 	logf("doOneTask: creating worktree for %s", task.ID)
 	wtStart := time.Now()


### PR DESCRIPTION
## Summary

Adds a pre-execution dedup check in stitch that skips tasks whose PRD R-items were already completed by an earlier task in the same measure batch. This closes the gap where measure-time validation cannot catch duplicates within the same batch.

## Changes

- Added `AllRefsAlreadyComplete` function to `pkg/orchestrator/internal/generate/requirements.go`
- Added pre-execution dedup check in `pkg/orchestrator/stitch.go` `doOneTask` method
- Added 10 sub-tests in `TestAllRefsAlreadyComplete` covering all edge cases

## Stats

- Lines of code (Go, production): 18666 (+54)
- Lines of code (Go, tests): 32526 (+90)
- Words (documentation): 20871 (+0)

## Test plan

- [x] `mage analyze` passes
- [x] All generate package tests pass
- [x] All orchestrator package tests pass

Closes #1434