### PR TITLE
GH-1608: generator:start creates its own git worktree

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -65,6 +65,10 @@ var errTaskReset = generate.ErrTaskReset
 // generation was started from, stored inside the cobbler directory.
 const baseBranchFile = generate.BaseBranchFile
 
+// repoRootFile records the main repository root path so GeneratorStop
+// can find the main repo when running inside a worktree.
+const repoRootFile = generate.RepoRootFile
+
 // tagSuffixes lists the lifecycle tag suffixes in order.
 var tagSuffixes = generate.TagSuffixes
 
@@ -711,10 +715,35 @@ func (o *Orchestrator) GeneratorStart() error {
 		return fmt.Errorf("tagging base branch: %w", err)
 	}
 
-	// Create and switch to generation branch.
-	logf("generator:start: creating branch")
-	if err := gitCheckoutNew(genName, "."); err != nil {
+	// Resolve the main repo root before creating the worktree. All
+	// subsequent operations will run inside the worktree via os.Chdir.
+	repoRoot, err := filepath.Abs(".")
+	if err != nil {
+		return fmt.Errorf("resolving repo root: %w", err)
+	}
+
+	// Create a sibling worktree for the generation branch. The main repo
+	// stays on the base branch so generator:stop does not accidentally
+	// merge into the wrong place (GH-1608).
+	worktreeDir := filepath.Join(filepath.Dir(repoRoot), genName)
+	logf("generator:start: creating worktree at %s", worktreeDir)
+
+	if err := gitCreateBranch(genName, "."); err != nil {
 		return fmt.Errorf("creating branch: %w", err)
+	}
+	cmd := gitWorktreeAdd(worktreeDir, genName, ".")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		// Clean up the branch if worktree creation fails.
+		_ = gitDeleteBranch(genName, ".")
+		return fmt.Errorf("creating worktree: %w", err)
+	}
+
+	// Switch into the worktree so all subsequent operations (source reset,
+	// squash, etc.) run there rather than in the main repo.
+	if err := os.Chdir(worktreeDir); err != nil {
+		return fmt.Errorf("switching to worktree: %w", err)
 	}
 
 	// Record branch point so intermediate commits can be squashed.
@@ -727,6 +756,12 @@ func (o *Orchestrator) GeneratorStart() error {
 	// (prd002 R2.8).
 	if err := o.writeBaseBranch(baseBranch); err != nil {
 		return fmt.Errorf("recording base branch: %w", err)
+	}
+
+	// Record the main repo root so GeneratorStop can find it from the
+	// worktree (GH-1608).
+	if err := o.writeRepoRoot(repoRoot); err != nil {
+		return fmt.Errorf("recording repo root: %w", err)
 	}
 
 	// Ensure bin/ is ignored on the generation branch so compiled binaries
@@ -776,7 +811,8 @@ func (o *Orchestrator) GeneratorStart() error {
 		return fmt.Errorf("committing clean state: %w", err)
 	}
 
-	logf("generator:start: done, run mage generator:run to begin building")
+	logf("generator:start: done, worktree is at %s", worktreeDir)
+	logf("generator:start: run mage generator:run to begin building")
 	return nil
 }
 
@@ -787,6 +823,26 @@ func (o *Orchestrator) writeBaseBranch(branch string) error {
 		return fmt.Errorf("creating %s: %w", dir, err)
 	}
 	return os.WriteFile(filepath.Join(dir, baseBranchFile), []byte(branch+"\n"), 0o644)
