### PR TITLE
GH-1468: clean go.sum and go.mod during specs-only reset

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -1302,14 +1302,55 @@ func (o *Orchestrator) resetGoSources(version string) error {
 	return o.reinitGoModule()
 }
 
-// cleanGoSources removes all Go files, empty source directories, and the
-// binary directory without re-seeding files or reinitializing the module.
+// cleanGoSources removes all Go files, empty source directories, the
+// binary directory, go.sum, and require/replace blocks from go.mod.
+// After this call the working tree contains only specs and a minimal
+// go.mod (module + go version) (GH-1468).
 func (o *Orchestrator) cleanGoSources() {
 	o.deleteGoFiles(".")
 	for _, dir := range o.cfg.Project.GoSourceDirs {
 		removeEmptyDirs(dir)
 	}
 	os.RemoveAll(o.cfg.Project.BinaryDir + "/")
+	_ = os.Remove("go.sum") // best-effort; may not exist
+	stripGoModRequires("go.mod")
+}
+
+// stripGoModRequires rewrites go.mod to keep only the module declaration
+// and go version, removing require and replace blocks.
+func stripGoModRequires(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return // file absent — nothing to clean
+	}
+	var kept []string
+	inBlock := false
+	for _, line := range strings.Split(string(data), "\n") {
+		trimmed := strings.TrimSpace(line)
+		if strings.HasPrefix(trimmed, "require ") && strings.HasSuffix(trimmed, "(") {
+			inBlock = true
+			continue
+		}
+		if strings.HasPrefix(trimmed, "replace ") && strings.HasSuffix(trimmed, "(") {
+			inBlock = true
+			continue
+		}
+		if inBlock {
+			if trimmed == ")" {
+				inBlock = false
+			}
+			continue
+		}
+		// Skip single-line require/replace directives.
+		if strings.HasPrefix(trimmed, "require ") || strings.HasPrefix(trimmed, "replace ") {
+			continue
+		}
+		kept = append(kept, line)
+	}
+	result := strings.Join(kept, "\n")
+	// Ensure single trailing newline.
+	result = strings.TrimRight(result, "\n") + "\n"
+	_ = os.WriteFile(path, []byte(result), 0o644)
 }
 
 // seedFiles creates the configured seed files using Go templates.

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -1888,6 +1888,56 @@ func TestResetImplementedReleases_RevertsUCStatuses(t *testing.T) {
 	}
 }
 
+// TestStripGoModRequires verifies that require and replace blocks are
+// removed from go.mod, keeping only module and go version (GH-1468).
+func TestStripGoModRequires(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	gomod := filepath.Join(dir, "go.mod")
+
+	content := `module example.com/test
+
+go 1.25.7
+
+require (
+	github.com/stretchr/testify v1.9.0
+	gopkg.in/yaml.v3 v3.0.1
+)
+
+require github.com/single/dep v1.0.0
+
+replace github.com/foo/bar => ./bar
+`
+	os.WriteFile(gomod, []byte(content), 0o644)
+
+	stripGoModRequires(gomod)
+
+	data, err := os.ReadFile(gomod)
+	if err != nil {
+		t.Fatalf("cannot read go.mod: %v", err)
+	}
+	result := string(data)
+
+	if strings.Contains(result, "require") {
+		t.Errorf("go.mod still contains require after strip:\n%s", result)
+	}
+	if strings.Contains(result, "replace") {
+		t.Errorf("go.mod still contains replace after strip:\n%s", result)
+	}
+	if !strings.Contains(result, "module example.com/test") {
+		t.Errorf("go.mod missing module line:\n%s", result)
+	}
+	if !strings.Contains(result, "go 1.25.7") {
+		t.Errorf("go.mod missing go version:\n%s", result)
+	}
+}
+
+func TestStripGoModRequires_NoFile(t *testing.T) {
+	t.Parallel()
+	// Should not panic on missing file.
+	stripGoModRequires("/nonexistent/go.mod")
+}
+
 func TestResetImplementedReleases_NoRoadmap(t *testing.T) {
 	initTestGitRepo(t)
 


### PR DESCRIPTION
## Summary

Fixed `cleanGoSources` to also remove `go.sum` and strip `require`/`replace` blocks from `go.mod` during the specs-only reset in `generator:stop`. Previously these dependency artifacts from generated code persisted on the specs-only branch.

## Changes

- Added `go.sum` removal and `stripGoModRequires` call to `cleanGoSources`
- New `stripGoModRequires` function: parses go.mod, keeps only module + go version lines
- Two new tests: block stripping and missing-file safety

## Test plan

- [x] All tests pass
- [x] `TestStripGoModRequires` verifies require/replace blocks removed, module/go lines kept

Closes #1468