### PR TITLE
GH-1445: stats:generator reads requirements from generation branch

### DIFF
--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -33,6 +33,9 @@ func (o *Orchestrator) GeneratorStats() error {
 		},
 		HistoryDir: o.historyDir(),
 		CobblerDir: o.cfg.Cobbler.Dir,
+		ReadBranchFile: func(branch, path string) ([]byte, error) {
+			return gitShowFileContent(branch, path, ".")
+		},
 	})
 }
 

--- a/pkg/orchestrator/internal/generate/requirements.go
+++ b/pkg/orchestrator/internal/generate/requirements.go
@@ -36,6 +36,12 @@ func LoadRequirementStates(cobblerDir string) map[string]map[string]RequirementS
 	if err != nil {
 		return nil
 	}
+	return ParseRequirementStates(data)
+}
+
+// ParseRequirementStates parses requirements.yaml content from raw bytes.
+// Returns nil if the data cannot be parsed.
+func ParseRequirementStates(data []byte) map[string]map[string]RequirementState {
 	var rf RequirementsFile
 	if err := yaml.Unmarshal(data, &rf); err != nil {
 		return nil

--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -43,8 +43,9 @@ type GeneratorStatsDeps struct {
 	CurrentBranch          string // current git branch, used to prefer the active generation
 	DetectGitHubRepo       func() (string, error)
 	ListAllIssues          func(repo, generation string) ([]gh.CobblerIssue, error)
-	HistoryDir string // path to .cobbler/history for local stats files
-	CobblerDir string // path to .cobbler directory for requirements.yaml
+	HistoryDir    string                                  // path to .cobbler/history for local stats files
+	CobblerDir    string                                  // path to .cobbler directory for requirements.yaml
+	ReadBranchFile func(branch, path string) ([]byte, error) // read a file from a git branch; nil means unavailable
 }
 
 // LoadHistoryStats reads all *-stats.yaml files from dir and returns the
@@ -543,16 +544,16 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 
 	// Requirements progress: count actual non-ready R-items from
 	// requirements.yaml rather than all R-items in any touched PRD (GH-1437).
+	// When on the wrong branch, read requirements.yaml from the generation
+	// branch via git to avoid stale CWD data (GH-1445).
 	total, _ := CountTotalPRDRequirements()
 	if total > 0 {
 		addressed := 0
-		if deps.CobblerDir != "" {
-			reqStates := generate.LoadRequirementStates(deps.CobblerDir)
-			for _, prdReqs := range reqStates {
-				for _, st := range prdReqs {
-					if st.Status != "ready" {
-						addressed++
-					}
+		reqStates := loadRequirementStatesForStats(deps, genBranch)
+		for _, prdReqs := range reqStates {
+			for _, st := range prdReqs {
+				if st.Status != "ready" {
+					addressed++
 				}
 			}
 		}
@@ -563,6 +564,30 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		fmt.Printf("\nRequirements: %d/%d addressed by this generation (%d%%)\n", addressed, total, pct)
 	}
 
+	return nil
+}
+
+// loadRequirementStatesForStats returns requirement states for the generation.
+// When the caller is on the generation branch, it reads from the local cobbler
+// dir. When on a different branch (e.g. main), it reads requirements.yaml from
+// the generation branch via git to avoid stale CWD data (GH-1445).
+func loadRequirementStatesForStats(deps GeneratorStatsDeps, genBranch string) map[string]map[string]generate.RequirementState {
+	onCorrectBranch := deps.CurrentBranch == "" || deps.CurrentBranch == genBranch
+
+	// When on the wrong branch, try reading from the generation branch via git.
+	if !onCorrectBranch && deps.ReadBranchFile != nil {
+		reqPath := filepath.Join(deps.CobblerDir, generate.RequirementsFileName)
+		if data, err := deps.ReadBranchFile(genBranch, reqPath); err == nil {
+			if states := generate.ParseRequirementStates(data); states != nil {
+				return states
+			}
+		}
+	}
+
+	// Default: read from CWD (correct branch or no ReadBranchFile available).
+	if deps.CobblerDir != "" {
+		return generate.LoadRequirementStates(deps.CobblerDir)
+	}
 	return nil
 }
 

--- a/pkg/orchestrator/internal/stats/generator_stats_test.go
+++ b/pkg/orchestrator/internal/stats/generator_stats_test.go
@@ -4,6 +4,7 @@
 package stats
 
 import (
+	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -968,6 +969,185 @@ func TestPrintGeneratorStats_NoWarnWhenOnCorrectBranch(t *testing.T) {
 
 	if strings.Contains(stderr, "warning") {
 		t.Errorf("expected no warning when on correct branch, got: %q", stderr)
+	}
+}
+
+// TestPrintGeneratorStats_ReqsFromBranch verifies that when on the wrong
+// branch, requirements.yaml is read from the generation branch via
+// ReadBranchFile instead of from stale CWD data (GH-1445).
+func TestPrintGeneratorStats_ReqsFromBranch(t *testing.T) {
+	// Uses os.Chdir — do NOT use t.Parallel()
+	dir := t.TempDir()
+
+	// Create a PRD with 4 R-items.
+	prdDir := filepath.Join(dir, "docs", "specs", "product-requirements")
+	os.MkdirAll(prdDir, 0o755)
+	prdYAML := `id: prd001-test
+requirements:
+  R1:
+    title: "Group"
+    items:
+      - R1.1: "first"
+      - R1.2: "second"
+      - R1.3: "third"
+      - R1.4: "fourth"
+`
+	os.WriteFile(filepath.Join(prdDir, "prd001-test.yaml"), []byte(prdYAML), 0o644)
+
+	// Stale CWD requirements.yaml: shows 3 of 4 addressed (wrong).
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+	staleReqYAML := `requirements:
+  prd001-test:
+    R1.1:
+      status: complete
+    R1.2:
+      status: complete
+    R1.3:
+      status: complete
+    R1.4:
+      status: ready
+`
+	os.WriteFile(filepath.Join(cobblerDir, generate.RequirementsFileName), []byte(staleReqYAML), 0o644)
+
+	// Fresh requirements from generation branch: only 1 addressed.
+	freshReqYAML := `requirements:
+  prd001-test:
+    R1.1:
+      status: complete
+    R1.2:
+      status: ready
+    R1.3:
+      status: ready
+    R1.4:
+      status: ready
+`
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	// Capture stdout, discard stderr (warning from GH-1444).
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	_, stderrW, _ := os.Pipe()
+	os.Stderr = stderrW
+
+	deps := GeneratorStatsDeps{
+		Log:                    func(format string, args ...any) {},
+		ListGenerationBranches: func() []string { return []string{"generation-main"} },
+		GenerationBranch:       "generation-main",
+		CurrentBranch:          "main", // wrong branch — triggers ReadBranchFile
+		DetectGitHubRepo:       func() (string, error) { return "owner/repo", nil },
+		ListAllIssues: func(repo, generation string) ([]gh.CobblerIssue, error) {
+			return []gh.CobblerIssue{
+				{Number: 100, Title: "test task", State: "open", Labels: []string{"cobbler-task"}},
+			}, nil
+		},
+		HistoryDir: filepath.Join(cobblerDir, "history"),
+		CobblerDir: cobblerDir,
+		ReadBranchFile: func(branch, path string) ([]byte, error) {
+			if branch == "generation-main" {
+				return []byte(freshReqYAML), nil
+			}
+			return nil, fmt.Errorf("branch not found")
+		},
+	}
+
+	err := PrintGeneratorStats(deps)
+	w.Close()
+	stderrW.Close()
+	captured, _ := io.ReadAll(r)
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	output := string(captured)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should report 1/4 (from branch), not 3/4 (from stale CWD).
+	if !strings.Contains(output, "Requirements: 1/4") {
+		t.Errorf("expected 'Requirements: 1/4' (from branch), got:\n%s", output)
+	}
+	if strings.Contains(output, "Requirements: 3/4") {
+		t.Errorf("bug: still reading stale CWD requirements (3/4):\n%s", output)
+	}
+}
+
+// TestPrintGeneratorStats_ReqsFallbackToCWD verifies that when ReadBranchFile
+// is nil (not available), requirements are still read from CWD.
+func TestPrintGeneratorStats_ReqsFallbackToCWD(t *testing.T) {
+	// Uses os.Chdir — do NOT use t.Parallel()
+	dir := t.TempDir()
+
+	prdDir := filepath.Join(dir, "docs", "specs", "product-requirements")
+	os.MkdirAll(prdDir, 0o755)
+	prdYAML := `id: prd001-test
+requirements:
+  R1:
+    title: "Group"
+    items:
+      - R1.1: "first"
+      - R1.2: "second"
+`
+	os.WriteFile(filepath.Join(prdDir, "prd001-test.yaml"), []byte(prdYAML), 0o644)
+
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+	reqYAML := `requirements:
+  prd001-test:
+    R1.1:
+      status: complete
+    R1.2:
+      status: ready
+`
+	os.WriteFile(filepath.Join(cobblerDir, generate.RequirementsFileName), []byte(reqYAML), 0o644)
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	_, stderrW, _ := os.Pipe()
+	os.Stderr = stderrW
+
+	deps := GeneratorStatsDeps{
+		Log:                    func(format string, args ...any) {},
+		ListGenerationBranches: func() []string { return []string{"generation-main"} },
+		GenerationBranch:       "generation-main",
+		CurrentBranch:          "generation-main", // correct branch
+		DetectGitHubRepo:       func() (string, error) { return "owner/repo", nil },
+		ListAllIssues: func(repo, generation string) ([]gh.CobblerIssue, error) {
+			return []gh.CobblerIssue{
+				{Number: 100, Title: "test task", State: "open", Labels: []string{"cobbler-task"}},
+			}, nil
+		},
+		HistoryDir:     filepath.Join(cobblerDir, "history"),
+		CobblerDir:     cobblerDir,
+		ReadBranchFile: nil, // not available
+	}
+
+	err := PrintGeneratorStats(deps)
+	w.Close()
+	stderrW.Close()
+	captured, _ := io.ReadAll(r)
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+	output := string(captured)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should still show 1/2 from CWD.
+	if !strings.Contains(output, "Requirements: 1/2") {
+		t.Errorf("expected 'Requirements: 1/2' from CWD fallback, got:\n%s", output)
 	}
 }
 


### PR DESCRIPTION
## Summary

When `stats:generator` runs from the main repo instead of the generation worktree, requirements.yaml is now read from the generation branch via `git show` instead of from the stale CWD copy. This prevents incorrect requirement counts (e.g. 156/867 instead of 8/867).

## Changes

- Extracted `ParseRequirementStates(data []byte)` in `generate/requirements.go` for parsing from raw bytes
- Added `ReadBranchFile` function field to `GeneratorStatsDeps`
- Added `loadRequirementStatesForStats` helper that reads from the generation branch when on wrong branch, falls back to CWD otherwise
- Wired `gitShowFileContent` as `ReadBranchFile` in the orchestrator wrapper
- Two new tests: branch read path and CWD fallback path

## Stats

go_loc_prod: 18880 (+25 prod)
go_loc_test: 32967 (+189 test)

## Test plan

- [x] `go test ./pkg/orchestrator/...` passes
- [x] New tests cover both branch-read and CWD-fallback paths
- [x] Existing `TestRequirementsCountUsesPerItemState` still passes

Closes #1445