### PR TITLE
GH-1646: Remove intra-batch file overlap dedup

### DIFF
--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -614,11 +614,11 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 			continue
 		}
 		filtered = append(filtered, issue)
-		// Track accepted issue for intra-batch dedup (GH-1605).
+		// Track accepted title for intra-batch dedup (GH-1605).
+		// File overlap is only checked against existing GitHub issues, not
+		// within the same batch — tasks in the same package naturally share
+		// files and are not duplicates (GH-1646).
 		existingTitles[norm] = issue.Index
-		for _, fp := range extractDescriptionFiles(issue.Description) {
-			existingFiles[fp] = issue.Index
-		}
 	}
 	issues = filtered
 


### PR DESCRIPTION
## Summary

Removes intra-batch file overlap dedup from `importIssues`. When `max_measure_issues > 1`, tasks in the same batch naturally share files within a package and are not duplicates. File overlap is now only checked against existing GitHub issues. Intra-batch title dedup is retained.

## Changes

- Removed intra-batch file tracking from the dedup loop in `importIssues` (`measure.go`)
- Kept intra-batch title tracking to prevent exact title duplicates

## Test plan

- [x] `go build ./pkg/orchestrator/...` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)

Closes #1646