### PR TITLE
GH-1509: separate idle timeout for measure (30min default)

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -164,6 +164,15 @@ func (o *Orchestrator) runClaudeDeps() claude.RunClaudeDeps {
 	}
 }
 
+// runMeasureClaude executes Claude with the measure-specific idle timeout,
+// which is higher than the default to accommodate large prompts that cause
+// extended thinking time (GH-1509).
+func (o *Orchestrator) runMeasureClaude(prompt, dir string, silence bool, extraClaudeArgs ...string) (ClaudeResult, error) {
+	deps := o.runClaudeDeps()
+	deps.IdleTimeoutS = o.cfg.Cobbler.MeasureIdleTimeoutSeconds
+	return claude.RunClaude(deps, prompt, dir, silence, extraClaudeArgs...)
+}
+
 // runClaudeSDK executes Claude via the Go Agent SDK.
 func (o *Orchestrator) runClaudeSDK(ctx context.Context, prompt, workDir string, silence bool, extraClaudeArgs ...string) (ClaudeResult, error) {
 	return claude.RunClaudeSDK(o.runClaudeDeps(), ctx, prompt, workDir, silence, extraClaudeArgs...)

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -241,6 +241,12 @@ type CobblerConfig struct {
 	// reads, tool calls, code). Default 60. Set to 0 to disable.
 	IdleTimeoutSeconds int `yaml:"idle_timeout_seconds"`
 
+	// MeasureIdleTimeoutSeconds overrides IdleTimeoutSeconds for measure
+	// invocations. Measure prompts can be very large (100KB+) causing
+	// Claude to think for 20+ minutes before producing output. Default
+	// 1800 (30 min). Set to 0 to disable the watchdog for measure.
+	MeasureIdleTimeoutSeconds int `yaml:"measure_idle_timeout_seconds"`
+
 	// MeasureExcludeSource excludes all Go source files from the measure
 	// prompt context when true. Specs (PRDs, use cases, constitutions,
 	// road-map) are always included. Default false; existing behaviour
@@ -508,6 +514,9 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Cobbler.IdleTimeoutSeconds == 0 {
 		c.Cobbler.IdleTimeoutSeconds = 60
+	}
+	if c.Cobbler.MeasureIdleTimeoutSeconds == 0 {
+		c.Cobbler.MeasureIdleTimeoutSeconds = 1800
 	}
 	if c.Cobbler.MaxConsecutiveZeroLOCCycles == 0 {
 		c.Cobbler.MaxConsecutiveZeroLOCCycles = 3

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -212,7 +212,7 @@ func (o *Orchestrator) RunMeasure() error {
 			o.saveHistoryPrompt(historyTS, "measure", prompt)
 
 			iterStart := time.Now()
-			tokens, err := o.runClaude(prompt, "", o.cfg.Silence(), "--max-turns", "1")
+			tokens, err := o.runMeasureClaude(prompt, "", o.cfg.Silence(), "--max-turns", "1")
 			iterDuration := time.Since(iterStart)
 
 			totalTokens.InputTokens += tokens.InputTokens


### PR DESCRIPTION
## Summary

Added `MeasureIdleTimeoutSeconds` config field (default 1800s) so measure invocations have a longer idle watchdog timeout than stitch (60s). Large prompts (100KB+, 70+ PRDs) cause Claude to think for 20+ minutes before producing output, triggering the default watchdog.

## Changes

- Added `MeasureIdleTimeoutSeconds` to `CobblerConfig` with default 1800
- Added `runMeasureClaude` method that overrides idle timeout for measure
- Measure loop calls `runMeasureClaude` instead of `runClaude`

## Test plan

- [x] All tests pass
- [ ] Verify in next generation with 70+ PRDs: measure completes without watchdog kill

Closes #1509