+}
+
+// writeRepoRoot writes the main repository root path to .cobbler/repo-root.
+// GeneratorStop reads this to locate the main repo when running inside a worktree.
+func (o *Orchestrator) writeRepoRoot(root string) error {
+	dir := o.cfg.Cobbler.Dir
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("creating %s: %w", dir, err)
+	}
+	return os.WriteFile(filepath.Join(dir, repoRootFile), []byte(root+"\n"), 0o644)
+}
+
+// readRepoRoot reads the main repository root from .cobbler/repo-root.
+// Returns "" if the file does not exist (pre-worktree generations).
+func (o *Orchestrator) readRepoRoot() string {
+	data, err := os.ReadFile(filepath.Join(o.cfg.Cobbler.Dir, repoRootFile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
 }
 
 // readBaseBranch reads the base branch from .cobbler/base-branch on the
@@ -807,6 +863,10 @@ func (o *Orchestrator) readBaseBranch() string {
 // GeneratorStop completes a generation trail and merges it into the base branch.
 // Reads the base branch from .cobbler/base-branch (falls back to "main").
 // Uses Config.GenerationBranch, current branch, or auto-detects.
+//
+// When running inside a worktree created by GeneratorStart (GH-1608), the
+// function tags the generation in the worktree, switches to the main repo for
+// the merge, and removes the worktree afterward.
 func (o *Orchestrator) GeneratorStop() error {
 	branch := o.cfg.Generation.Branch
 	if branch != "" {
@@ -841,6 +901,18 @@ func (o *Orchestrator) GeneratorStop() error {
 
 	logf("generator:stop: beginning")
 
+	// Detect whether we are inside a worktree created by GeneratorStart.
+	repoRoot := o.readRepoRoot()
+	var worktreeDir string
+	if repoRoot != "" {
+		var err error
+		worktreeDir, err = filepath.Abs(".")
+		if err != nil {
+			return fmt.Errorf("resolving worktree directory: %w", err)
+		}
+		logf("generator:stop: running in worktree %s (main repo: %s)", worktreeDir, repoRoot)
+	}
+
 	// Capture the caller's branch before switching to the generation branch.
 	callerBranch, err := gitCurrentBranch(".")
 	if err != nil {
@@ -854,9 +926,13 @@ func (o *Orchestrator) GeneratorStop() error {
 
 	// Determine the merge target (GH-523).
 	recordedBase := o.readBaseBranch()
-	baseBranch := resolveStopTarget(callerBranch, branch, recordedBase)
-	if baseBranch != recordedBase {
-		logf("generator:stop: caller was on %s; using it as merge target instead of recorded base %s", callerBranch, recordedBase)
+	baseBranch := recordedBase
+	if repoRoot == "" {
+		// Legacy path (no worktree): respect caller branch override.
+		baseBranch = resolveStopTarget(callerBranch, branch, recordedBase)
+		if baseBranch != recordedBase {
+			logf("generator:stop: caller was on %s; using it as merge target instead of recorded base %s", callerBranch, recordedBase)
+		}
 	}
 
 	// Commit any uncommitted history files (orchestrator logs, late stats)
@@ -873,10 +949,18 @@ func (o *Orchestrator) GeneratorStop() error {
 		return fmt.Errorf("tagging generation: %w", err)
 	}
 
-	// Switch to the base branch.
-	logf("generator:stop: switching to %s", baseBranch)
-	if err := gitCheckout(baseBranch, "."); err != nil {
-		return fmt.Errorf("checking out %s: %w", baseBranch, err)
+	// If running in a worktree, switch to the main repo for the merge.
+	if repoRoot != "" {
+		logf("generator:stop: switching to main repo at %s", repoRoot)
+		if err := os.Chdir(repoRoot); err != nil {
+			return fmt.Errorf("switching to main repo: %w", err)
+		}
+	} else {
+		// Legacy path: switch to the base branch in the current repo.
+		logf("generator:stop: switching to %s", baseBranch)
+		if err := gitCheckout(baseBranch, "."); err != nil {
+			return fmt.Errorf("checking out %s: %w", baseBranch, err)
+		}
 	}
 
 	// Clean up untracked history files on the base branch so they don't
@@ -884,6 +968,18 @@ func (o *Orchestrator) GeneratorStop() error {
 	// finished tag above (GH-1452).
 	if err := o.HistoryClean(); err != nil {
 		logf("generator:stop: warning clearing history: %v", err)
+	}
+
+	// Remove the worktree before merging so the generation branch is not
+	// locked by the worktree checkout. mergeGeneration deletes the branch
+	// after a successful merge; git refuses to delete a branch that is
+	// checked out in any worktree (GH-1608).
+	if worktreeDir != "" {
+		logf("generator:stop: removing worktree %s", worktreeDir)
+		if err := gitWorktreeRemove(worktreeDir, "."); err != nil {
+			logf("generator:stop: worktree remove warning: %v", err)
+		}
+		_ = gitWorktreePrune(".")
 	}
 
 	if err := o.mergeGeneration(branch, baseBranch); err != nil {

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -813,6 +813,174 @@ func TestGeneratorStart_AddsBinToGitignore(t *testing.T) {
 	}
 }
 
+// --- GeneratorStart worktree lifecycle (git, NOT parallel, GH-1608) ---
+
+// TestGeneratorStart_CreatesWorktree verifies that GeneratorStart creates a
+// sibling worktree and leaves the main repo on the original branch.
+func TestGeneratorStart_CreatesWorktree(t *testing.T) {
+	repoDir := initTestGitRepo(t)
+
+	o := &Orchestrator{cfg: Config{
+		Generation: GenerationConfig{
+			Prefix:          "generation-",
+			Name:            "wt-test",
+			PreserveSources: true,
+		},
+		Project: ProjectConfig{MagefilesDir: "magefiles"},
+		Cobbler: CobblerConfig{Dir: ".cobbler/"},
+	}}
+
+	if err := o.GeneratorStart(); err != nil {
+		t.Fatalf("GeneratorStart() error = %v", err)
+	}
+
+	// After GeneratorStart, CWD should be inside the worktree.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	worktreeDir := filepath.Join(filepath.Dir(repoDir), "generation-wt-test")
+	// Resolve symlinks for macOS /private/var/folders vs /var/folders.
+	cwdReal, _ := filepath.EvalSymlinks(cwd)
+	wtReal, _ := filepath.EvalSymlinks(worktreeDir)
+	if cwdReal != wtReal {
+		t.Errorf("CWD = %q, want worktree %q", cwdReal, wtReal)
+	}
+
+	// The worktree should be on the generation branch.
+	branch, err := gitCurrentBranch("")
+	if err != nil {
+		t.Fatalf("gitCurrentBranch in worktree: %v", err)
+	}
+	if branch != "generation-wt-test" {
+		t.Errorf("worktree branch = %q, want %q", branch, "generation-wt-test")
+	}
+
+	// The main repo should still be on main.
+	mainBranch, err := gitCurrentBranch(repoDir)
+	if err != nil {
+		t.Fatalf("gitCurrentBranch in main repo: %v", err)
+	}
+	if mainBranch != "main" {
+		t.Errorf("main repo branch = %q, want %q", mainBranch, "main")
+	}
+
+	// The repo-root file should record the main repo path.
+	repoRoot := o.readRepoRoot()
+	repoRootReal, _ := filepath.EvalSymlinks(repoRoot)
+	repoDirReal, _ := filepath.EvalSymlinks(repoDir)
+	if repoRootReal != repoDirReal {
+		t.Errorf("readRepoRoot() = %q, want %q", repoRootReal, repoDirReal)
+	}
+}
+
+// TestGeneratorStart_WorktreeRecordsRepoRoot verifies that writeRepoRoot and
+// readRepoRoot round-trip correctly.
+func TestGeneratorStart_WorktreeRecordsRepoRoot(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &Orchestrator{cfg: Config{
+		Cobbler: CobblerConfig{Dir: filepath.Join(dir, ".cobbler")},
+	}}
+
+	if err := o.writeRepoRoot("/some/path"); err != nil {
+		t.Fatalf("writeRepoRoot: %v", err)
+	}
+	got := o.readRepoRoot()
+	if got != "/some/path" {
+		t.Errorf("readRepoRoot() = %q, want %q", got, "/some/path")
+	}
+}
+
+// TestGeneratorStart_WorktreeReadRepoRoot_Missing verifies readRepoRoot
+// returns "" when the file is absent (pre-worktree generations).
+func TestGeneratorStart_WorktreeReadRepoRoot_Missing(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	o := &Orchestrator{cfg: Config{
+		Cobbler: CobblerConfig{Dir: filepath.Join(dir, ".cobbler")},
+	}}
+	got := o.readRepoRoot()
+	if got != "" {
+		t.Errorf("readRepoRoot() = %q, want empty string", got)
+	}
+}
+
+// TestGeneratorStop_CleansUpWorktree verifies the full start→stop lifecycle:
+// GeneratorStart creates a worktree, GeneratorStop merges and removes it.
+func TestGeneratorStop_CleansUpWorktree(t *testing.T) {
+	repoDir := initTestGitRepo(t)
+
+	o := &Orchestrator{cfg: Config{
+		Generation: GenerationConfig{
+			Prefix:          "generation-",
+			Name:            "stop-test",
+			PreserveSources: true,
+		},
+		Project: ProjectConfig{MagefilesDir: "magefiles"},
+		Cobbler: CobblerConfig{Dir: ".cobbler/"},
+	}}
+
+	if err := o.GeneratorStart(); err != nil {
+		t.Fatalf("GeneratorStart() error = %v", err)
+	}
+
+	worktreeDir := filepath.Join(filepath.Dir(repoDir), "generation-stop-test")
+
+	// Verify worktree exists.
+	if _, err := os.Stat(worktreeDir); os.IsNotExist(err) {
+		t.Fatalf("worktree directory does not exist after GeneratorStart")
+	}
+
+	// Create a file in the worktree to verify it gets merged.
+	testFile := filepath.Join(worktreeDir, "test-output.txt")
+	if err := os.WriteFile(testFile, []byte("generated\n"), 0o644); err != nil {
+		t.Fatalf("writing test file: %v", err)
+	}
+	_ = gitStageAll(".")
+	_ = gitCommit("Add test output", ".")
+
+	if err := o.GeneratorStop(); err != nil {
+		t.Fatalf("GeneratorStop() error = %v", err)
+	}
+
+	// After stop, CWD should be back in the main repo.
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	cwdReal, _ := filepath.EvalSymlinks(cwd)
+	repoDirReal, _ := filepath.EvalSymlinks(repoDir)
+	if cwdReal != repoDirReal {
+		t.Errorf("CWD after stop = %q, want main repo %q", cwdReal, repoDirReal)
+	}
+
+	// The main repo should be on the base branch.
+	branch, err := gitCurrentBranch("")
+	if err != nil {
+		t.Fatalf("gitCurrentBranch: %v", err)
+	}
+	if branch != "main" {
+		t.Errorf("branch after stop = %q, want %q", branch, "main")
+	}
+
+	// The worktree directory should be removed.
+	if _, err := os.Stat(worktreeDir); !os.IsNotExist(err) {
+		t.Errorf("worktree directory still exists after GeneratorStop")
+	}
+
+	// The generation branch should be deleted.
+	if gitBranchExists("generation-stop-test", "") {
+		t.Errorf("generation branch still exists after GeneratorStop")
+	}
+
+	// The test file should be present via merge.
+	merged := filepath.Join(repoDir, "test-output.txt")
+	if _, err := os.Stat(merged); os.IsNotExist(err) {
+		t.Errorf("test-output.txt not present on main after merge")
+	}
+}
+
 // --- appendToGitignore (parallel-safe, no git) ---
 
 func TestAppendToGitignore_CreatesFileWhenMissing(t *testing.T) {

--- a/pkg/orchestrator/internal/generate/generator.go
+++ b/pkg/orchestrator/internal/generate/generator.go
@@ -37,6 +37,11 @@ var (
 // generation was started from, stored inside the cobbler directory.
 const BaseBranchFile = "base-branch"
 
+// RepoRootFile is the name of the file that records the main repository
+// root path, stored inside the cobbler directory. GeneratorStart writes
+// this when it creates a worktree so GeneratorStop can find the main repo.
+const RepoRootFile = "repo-root"
+
 // TagSuffixes lists the lifecycle tag suffixes in order.
 var TagSuffixes = []string{"-start", "-finished", "-merged", "-abandoned"}
 


### PR DESCRIPTION
## Summary

`GeneratorStart` now creates a sibling git worktree instead of checking out the generation branch in the main repo. This prevents accidental merges into `main` that have occurred multiple times in production runs.

## Changes

- `GeneratorStart` creates a worktree at `../<generation-name>` via `gitCreateBranch` + `gitWorktreeAdd`, then `os.Chdir` into it. All subsequent operations (source reset, squash, etc.) run in the worktree.
- `GeneratorStop` reads `.cobbler/repo-root` to detect worktree mode, switches to the main repo for the merge, removes the worktree before `mergeGeneration` so the branch is not locked, then proceeds as before.
- New `RepoRootFile` constant and `writeRepoRoot`/`readRepoRoot` methods for worktree-to-main-repo path tracking.
- Legacy non-worktree path preserved for backward compatibility with older generations.

## Stats

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| go_loc_prod | 18997 | 18944 | -53 |
| go_loc_test | 34188 | 34356 | +168 |

## Test plan

- [x] `mage analyze` passes
- [x] All existing tests pass (16.9s full suite)
- [x] 4 new tests verify worktree lifecycle:
  - `TestGeneratorStart_CreatesWorktree` — worktree created, main repo stays on original branch
  - `TestGeneratorStart_WorktreeRecordsRepoRoot` — write/read round-trip
  - `TestGeneratorStart_WorktreeReadRepoRoot_Missing` — backward compat
  - `TestGeneratorStop_CleansUpWorktree` — full start→stop: merge, worktree removed, branch deleted

Closes #1608