### PR TITLE
GH-1438: fix placeholder failure task_id 0 and include gh stderr

### DIFF
--- a/pkg/orchestrator/internal/github/issues.go
+++ b/pkg/orchestrator/internal/github/issues.go
@@ -8,6 +8,7 @@ package github
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"hash/fnv"
 	"os"
@@ -490,6 +491,14 @@ func (t *GitHubTracker) CreateMeasuringPlaceholder(repo, generation string, iter
 		"--body", body,
 	).Output()
 	if err != nil {
+		stderr := ""
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			stderr = strings.TrimSpace(string(exitErr.Stderr))
+		}
+		if stderr != "" {
+			return 0, fmt.Errorf("gh issue create placeholder: %w (stderr: %s)", err, stderr)
+		}
 		return 0, fmt.Errorf("gh issue create placeholder: %w", err)
 	}
 	number, err := ParseIssueURL(string(out))

--- a/pkg/orchestrator/internal/github/issues_test.go
+++ b/pkg/orchestrator/internal/github/issues_test.go
@@ -657,6 +657,11 @@ func TestCreateMeasuringPlaceholder_FakeRepo_Error(t *testing.T) {
 	if err == nil {
 		t.Error("CreateMeasuringPlaceholder with fake repo must return an error")
 	}
+	// GH-1438: error must include stderr from the gh CLI when available.
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, "stderr:") && !strings.Contains(errMsg, "exit status") {
+		t.Errorf("error should contain stderr or exit status, got: %s", errMsg)
+	}
 }
 
 // TestCloseMeasuringPlaceholder_FakeRepo_NoOp verifies CloseMeasuringPlaceholder

--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -429,7 +429,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	})
 	for i, m := range measureEntries {
 		mid := fmt.Sprintf("M%d", i+1)
-		if m.TaskID != "" {
+		if m.TaskID != "" && m.TaskID != "0" {
 			mid = m.TaskID
 		}
 		tr := tableRow{

--- a/pkg/orchestrator/internal/stats/generator_stats_test.go
+++ b/pkg/orchestrator/internal/stats/generator_stats_test.go
@@ -879,3 +879,69 @@ requirements:
 		t.Errorf("bug not fixed: output still shows 6/6 (all R-items in touched PRD):\n%s", output)
 	}
 }
+
+// TestMeasureTaskIDZeroDisplaysAsMN verifies that a measure entry with
+// TaskID "0" (from a failed placeholder creation) displays as "M1" in the
+// stats table, not as "0" (GH-1438).
+func TestMeasureTaskIDZeroDisplaysAsMN(t *testing.T) {
+	// Uses os.Chdir — do NOT use t.Parallel()
+	dir := t.TempDir()
+
+	histDir := filepath.Join(dir, "history")
+	os.MkdirAll(histDir, 0o755)
+
+	// Simulate a measure stats file with task_id "0" (placeholder failure).
+	measureYAML := `caller: measure
+started_at: "2026-03-09T18:00:04Z"
+duration: "56s"
+duration_s: 56
+task_id: "0"
+tokens:
+  input: 48000
+  output: 2000
+  cache_creation: 0
+  cache_read: 0
+cost_usd: 0.31
+num_turns: 2
+`
+	os.WriteFile(filepath.Join(histDir, "2026-03-09-18-00-04-measure-stats.yaml"), []byte(measureYAML), 0o644)
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	deps := GeneratorStatsDeps{
+		Log: func(format string, args ...any) {},
+		ListGenerationBranches: func() []string { return []string{"generation-main"} },
+		GenerationBranch:       "generation-main",
+		DetectGitHubRepo:       func() (string, error) { return "owner/repo", nil },
+		ListAllIssues: func(repo, generation string) ([]gh.CobblerIssue, error) {
+			return []gh.CobblerIssue{
+				{Number: 100, Title: "test task", State: "closed", Labels: []string{"cobbler-task"}},
+			}, nil
+		},
+		HistoryDir: histDir,
+	}
+
+	err := PrintGeneratorStats(deps)
+	w.Close()
+	captured, _ := io.ReadAll(r)
+	os.Stdout = oldStdout
+	output := string(captured)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// The measure row should show "M1", not "0".
+	if strings.Contains(output, "\n0 ") || strings.Contains(output, "\n0\t") {
+		t.Errorf("measure row should display as M1, not 0:\n%s", output)
+	}
+	if !strings.Contains(output, "M1") {
+		t.Errorf("expected M1 in output:\n%s", output)
+	}
+}

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -216,6 +216,12 @@ func (o *Orchestrator) RunMeasure() error {
 			totalTokens.CacheReadTokens += tokens.CacheReadTokens
 			totalTokens.CostUSD += tokens.CostUSD
 
+			// Build taskID once for both success and failure paths (GH-1438).
+			taskID := ""
+			if placeholderNum > 0 {
+				taskID = fmt.Sprintf("%d", placeholderNum)
+			}
+
 			if err != nil {
 				logf("Claude failed on iteration %d after %s: %v",
 					i+1, iterDuration.Round(time.Second), err)
@@ -223,7 +229,7 @@ func (o *Orchestrator) RunMeasure() error {
 				o.saveHistoryLog(historyTS, "measure", tokens.RawOutput)
 				o.saveHistoryStats(historyTS, "measure", HistoryStats{
 					Caller:        "measure",
-					TaskID:        fmt.Sprintf("%d", placeholderNum),
+					TaskID:        taskID,
 					Status:        "failed",
 					Error:         fmt.Sprintf("claude failure (iteration %d/%d): %v", i+1, totalIssues, err),
 					StartedAt:     iterStart.UTC().Format(time.RFC3339),
@@ -245,7 +251,7 @@ func (o *Orchestrator) RunMeasure() error {
 			o.saveHistory(historyTS, tokens.RawOutput, outputFile)
 			o.saveHistoryStats(historyTS, "measure", HistoryStats{
 				Caller:        "measure",
-				TaskID:        fmt.Sprintf("%d", placeholderNum),
+				TaskID:        taskID,
 				Status:        "success",
 				StartedAt:     iterStart.UTC().Format(time.RFC3339),
 				Duration:      iterDuration.Round(time.Second).String(),


### PR DESCRIPTION
## Summary

Fixes three issues when `CreateMeasuringPlaceholder` fails: stderr from the gh CLI was discarded, `task_id: "0"` was written to stats files, and the stats table displayed "0" instead of "M1".

## Changes

- `issues.go`: extract stderr from `exec.ExitError` in error messages
- `measure.go`: only set TaskID when placeholderNum > 0
- `generator_stats.go`: treat TaskID "0" as empty in display
- Added/enhanced tests for all three fixes

## Stats

- Lines of code (Go, production): 18692 (+26)
- Lines of code (Go, tests): 32812 (+71)

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (12 packages)

Closes #1438