### PR TITLE
GH-1444: stats:generator warns when invoked from wrong branch

### DIFF
--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -100,6 +100,13 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		genBranch = branches[0]
 	}
 
+	// Warn if the caller is not on the generation branch (GH-1444).
+	if deps.CurrentBranch != "" && deps.CurrentBranch != genBranch {
+		fmt.Fprintf(os.Stderr, "warning: stats:generator should be run from the generation worktree, not the main repo.\n"+
+			"Expected branch: %s, current branch: %s.\n"+
+			"Stats may be incomplete or incorrect.\n\n", genBranch, deps.CurrentBranch)
+	}
+
 	repo, err := deps.DetectGitHubRepo()
 	if err != nil || repo == "" {
 		return fmt.Errorf("detecting GitHub repo: %w", err)

--- a/pkg/orchestrator/internal/stats/generator_stats_test.go
+++ b/pkg/orchestrator/internal/stats/generator_stats_test.go
@@ -880,6 +880,97 @@ requirements:
 	}
 }
 
+// TestPrintGeneratorStats_WarnsWrongBranch verifies that a warning is printed
+// to stderr when the current branch does not match the generation branch (GH-1444).
+func TestPrintGeneratorStats_WarnsWrongBranch(t *testing.T) {
+	// Uses os.Chdir — do NOT use t.Parallel()
+	dir := t.TempDir()
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	// Capture stderr.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	deps := GeneratorStatsDeps{
+		Log: func(format string, args ...any) {},
+		ListGenerationBranches: func() []string { return []string{"generation-main"} },
+		GenerationBranch:       "generation-main",
+		CurrentBranch:          "main",
+		DetectGitHubRepo:       func() (string, error) { return "owner/repo", nil },
+		ListAllIssues: func(repo, generation string) ([]gh.CobblerIssue, error) {
+			return []gh.CobblerIssue{
+				{Number: 100, Title: "test task", State: "open", Labels: []string{"cobbler-task"}},
+			}, nil
+		},
+		HistoryDir: filepath.Join(dir, "history"),
+	}
+
+	err := PrintGeneratorStats(deps)
+	w.Close()
+	captured, _ := io.ReadAll(r)
+	os.Stderr = oldStderr
+	stderr := string(captured)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if !strings.Contains(stderr, "warning: stats:generator should be run from the generation worktree") {
+		t.Errorf("expected warning on stderr, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "Expected branch: generation-main, current branch: main.") {
+		t.Errorf("expected branch names in warning, got: %q", stderr)
+	}
+}
+
+// TestPrintGeneratorStats_NoWarnWhenOnCorrectBranch verifies no warning is
+// printed when the current branch matches the generation branch.
+func TestPrintGeneratorStats_NoWarnWhenOnCorrectBranch(t *testing.T) {
+	// Uses os.Chdir — do NOT use t.Parallel()
+	dir := t.TempDir()
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	// Capture stderr.
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	deps := GeneratorStatsDeps{
+		Log: func(format string, args ...any) {},
+		ListGenerationBranches: func() []string { return []string{"generation-main"} },
+		GenerationBranch:       "generation-main",
+		CurrentBranch:          "generation-main",
+		DetectGitHubRepo:       func() (string, error) { return "owner/repo", nil },
+		ListAllIssues: func(repo, generation string) ([]gh.CobblerIssue, error) {
+			return []gh.CobblerIssue{
+				{Number: 100, Title: "test task", State: "open", Labels: []string{"cobbler-task"}},
+			}, nil
+		},
+		HistoryDir: filepath.Join(dir, "history"),
+	}
+
+	err := PrintGeneratorStats(deps)
+	w.Close()
+	captured, _ := io.ReadAll(r)
+	os.Stderr = oldStderr
+	stderr := string(captured)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if strings.Contains(stderr, "warning") {
+		t.Errorf("expected no warning when on correct branch, got: %q", stderr)
+	}
+}
+
 // TestMeasureTaskIDZeroDisplaysAsMN verifies that a measure entry with
 // TaskID "0" (from a failed placeholder creation) displays as "M1" in the
 // stats table, not as "0" (GH-1438).


### PR DESCRIPTION
## Summary

Adds a stderr warning when `stats:generator` is run from a branch that doesn't match the resolved generation branch, preventing users from silently getting incorrect stats when running from the main repo instead of the generation worktree.

## Changes

- Added warning block in `PrintGeneratorStats` after generation branch resolution
- Two new tests: branch mismatch triggers warning, correct branch produces no warning

## Stats

go_loc_prod: 18873 (+6)
go_loc_test: 32876 (+92)

## Test plan

- [x] `go test ./pkg/orchestrator/...` passes
- [x] New tests cover both warning and no-warning paths

Closes #1444