### PR TITLE
GH-1464: exclude PRDs from stitch context, read via required_reading

### DIFF
--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -429,6 +429,21 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 		}
 	}
 
+	// Exclude PRDs from stitch context — Claude reads them via required_reading
+	// instead. This avoids double-delivery (inline + Read tool) and shrinks the
+	// prompt by 10-30KB (GH-1464).
+	{
+		if phaseCtx == nil {
+			phaseCtx = &PhaseContext{}
+		}
+		prdExclude := "docs/specs/product-requirements/prd*.yaml"
+		if phaseCtx.Exclude == "" {
+			phaseCtx.Exclude = prdExclude
+		} else {
+			phaseCtx.Exclude = phaseCtx.Exclude + "\n" + prdExclude
+		}
+	}
+
 	// Build project context from the worktree directory.
 	var projectCtx *ProjectContext
 	if task.WorktreeDir != "" {


### PR DESCRIPTION
## Summary

Excluded PRD files from the stitch prompt's project_context by adding `docs/specs/product-requirements/prd*.yaml` to the phase context's Exclude patterns. Claude reads PRDs via the Read tool through required_reading instead, eliminating double-delivery and shrinking the prompt by 10-30KB.

## Changes

- Added PRD exclusion block in `buildStitchPrompt` after the stitch_exclude_tests block
- Measure prompt unchanged (needs PRDs inline since it cannot use tools)

## Test plan

- [x] All tests pass
- [ ] Verify in next generation run: prompt size reduced, Claude reads PRDs via Read tool

Closes #1464