### PR TITLE
GH-1437: fix stats:generator requirements count to use per-R-item state

### DIFF
--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -32,6 +32,7 @@ func (o *Orchestrator) GeneratorStats() error {
 			return listAllCobblerIssues(repo, generation)
 		},
 		HistoryDir: o.historyDir(),
+		CobblerDir: o.cfg.Cobbler.Dir,
 	})
 }
 

--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -14,6 +14,7 @@ import (
 	"text/tabwriter"
 
 	cl "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/generate"
 	gh "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/github"
 	"gopkg.in/yaml.v3"
 )
@@ -43,6 +44,7 @@ type GeneratorStatsDeps struct {
 	DetectGitHubRepo       func() (string, error)
 	ListAllIssues          func(repo, generation string) ([]gh.CobblerIssue, error)
 	HistoryDir string // path to .cobbler/history for local stats files
+	CobblerDir string // path to .cobbler directory for requirements.yaml
 }
 
 // LoadHistoryStats reads all *-stats.yaml files from dir and returns the
@@ -532,13 +534,19 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		}
 	}
 
-	// Requirements progress.
-	total, byPRD := CountTotalPRDRequirements()
+	// Requirements progress: count actual non-ready R-items from
+	// requirements.yaml rather than all R-items in any touched PRD (GH-1437).
+	total, _ := CountTotalPRDRequirements()
 	if total > 0 {
 		addressed := 0
-		for prd, status := range prdStatus {
-			if status == "done" || status == "in-progress" {
-				addressed += byPRD[prd]
+		if deps.CobblerDir != "" {
+			reqStates := generate.LoadRequirementStates(deps.CobblerDir)
+			for _, prdReqs := range reqStates {
+				for _, st := range prdReqs {
+					if st.Status != "ready" {
+						addressed++
+					}
+				}
 			}
 		}
 		pct := 0

--- a/pkg/orchestrator/internal/stats/generator_stats_test.go
+++ b/pkg/orchestrator/internal/stats/generator_stats_test.go
@@ -4,10 +4,13 @@
 package stats
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/generate"
 	gh "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/github"
 )
 
@@ -777,5 +780,102 @@ num_turns: 3
 	err := PrintGeneratorStats(deps)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestRequirementsCountUsesPerItemState verifies that the "Requirements: X/Y"
+// line counts actual non-ready R-items from requirements.yaml, not all R-items
+// in any touched PRD (GH-1437).
+func TestRequirementsCountUsesPerItemState(t *testing.T) {
+	// Uses os.Chdir — do NOT use t.Parallel()
+	dir := t.TempDir()
+
+	// Create a PRD with 6 R-items across 2 groups.
+	prdDir := filepath.Join(dir, "docs", "specs", "product-requirements")
+	os.MkdirAll(prdDir, 0o755)
+	prdYAML := `id: prd001-testutils
+requirements:
+  R1:
+    title: "Group 1"
+    items:
+      - R1.1: "first"
+      - R1.2: "second"
+      - R1.3: "third"
+  R2:
+    title: "Group 2"
+    items:
+      - R2.1: "fourth"
+      - R2.2: "fifth"
+      - R2.3: "sixth"
+`
+	os.WriteFile(filepath.Join(prdDir, "prd001-testutils.yaml"), []byte(prdYAML), 0o644)
+
+	// Create requirements.yaml with only 2 of 6 R-items completed.
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+	reqYAML := `requirements:
+  prd001-testutils:
+    R1.1:
+      status: complete
+      issue: 100
+    R1.2:
+      status: complete
+      issue: 100
+    R1.3:
+      status: ready
+    R2.1:
+      status: ready
+    R2.2:
+      status: ready
+    R2.3:
+      status: ready
+`
+	os.WriteFile(filepath.Join(cobblerDir, generate.RequirementsFileName), []byte(reqYAML), 0o644)
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	// Capture stdout.
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	deps := GeneratorStatsDeps{
+		Log: func(format string, args ...any) {},
+		ListGenerationBranches: func() []string { return []string{"generation-main"} },
+		GenerationBranch:       "generation-main",
+		DetectGitHubRepo:       func() (string, error) { return "owner/repo", nil },
+		ListAllIssues: func(repo, generation string) ([]gh.CobblerIssue, error) {
+			return []gh.CobblerIssue{
+				{
+					Number:      100,
+					Title:       "implement R1.1-R1.2 (prd001-testutils)",
+					State:       "closed",
+					Labels:      []string{"cobbler-task"},
+					Description: "requirements:\n  - text: \"prd001-testutils R1.1\"\n    source: test\n",
+				},
+			}, nil
+		},
+		HistoryDir: filepath.Join(cobblerDir, "history"),
+		CobblerDir: cobblerDir,
+	}
+
+	err := PrintGeneratorStats(deps)
+	w.Close()
+	captured, _ := io.ReadAll(r)
+	os.Stdout = oldStdout
+	output := string(captured)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should report 2/6, not 6/6.
+	if !strings.Contains(output, "Requirements: 2/6") {
+		t.Errorf("expected 'Requirements: 2/6' in output, got:\n%s", output)
+	}
+	if strings.Contains(output, "Requirements: 6/6") {
+		t.Errorf("bug not fixed: output still shows 6/6 (all R-items in touched PRD):\n%s", output)
 	}
 }


### PR DESCRIPTION
## Summary

The "Requirements: X/Y addressed" line in `mage stats:generator` was counting all R-items in any touched PRD, inflating the count. Now reads actual per-R-item completion state from `requirements.yaml`.

## Changes

- `generator_stats.go`: use `generate.LoadRequirementStates` to count non-ready R-items instead of summing `byPRD[prd]` for touched PRDs
- Added `CobblerDir` to `GeneratorStatsDeps` and wired from orchestrator caller
- Added `TestRequirementsCountUsesPerItemState` verifying 2/6 count with fixture data

## Stats

- Lines of code (Go, production): 18677 (+11)
- Lines of code (Go, tests): 32741 (+100)

## Test plan

- [x] `mage analyze` passes
- [x] All stats package tests pass
- [x] All orchestrator tests pass

Closes #1437