### PR TITLE
GH-1463: stop stitch from rereading project_context files

### DIFF
--- a/pkg/orchestrator/prompts/stitch.yaml
+++ b/pkg/orchestrator/prompts/stitch.yaml
@@ -4,7 +4,7 @@ role: |
 task: |
   Follow these steps in order. Complete each step before moving to the next.
 
-  1. **Review provided context** — The project_context above contains all project documentation and source code. Review the files listed in Required Reading by finding them in the project_context. Only use tools to read files that are NOT already provided above.
+  1. **Review provided context** — The project_context section above already contains all project documentation, PRDs, source code, shared_protocols, and package_contracts inline in this prompt. Review Required Reading files by scrolling up to find them in project_context — do NOT call the Read, Glob, or Grep tools for any file already present above. The only files you may read with tools are files NOT in project_context (e.g. files you are about to create or modify).
 
   2. **Plan approach** — Before writing code, determine:
      - What exists already (interfaces, types, patterns in the source code above)
@@ -17,7 +17,7 @@ task: |
 
 constraints: |
   - Do NOT read any file in the repository to infer style, patterns, or conventions. All style guidance is provided in go_style_constitution above. All source patterns are provided in project_context above. If a file you need is absent from project_context, write it from scratch following go_style_constitution — do not read the filesystem to fill the gap.
-  - Do NOT read files already provided in project_context. They are already inline above.
+  - Do NOT use Read, Glob, or Grep tools on files already in project_context. PRDs, source code, ARCHITECTURE, VISION, shared_protocols, package_contracts — all are inline above. Reading them again wastes a turn and adds no information. Only use Read for files not present in project_context.
   - Do NOT explore the filesystem. Do NOT run ls, find, tree, or similar commands.
   - Do NOT modify files outside the Files to Create/Modify list unless a requirement explicitly demands it.
   - Do NOT use bd or cupboard commands. Task tracking is handled externally.


### PR DESCRIPTION
## Summary

Strengthened stitch prompt to prevent Claude from wasting turns calling Read/Glob/Grep on files already inline in project_context. Step 1 now says "scroll up" explicitly, and the constraint names the specific tools and explains that rereading wastes a turn.

## Changes

- Updated Step 1 in `stitch.yaml` to say "scroll up to find them in project_context — do NOT call Read, Glob, or Grep"
- Replaced generic "Do NOT read files" constraint with tool-specific prohibition naming Read, Glob, Grep and listing the content categories already inline

## Test plan

- [x] All tests pass
- [ ] Verify in next generation run: zero Read/Glob/Grep calls for project_context files

Closes #1463