### PR TITLE
GH-1604: Fix ExtractDescriptionFiles frontmatter parsing

### DIFF
--- a/pkg/orchestrator/internal/github/issues.go
+++ b/pkg/orchestrator/internal/github/issues.go
@@ -257,12 +257,17 @@ func NormalizeIssueTitle(title string) string {
 // and returns the set of file paths. Returns nil if parsing fails or no files
 // are found. Works with both CobblerIssue.Description and ProposedIssue.Description.
 func ExtractDescriptionFiles(description string) []string {
+	// Strip cobbler frontmatter if present (GH-1604). GitHub issue bodies
+	// have frontmatter prepended by CreateCobblerIssue; yaml.Unmarshal only
+	// parses the first YAML document, missing the files section entirely.
+	_, desc := ParseIssueFrontMatter(description)
+
 	var parsed struct {
 		Files []struct {
 			Path string `yaml:"path"`
 		} `yaml:"files"`
 	}
-	if err := yaml.Unmarshal([]byte(description), &parsed); err != nil {
+	if err := yaml.Unmarshal([]byte(desc), &parsed); err != nil {
 		return nil
 	}
 	var paths []string

--- a/pkg/orchestrator/internal/github/issues_test.go
+++ b/pkg/orchestrator/internal/github/issues_test.go
@@ -1219,3 +1219,39 @@ func TestGoModModulePath_ModuleWithComment(t *testing.T) {
 		t.Errorf("GoModModulePath = %q, want github.com/org/repo", got)
 	}
 }
+
+// --- ExtractDescriptionFiles (GH-1604) ---
+
+func TestExtractDescriptionFiles_WithFrontmatter(t *testing.T) {
+	t.Parallel()
+	body := "---\ncobbler_generation: generation-gh-2607-run35\ncobbler_index: 0\n---\n\n" +
+		"deliverable_type: code\nfiles:\n  - path: pkg/testutils/difftest.go\n  - path: pkg/testutils/build.go\n"
+	got := ExtractDescriptionFiles(body)
+	want := []string{"pkg/testutils/difftest.go", "pkg/testutils/build.go"}
+	if len(got) != len(want) {
+		t.Fatalf("ExtractDescriptionFiles returned %d paths, want %d: %v", len(got), len(want), got)
+	}
+	for i, g := range got {
+		if g != want[i] {
+			t.Errorf("path[%d] = %q, want %q", i, g, want[i])
+		}
+	}
+}
+
+func TestExtractDescriptionFiles_WithoutFrontmatter(t *testing.T) {
+	t.Parallel()
+	body := "deliverable_type: code\nfiles:\n  - path: pkg/foo/bar.go\n"
+	got := ExtractDescriptionFiles(body)
+	if len(got) != 1 || got[0] != "pkg/foo/bar.go" {
+		t.Errorf("ExtractDescriptionFiles = %v, want [pkg/foo/bar.go]", got)
+	}
+}
+
+func TestExtractDescriptionFiles_NoFiles(t *testing.T) {
+	t.Parallel()
+	body := "---\ncobbler_generation: gen1\ncobbler_index: 0\n---\n\ndeliverable_type: docs\n"
+	got := ExtractDescriptionFiles(body)
+	if len(got) != 0 {
+		t.Errorf("ExtractDescriptionFiles = %v, want nil/empty", got)
+	}
+}


### PR DESCRIPTION
## Summary

`ExtractDescriptionFiles` failed to parse file paths from GitHub issue bodies because `yaml.Unmarshal` only parsed the frontmatter document, never reaching the `files` section. This made the entire file-overlap dedup in measure dead code. The fix calls `ParseIssueFrontMatter` to strip frontmatter before parsing.

## Changes

- `pkg/orchestrator/internal/github/issues.go`: Added `ParseIssueFrontMatter` call in `ExtractDescriptionFiles` to strip cobbler frontmatter before YAML parsing
- `pkg/orchestrator/internal/github/issues_test.go`: Added 3 tests covering frontmatter, no-frontmatter, and no-files cases

## Stats

- prod LOC: +4 (one comment block + one function call)
- test LOC: +38

## Test plan

- [x] `TestExtractDescriptionFiles_WithFrontmatter` passes
- [x] `TestExtractDescriptionFiles_WithoutFrontmatter` passes
- [x] `TestExtractDescriptionFiles_NoFiles` passes
- [x] All existing tests pass (`go test ./pkg/orchestrator/... -count=1`)

Closes #1604