### PR TITLE
GH-1434: Fix PRDRefPattern to handle intervening words

### DIFF
--- a/pkg/orchestrator/internal/generate/measure.go
+++ b/pkg/orchestrator/internal/generate/measure.go
@@ -96,11 +96,13 @@ func MeasureReleasesConstraint(releases []string, release string) string {
 // ---------------------------------------------------------------------------
 
 // PRDRefPattern matches PRD requirement references in task requirement text.
-// Examples: "prd003 R2", "prd004-ts R1.3", "prd001-orchestrator-core R5".
+// Examples: "prd003 R2", "prd004-ts R1.3", "prd002-sys requirement R2.5".
+// Allows up to 2 intervening words between the PRD stem and R-number to handle
+// Claude inserting words like "requirement" (e.g., "prd002-sys requirement R2.5").
 // Group 1 = PRD stem (e.g., "prd003" or "prd004-ts").
 // Group 2 = requirement group number (e.g., "2" from "R2").
 // Group 3 = optional sub-item number (e.g., "3" from "R1.3"); empty for groups.
-var PRDRefPattern = regexp.MustCompile(`(prd\d+[-\w]*)\s+R(\d+)(?:\.(\d+))?`)
+var PRDRefPattern = regexp.MustCompile(`(prd\d+[-\w]*)\s+(?:\w+\s+){0,2}R(\d+)(?:\.(\d+))?`)
 
 // ---------------------------------------------------------------------------
 // Validation

--- a/pkg/orchestrator/internal/generate/measure_test.go
+++ b/pkg/orchestrator/internal/generate/measure_test.go
@@ -594,6 +594,27 @@ func TestPRDRefPattern_MatchesSubItem(t *testing.T) {
 	}
 }
 
+func TestPRDRefPattern_MatchesWithInterveningWord(t *testing.T) {
+	// Claude sometimes writes "prd002-sys requirement R2.5" instead of "prd002-sys R2.5".
+	matches := PRDRefPattern.FindStringSubmatch("Implement prd002-sys requirement R2.5 as specified")
+	if matches == nil {
+		t.Fatal("expected match")
+	}
+	if matches[1] != "prd002-sys" || matches[2] != "2" || matches[3] != "5" {
+		t.Errorf("unexpected match: stem=%q group=%q sub=%q", matches[1], matches[2], matches[3])
+	}
+}
+
+func TestPRDRefPattern_MatchesWithTwoInterveningWords(t *testing.T) {
+	matches := PRDRefPattern.FindStringSubmatch("prd003-format requirement group R1")
+	if matches == nil {
+		t.Fatal("expected match")
+	}
+	if matches[1] != "prd003-format" || matches[2] != "1" || matches[3] != "" {
+		t.Errorf("unexpected match: stem=%q group=%q sub=%q", matches[1], matches[2], matches[3])
+	}
+}
+
 func TestPRDRefPattern_NoMatch(t *testing.T) {
 	if PRDRefPattern.FindStringSubmatch("no prd reference here") != nil {
 		t.Error("expected no match")

--- a/pkg/orchestrator/internal/generate/requirements_test.go
+++ b/pkg/orchestrator/internal/generate/requirements_test.go
@@ -1195,6 +1195,100 @@ func TestAllRefsAlreadyComplete(t *testing.T) {
 	})
 }
 
+func TestUpdateRequirementsFile_InterveningWord(t *testing.T) {
+	// Reproduces the bug from go-unix-utils run 27 (GH-1434): Claude writes
+	// "prd002-sys requirement R2.5" instead of "prd002-sys R2.5". The regex
+	// must handle intervening words between the PRD stem and R-number.
+	dir := t.TempDir()
+	reqPath := filepath.Join(dir, RequirementsFileName)
+	rf := RequirementsFile{
+		Requirements: map[string]map[string]RequirementState{
+			"prd002-sys": {
+				"R2.5": {Status: "ready"},
+				"R2.6": {Status: "ready"},
+			},
+		},
+	}
+	data, err := yaml.Marshal(rf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(reqPath, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	description := `deliverable_type: code
+requirements:
+  - id: R1
+    text: "Implement prd002-sys requirement R2.5 as specified in the PRD"
+  - id: R2
+    text: "Implement prd002-sys requirement R2.6 as specified in the PRD"`
+
+	if err := UpdateRequirementsFile(dir, description, 660, true); err != nil {
+		t.Fatalf("UpdateRequirementsFile: %v", err)
+	}
+
+	updated := readReqFile(t, reqPath)
+	assertReqState(t, updated, "prd002-sys", "R2.5", "complete", 660)
+	assertReqState(t, updated, "prd002-sys", "R2.6", "complete", 660)
+}
+
+func TestCrossBatchDuplicatePrevention_InterveningWord(t *testing.T) {
+	// Verifies that ValidateMeasureOutput rejects proposals using the
+	// "prd002-sys requirement R2.5" format when R2.5 is already complete.
+	reqStates := map[string]map[string]RequirementState{
+		"prd002-sys": {
+			"R2.5": {Status: "complete", Issue: 660},
+			"R2.6": {Status: "complete", Issue: 660},
+		},
+	}
+
+	desc := `deliverable_type: code
+requirements:
+  - id: R1
+    text: "Implement prd002-sys requirement R2.5 exactly as specified in the PRD"
+  - id: R2
+    text: "Implement prd002-sys requirement R2.6 exactly as specified in the PRD"
+  - id: R3
+    text: "More work"
+  - id: R4
+    text: "Even more"
+  - id: R5
+    text: "Last one"
+acceptance_criteria:
+  - id: AC1
+    text: ac1
+  - id: AC2
+    text: ac2
+  - id: AC3
+    text: ac3
+  - id: AC4
+    text: ac4
+  - id: AC5
+    text: ac5
+design_decisions:
+  - id: DD1
+    text: dd1
+  - id: DD2
+    text: dd2
+  - id: DD3
+    text: dd3
+files:
+  - path: pkg/sys/stat.go`
+
+	issues := []ProposedIssue{{Index: 0, Title: "test", Description: desc}}
+	result := ValidateMeasureOutput(issues, 0, nil, reqStates)
+	found := 0
+	for _, e := range result.Errors {
+		if strings.Contains(e, "already complete") {
+			found++
+		}
+	}
+	if found != 2 {
+		t.Errorf("expected 2 'already complete' errors for R2.5 and R2.6, got %d; errors: %v", found, result.Errors)
+	}
+}
+
 func readReqFile(t *testing.T, path string) RequirementsFile {
 	t.Helper()
 	data, err := os.ReadFile(path)


### PR DESCRIPTION
## Summary

Fix the `PRDRefPattern` regex that broke when Claude inserted the word "requirement" between the PRD stem and R-number (e.g., `prd002-sys requirement R2.5`). This caused both `UpdateRequirementsFile` and `ValidateMeasureOutput` to silently fail, allowing duplicate task proposals in go-unix-utils run 27.

## Changes

- Updated `PRDRefPattern` regex to allow up to 2 intervening words via `(?:\w+\s+){0,2}`
- Added 2 regex pattern tests for 1-word and 2-word intervening patterns
- Added `TestUpdateRequirementsFile_InterveningWord` reproducing the exact bug
- Added `TestCrossBatchDuplicatePrevention_InterveningWord` verifying duplicate rejection

## Test plan

- [x] All existing tests pass (no regressions)
- [x] New tests reproduce and verify the fix for the exact run-27 scenario
- [x] `go test ./pkg/orchestrator/internal/generate/` passes

Closes #1434