### PR TITLE
GH-1561: Recover stale task branches in CreateWorktree

### DIFF
--- a/pkg/orchestrator/internal/generate/stitch.go
+++ b/pkg/orchestrator/internal/generate/stitch.go
@@ -312,6 +312,8 @@ func PickTask(baseBranch, worktreeBase, repo, generation string, issueDeps Stitc
 }
 
 // CreateWorktree creates a git worktree for the given task.
+// If a stale branch exists from a previous failed attempt, it is deleted
+// and recreated before retrying (GH-1561).
 func CreateWorktree(task StitchTask, gitDeps StitchGitDeps) error {
 	Log("createWorktree: dir=%s branch=%s", task.WorktreeDir, task.BranchName)
 
@@ -336,6 +338,34 @@ func CreateWorktree(task StitchTask, gitDeps StitchGitDeps) error {
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		Log("createWorktree: worktree add failed: %v", err)
+
+		// The branch may be stale from a previous interrupted run where the
+		// worktree was cleaned up but the branch survived. Task branches are
+		// ephemeral, so delete the stale branch, prune worktree bookkeeping,
+		// recreate the branch from HEAD, and retry once (GH-1561).
+		if gitDeps.BranchExists(task.BranchName, ".") {
+			Log("createWorktree: stale branch %s detected, recovering", task.BranchName)
+			if delErr := gitDeps.ForceDeleteBranch(task.BranchName, "."); delErr != nil {
+				Log("createWorktree: force delete stale branch failed: %v", delErr)
+				return fmt.Errorf("adding worktree: %w (stale branch cleanup also failed: %v)", err, delErr)
+			}
+			gitDeps.WorktreePrune(".")
+			if createErr := gitDeps.CreateBranch(task.BranchName, "."); createErr != nil {
+				Log("createWorktree: recreate branch after stale cleanup failed: %v", createErr)
+				return fmt.Errorf("adding worktree: %w (branch recreate failed: %v)", err, createErr)
+			}
+			Log("createWorktree: retrying worktree add after stale branch cleanup")
+			retryCmd := gitDeps.WorktreeAdd(task.WorktreeDir, task.BranchName, ".")
+			retryCmd.Stdout = os.Stdout
+			retryCmd.Stderr = os.Stderr
+			if retryErr := retryCmd.Run(); retryErr != nil {
+				Log("createWorktree: retry also failed: %v", retryErr)
+				return fmt.Errorf("adding worktree after stale branch recovery: %w", retryErr)
+			}
+			Log("createWorktree: recovered — worktree ready at %s on branch %s", task.WorktreeDir, task.BranchName)
+			return nil
+		}
+
 		return fmt.Errorf("adding worktree: %w", err)
 	}
 

--- a/pkg/orchestrator/internal/generate/stitch_test.go
+++ b/pkg/orchestrator/internal/generate/stitch_test.go
@@ -362,6 +362,132 @@ func TestCreateWorktree_BranchAlreadyExists(t *testing.T) {
 	}
 }
 
