### PR TITLE
GH-1469: revert UC implemented statuses during generator:stop

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -953,12 +953,16 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 // resetImplementedReleases loads road-map.yaml, finds all releases with
 // status "implemented", and calls ReleaseClear for each to reset them to
 // "spec_complete" and repopulate configuration.yaml (GH-1021).
+// Also reverts individual UC statuses that were marked "implemented" by
+// validateAndMarkUCs even when the release itself is not yet implemented
+// (GH-1469).
 func (o *Orchestrator) resetImplementedReleases() error {
 	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
 	if rm == nil {
 		return nil
 	}
 	var cleared []string
+	var revertedUCs []string
 	for _, rel := range rm.Releases {
 		if strings.EqualFold(rel.Status, "implemented") {
 			if err := o.ReleaseClear(rel.Version); err != nil {
@@ -966,17 +970,37 @@ func (o *Orchestrator) resetImplementedReleases() error {
 				continue
 			}
 			cleared = append(cleared, rel.Version)
+			continue
+		}
+		// Revert individual UC statuses even when the release itself is
+		// not yet implemented (GH-1469). validateAndMarkUCs promotes UCs
+		// one at a time during the run; generator:stop must undo them.
+		for _, uc := range rel.UseCases {
+			if ucStatusDone(uc.Status) {
+				if err := updateRoadmapSingleUCStatus(rel.Version, uc.ID, "spec_complete"); err != nil {
+					logf("resetImplementedReleases: revert UC %s in %s failed: %v", uc.ID, rel.Version, err)
+					continue
+				}
+				revertedUCs = append(revertedUCs, uc.ID)
+			}
 		}
 	}
-	if len(cleared) == 0 {
+	if len(cleared) == 0 && len(revertedUCs) == 0 {
 		return nil
 	}
 	_ = gitStageAll(".")
-	msg := fmt.Sprintf("Reset releases to spec_complete after generator:stop\n\nCleared: %s", strings.Join(cleared, ", "))
+	var parts []string
+	if len(cleared) > 0 {
+		parts = append(parts, fmt.Sprintf("Releases: %s", strings.Join(cleared, ", ")))
+	}
+	if len(revertedUCs) > 0 {
+		parts = append(parts, fmt.Sprintf("UCs: %s", strings.Join(revertedUCs, ", ")))
+	}
+	msg := fmt.Sprintf("Reset statuses to spec_complete after generator:stop\n\n%s", strings.Join(parts, "\n"))
 	if err := gitCommit(msg, "."); err != nil {
 		return fmt.Errorf("commit release reset: %w", err)
 	}
-	logf("resetImplementedReleases: cleared %d release(s): %s", len(cleared), strings.Join(cleared, ", "))
+	logf("resetImplementedReleases: cleared %d release(s), reverted %d UC(s)", len(cleared), len(revertedUCs))
 	return nil
 }
 

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -1837,6 +1837,57 @@ func TestGeneratorStop_CommitsHistoryBeforeTag(t *testing.T) {
 	}
 }
 
+// TestResetImplementedReleases_RevertsUCStatuses verifies that individual
+// UC statuses are reverted to spec_complete even when the release itself
+// is not yet marked implemented (GH-1469).
+func TestResetImplementedReleases_RevertsUCStatuses(t *testing.T) {
+	// Uses os.Chdir — do NOT use t.Parallel()
+	dir := initTestGitRepo(t)
+
+	// Create road-map.yaml with a release that has some UCs implemented
+	// but the release itself is still spec_complete.
+	docsDir := filepath.Join(dir, "docs")
+	os.MkdirAll(docsDir, 0o755)
+	roadmap := `releases:
+  - version: "00.0"
+    name: "Foundation"
+    status: spec_complete
+    use_cases:
+      - id: rel00.0-uc001-format
+        status: implemented
+      - id: rel00.0-uc002-sys
+        status: implemented
+      - id: rel00.0-uc003-testutils
+        status: spec_complete
+`
+	os.WriteFile(filepath.Join(docsDir, "road-map.yaml"), []byte(roadmap), 0o644)
+
+	cmd := exec.Command("git", "add", "-A")
+	cmd.Dir = dir
+	cmd.CombinedOutput()
+	cmd = exec.Command("git", "commit", "-m", "add roadmap")
+	cmd.Dir = dir
+	cmd.CombinedOutput()
+
+	o := &Orchestrator{cfg: Config{}}
+	if err := o.resetImplementedReleases(); err != nil {
+		t.Fatalf("resetImplementedReleases error: %v", err)
+	}
+
+	// Read the road-map.yaml and verify UC statuses were reverted.
+	data, err := os.ReadFile(filepath.Join(docsDir, "road-map.yaml"))
+	if err != nil {
+		t.Fatalf("cannot read road-map.yaml: %v", err)
+	}
+	content := string(data)
+
+	// Both implemented UCs should now be spec_complete.
+	// The file should not contain "implemented" for any UC.
+	if strings.Contains(content, "implemented") {
+		t.Errorf("road-map.yaml still contains 'implemented' after reset:\n%s", content)
+	}
+}
+
 func TestResetImplementedReleases_NoRoadmap(t *testing.T) {
 	initTestGitRepo(t)
 


### PR DESCRIPTION
## Summary

Fixed `generator:stop` to revert individual UC statuses from `implemented` back to `spec_complete`. Previously only release-level statuses were reset, leaving UC-level statuses inconsistent with the specs-only branch state.

## Changes

- Extended `resetImplementedReleases` to scan UC-level statuses within non-implemented releases
- New test: `TestResetImplementedReleases_RevertsUCStatuses`

## Test plan

- [x] All tests pass
- [x] New test verifies 2 UCs reverted when release is spec_complete but UCs are implemented

Closes #1469