### PR TITLE
GH-1475: prevent premature generator stop when requirements remain

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -226,6 +226,25 @@ func loadRequirementStates(cobblerDir string) map[string]map[string]generate.Req
 	return generate.LoadRequirementStates(cobblerDir)
 }
 
+// hasUnresolvedRequirements returns true if any R-item in requirements.yaml
+// has status "ready" (not yet implemented or skipped). Used to prevent the
+// generator from stopping prematurely when the GitHub API reports no open
+// issues but work remains (GH-1475).
+func (o *Orchestrator) hasUnresolvedRequirements() bool {
+	states := generate.LoadRequirementStates(o.cfg.Cobbler.Dir)
+	if states == nil {
+		return false
+	}
+	for _, prdReqs := range states {
+		for _, st := range prdReqs {
+			if st.Status == "ready" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 func warnOversizedGroups(maxReqs int) {
 	generate.WarnOversizedGroups(maxReqs)
 }
@@ -471,8 +490,21 @@ func (o *Orchestrator) RunCycles(label string) error {
 			logf("generator %s: hasOpenIssues error (assuming open): %v", label, err)
 		}
 		if !open && err == nil {
-			logf("generator %s: no open issues remain, stopping after %d cycle(s)", label, cycle)
-			break
+			// Before stopping, check if unresolved requirements remain.
+			// The GitHub API may report no open issues due to a race
+			// condition (stale cache after closing the last task). If
+			// requirements are still "ready", run measure to create new
+			// tasks instead of stopping prematurely (GH-1475).
+			if o.hasUnresolvedRequirements() {
+				logf("generator %s: cycle %d — no open issues but unresolved requirements remain, running measure",
+					label, cycle)
+				if err := o.RunMeasure(); err != nil {
+					return fmt.Errorf("cycle %d measure (fallback): %w", cycle, err)
+				}
+			} else {
+				logf("generator %s: no open issues remain, stopping after %d cycle(s)", label, cycle)
+				break
+			}
 		}
 		logf("generator %s: open issues remain, continuing to cycle %d", label, cycle+1)
 	}

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -1946,3 +1946,53 @@ func TestResetImplementedReleases_NoRoadmap(t *testing.T) {
 		t.Fatalf("resetImplementedReleases error: %v", err)
 	}
 }
+
+// --- hasUnresolvedRequirements (GH-1475) ---
+
+func TestHasUnresolvedRequirements_ReadyItems(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".cobbler"), 0o755)
+	reqYAML := `requirements:
+  prd001-core:
+    R1.1:
+      status: complete
+      issue: 10
+    R1.2:
+      status: ready
+`
+	os.WriteFile(filepath.Join(dir, ".cobbler", "requirements.yaml"), []byte(reqYAML), 0o644)
+
+	o := &Orchestrator{cfg: Config{Cobbler: CobblerConfig{Dir: filepath.Join(dir, ".cobbler")}}}
+	if !o.hasUnresolvedRequirements() {
+		t.Error("expected true: R1.2 is still ready")
+	}
+}
+
+func TestHasUnresolvedRequirements_AllComplete(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	os.MkdirAll(filepath.Join(dir, ".cobbler"), 0o755)
+	reqYAML := `requirements:
+  prd001-core:
+    R1.1:
+      status: complete
+      issue: 10
+    R1.2:
+      status: skip
+`
+	os.WriteFile(filepath.Join(dir, ".cobbler", "requirements.yaml"), []byte(reqYAML), 0o644)
+
+	o := &Orchestrator{cfg: Config{Cobbler: CobblerConfig{Dir: filepath.Join(dir, ".cobbler")}}}
+	if o.hasUnresolvedRequirements() {
+		t.Error("expected false: all items are complete or skip")
+	}
+}
+
+func TestHasUnresolvedRequirements_NoFile(t *testing.T) {
+	t.Parallel()
+	o := &Orchestrator{cfg: Config{Cobbler: CobblerConfig{Dir: "/nonexistent"}}}
+	if o.hasUnresolvedRequirements() {
+		t.Error("expected false: no requirements file")
+	}
+}


### PR DESCRIPTION
## Summary

Fixed the generator run loop to check for unresolved requirements before stopping when `hasOpenIssues` returns false. This prevents premature stops caused by GitHub API race conditions after closing the last task.

## Changes

- Added `hasUnresolvedRequirements()` method that scans requirements.yaml for "ready" items
- Modified stop condition: if no open issues but ready requirements exist, run measure instead of stopping
- 3 new tests: ready items, all-complete/skip, no file

## Test plan

- [x] All tests pass
- [x] `hasUnresolvedRequirements` correctly detects ready vs complete/skip items

Closes #1475