### PR TITLE
GH-1645: Fix double-parent sub-issue linking in measure flow

### DIFF
--- a/pkg/orchestrator/internal/github/issues.go
+++ b/pkg/orchestrator/internal/github/issues.go
@@ -559,6 +559,15 @@ func (t *GitHubTracker) FinalizeMeasurePlaceholder(repo string, number int, gene
 		t.Log("finalizeMeasurePlaceholder: add label #%d warning: %v", number, err)
 	}
 
+	// Link this measure issue as a sub-issue of the generation parent (GH-1645).
+	// Stitch issues are then linked as sub-issues of this measure issue,
+	// giving the hierarchy: generation → measure → stitch.
+	if parentNumber := ExtractParentIssueNumber(generation); parentNumber > 0 {
+		if err := t.LinkSubIssue(repo, parentNumber, number); err != nil {
+			t.Log("finalizeMeasurePlaceholder: linkSubIssue measure #%d -> parent #%d warning: %v", number, parentNumber, err)
+		}
+	}
+
 	// Link created stitch issues as sub-issues of this measure issue.
 	for _, child := range childIssues {
 		if err := t.LinkSubIssue(repo, number, child); err != nil {
@@ -606,13 +615,6 @@ func (t *GitHubTracker) CreateCobblerIssue(repo, generation string, issue Propos
 	}
 	t.Log("createCobblerIssue: created #%d %q gen=%s index=%d dep=%d",
 		number, title, generation, issue.Index, issue.Dependency)
-
-	// Link as sub-issue of the parent, if the generation name encodes one (GH-566).
-	if parentNumber := ExtractParentIssueNumber(generation); parentNumber > 0 {
-		if err := t.LinkSubIssue(repo, parentNumber, number); err != nil {
-			t.Log("createCobblerIssue: linkSubIssue warning for #%d -> parent #%d: %v", number, parentNumber, err)
-		}
-	}
 
 	return number, nil
 }


### PR DESCRIPTION
## Summary

Moves the generation→stitch `LinkSubIssue` call from `CreateCobblerIssue` to `FinalizeMeasurePlaceholder` so the sub-issue hierarchy is generation → measure → stitch. Previously each stitch issue was linked directly to the generation parent, then `FinalizeMeasurePlaceholder` tried to re-link it to the measure issue, causing GitHub HTTP 422 errors.

## Changes

- Removed `LinkSubIssue` call from `CreateCobblerIssue` (stitch issues no longer link directly to generation parent)
- Added `LinkSubIssue` call in `FinalizeMeasurePlaceholder` to link the measure issue itself to the generation parent
- Stitch→measure linking in `FinalizeMeasurePlaceholder` remains unchanged

## Test plan

- [x] `go build ./pkg/orchestrator/...` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)

Closes #1645