+func TestCreateWorktree_RecoversStaleBranch(t *testing.T) {
+	// Simulate: branch exists, first WorktreeAdd fails (stale worktree
+	// reference), recovery deletes branch + prunes + recreates, retry succeeds.
+	worktreeAddCalls := 0
+	var forceDeleted string
+	var pruned bool
+	var recreatedBranch string
+	gitDeps := StitchGitDeps{
+		RepoReader: &mockRepoReader{BranchExistsFn: func(name, dir string) bool { return true }},
+		BranchManager: &mockBranchManager{
+			ForceDeleteBranchFn: func(name, dir string) error { forceDeleted = name; return nil },
+			CreateBranchFn:      func(name, dir string) error { recreatedBranch = name; return nil },
+		},
+		WorktreeManager: &mockWorktreeManager{
+			WorktreeAddFn: func(wtDir, branch, dir string) *exec.Cmd {
+				worktreeAddCalls++
+				if worktreeAddCalls == 1 {
+					return exec.Command("false") // first attempt fails
+				}
+				return exec.Command("true") // retry succeeds
+			},
+			WorktreePruneFn: func(dir string) error { pruned = true; return nil },
+		},
+	}
+	task := StitchTask{
+		BranchName:  "task/gen-2064",
+		WorktreeDir: t.TempDir(),
+	}
+	if err := CreateWorktree(task, gitDeps); err != nil {
+		t.Fatalf("expected recovery to succeed, got: %v", err)
+	}
+	if worktreeAddCalls != 2 {
+		t.Errorf("expected 2 WorktreeAdd calls (initial + retry), got %d", worktreeAddCalls)
+	}
+	if forceDeleted != "task/gen-2064" {
+		t.Errorf("expected stale branch force-deleted, got %q", forceDeleted)
+	}
+	if !pruned {
+		t.Error("expected WorktreePrune to be called during recovery")
+	}
+	if recreatedBranch != "task/gen-2064" {
+		t.Errorf("expected branch recreated, got %q", recreatedBranch)
+	}
+}
+
+func TestCreateWorktree_StaleBranchRecoveryRetryFails(t *testing.T) {
+	// When the retry after stale branch cleanup also fails, the error
+	// should propagate without further retries.
+	gitDeps := StitchGitDeps{
+		RepoReader: &mockRepoReader{BranchExistsFn: func(name, dir string) bool { return true }},
+		BranchManager: &mockBranchManager{
+			ForceDeleteBranchFn: func(name, dir string) error { return nil },
+			CreateBranchFn:      func(name, dir string) error { return nil },
+		},
+		WorktreeManager: &mockWorktreeManager{
+			WorktreeAddFn: func(wtDir, branch, dir string) *exec.Cmd {
+				return exec.Command("false") // always fails
+			},
+			WorktreePruneFn: func(dir string) error { return nil },
+		},
+	}
+	task := StitchTask{
+		BranchName:  "task/gen-2064",
+		WorktreeDir: t.TempDir(),
+	}
+	err := CreateWorktree(task, gitDeps)
+	if err == nil {
+		t.Fatal("expected error when retry also fails")
+	}
+}
+
+func TestCreateWorktree_StaleBranchDeleteFails(t *testing.T) {
+	// When the stale branch cannot be force-deleted, the original error
+	// and the cleanup error should both be reported.
+	gitDeps := StitchGitDeps{
+		RepoReader: &mockRepoReader{BranchExistsFn: func(name, dir string) bool { return true }},
+		BranchManager: &mockBranchManager{
+			ForceDeleteBranchFn: func(name, dir string) error { return fmt.Errorf("branch locked") },
+		},
+		WorktreeManager: &mockWorktreeManager{
+			WorktreeAddFn: func(wtDir, branch, dir string) *exec.Cmd {
+				return exec.Command("false")
+			},
+		},
+	}
+	task := StitchTask{
+		BranchName:  "task/gen-2064",
+		WorktreeDir: t.TempDir(),
+	}
+	err := CreateWorktree(task, gitDeps)
+	if err == nil {
+		t.Fatal("expected error when stale branch delete fails")
+	}
+}
+
+func TestCreateWorktree_WorktreeAddFailsNoBranch(t *testing.T) {
+	// When WorktreeAdd fails but the branch does not exist (not a stale
+	// branch scenario), the error should propagate without recovery.
+	branchExistsCalls := 0
+	gitDeps := StitchGitDeps{
+		RepoReader: &mockRepoReader{BranchExistsFn: func(name, dir string) bool {
+			branchExistsCalls++
+			if branchExistsCalls == 1 {
+				return false // branch doesn't exist initially
+			}
+			return false // still doesn't exist when checking for stale recovery
+		}},
+		BranchManager: &mockBranchManager{
+			CreateBranchFn: func(name, dir string) error { return nil },
+		},
+		WorktreeManager: &mockWorktreeManager{
+			WorktreeAddFn: func(wtDir, branch, dir string) *exec.Cmd {
+				return exec.Command("false")
+			},
+		},
+	}
+	task := StitchTask{
+		BranchName:  "task/gen-999",
+		WorktreeDir: t.TempDir(),
+	}
+	err := CreateWorktree(task, gitDeps)
+	if err == nil {
+		t.Fatal("expected error when WorktreeAdd fails without stale branch")
+	}
+}
+
 // ---------------------------------------------------------------------------
 // MergeBranch
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

When a stitch task fails mid-execution (e.g., process kill, suspend), the worktree directory gets cleaned up but the git branch can survive. On restart, CreateWorktree fails with exit 128 because the branch already exists, and the generator loop retries the same task forever. This fix makes CreateWorktree self-healing: on WorktreeAdd failure, if the branch exists, it force-deletes the stale branch, prunes worktree bookkeeping, recreates the branch from HEAD, and retries once.

## Changes

- Modified CreateWorktree in pkg/orchestrator/internal/generate/stitch.go to detect and recover from stale task branches
- Added 4 unit tests covering: successful recovery, retry failure, delete failure, and non-stale failure path

## Stats

- 2 files changed, +156 lines
- go_loc_prod: 18881 -> ~18911 (+30)
- go_loc_test: 33795 -> ~33921 (+126)

## Test plan

- [x] go test ./pkg/orchestrator/internal/generate/ -count=1 passes
- [x] go test ./pkg/orchestrator/ -count=1 -run TestCreateWorktree passes
- [ ] mage analyze passes (pre-existing gaps in prd004-006, unrelated)

Closes #1561