### PR TITLE
GH-1448: deduplicate PRD refs by stripping .yaml suffix

### DIFF
--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -770,6 +770,10 @@ func ExtractPRDRefs(text string) []string {
 	var prds []string
 	for _, word := range strings.Fields(text) {
 		w := strings.ToLower(strings.Trim(word, ".,;:()[]`\"'"))
+		// Strip .yaml/.yml suffix so "prd001-foo.yaml" deduplicates with
+		// "prd001-foo" (GH-1448).
+		w = strings.TrimSuffix(w, ".yaml")
+		w = strings.TrimSuffix(w, ".yml")
 		if !strings.HasPrefix(w, "prd") || len(w) < 5 {
 			continue
 		}

--- a/pkg/orchestrator/internal/stats/generator_stats_test.go
+++ b/pkg/orchestrator/internal/stats/generator_stats_test.go
@@ -268,6 +268,18 @@ func TestExtractPRDRefs(t *testing.T) {
 			text: "bare prd003 without hyphen-name is not a ref",
 			want: nil,
 		},
+		{
+			text: "prd001-testutils.yaml should strip yaml suffix",
+			want: []string{"prd001-testutils"},
+		},
+		{
+			text: "prd001-testutils and prd001-testutils.yaml deduplicate",
+			want: []string{"prd001-testutils"},
+		},
+		{
+			text: "prd-auth-flow.yml strips yml suffix too",
+			want: []string{"prd-auth-flow"},
+		},
 	}
 	for _, tc := range tests {
 		got := ExtractPRDRefs(tc.text)


### PR DESCRIPTION
## Summary

Strips `.yaml`/`.yml` suffixes from PRD references in `ExtractPRDRefs` so that `prd001-testutils.yaml` normalizes to `prd001-testutils`, preventing duplicate rows in the PRD status table.

## Changes

- Added `strings.TrimSuffix` for `.yaml` and `.yml` in `ExtractPRDRefs`
- 3 new test cases: yaml suffix stripping, dedup with bare id, yml suffix

## Test plan

- [x] All tests pass
- [x] New test cases cover `.yaml`, `.yml`, and dedup scenarios

Closes #1448