### PR TITLE
GH-1632: Migrate direct git exec.Command calls to gitops interface

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -246,7 +246,7 @@ func formatOutcomeTrailers(rec InvocationRecord) []string {
 
 // appendOutcomeTrailers amends the last commit with outcome trailers.
 func appendOutcomeTrailers(worktreeDir string, rec InvocationRecord) error {
-	return claude.AppendOutcomeTrailers(worktreeDir, rec)
+	return claude.AppendOutcomeTrailers(worktreeDir, rec, defaultGitOps.CommitAmendTrailers)
 }
 
 // worktreeBasePath returns the directory used for stitch worktrees.

--- a/pkg/orchestrator/internal/claude/claude.go
+++ b/pkg/orchestrator/internal/claude/claude.go
@@ -396,18 +396,15 @@ func FormatOutcomeTrailers(rec InvocationRecord) []string {
 	}
 }
 
+// CommitAmendTrailersFn is a function that amends the last commit with trailers.
+// Injected by the parent package to use the gitops interface (GH-1632).
+type CommitAmendTrailersFn func(dir string, trailers []string) error
+
 // AppendOutcomeTrailers amends the last commit in the given git worktree
-// directory with outcome trailers from rec.
-func AppendOutcomeTrailers(worktreeDir string, rec InvocationRecord) error {
-	args := []string{"-C", worktreeDir, "commit", "--amend", "--no-edit"}
-	for _, t := range FormatOutcomeTrailers(rec) {
-		args = append(args, "--trailer", t)
-	}
-	cmd := exec.Command(BinGit, args...)
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return fmt.Errorf("git commit --amend: %w\n%s", err, out)
-	}
-	return nil
+// directory with outcome trailers from rec. The amendFn parameter provides
+// the git amend implementation (typically gitops.CommitAmendTrailers).
+func AppendOutcomeTrailers(worktreeDir string, rec InvocationRecord, amendFn CommitAmendTrailersFn) error {
+	return amendFn(worktreeDir, FormatOutcomeTrailers(rec))
 }
 
 // WorktreeBasePath returns the directory used for stitch worktrees.

--- a/pkg/orchestrator/internal/generate/gitdeps_test.go
+++ b/pkg/orchestrator/internal/generate/gitdeps_test.go
@@ -113,8 +113,9 @@ type mockCommitWriter struct {
 	HasChangesFn       func(dir string) bool
 	StashFn            func(msg, dir string) error
 	CommitFn           func(msg, dir string) error
-	CommitAllowEmptyFn func(msg, dir string) error
-	ResetSoftFn        func(ref, dir string) error
+	CommitAllowEmptyFn     func(msg, dir string) error
+	CommitAmendTrailersFn func(dir string, trailers []string) error
+	ResetSoftFn            func(ref, dir string) error
 }
 
 func (m *mockCommitWriter) StageAll(dir string) error {
@@ -156,6 +157,12 @@ func (m *mockCommitWriter) Commit(msg, dir string) error {
 func (m *mockCommitWriter) CommitAllowEmpty(msg, dir string) error {
 	if m.CommitAllowEmptyFn != nil {
 		return m.CommitAllowEmptyFn(msg, dir)
+	}
+	return nil
+}
+func (m *mockCommitWriter) CommitAmendTrailers(dir string, trailers []string) error {
+	if m.CommitAmendTrailersFn != nil {
+		return m.CommitAmendTrailersFn(dir, trailers)
 	}
 	return nil
 }

--- a/pkg/orchestrator/internal/gitops/gitops.go
+++ b/pkg/orchestrator/internal/gitops/gitops.go
@@ -58,6 +58,7 @@ type GitOps interface {
 	Stash(msg, dir string) error
 	Commit(msg, dir string) error
 	CommitAllowEmpty(msg, dir string) error
+	CommitAmendTrailers(dir string, trailers []string) error
 	RevParseHEAD(dir string) (string, error)
 	ResetSoft(ref, dir string) error
 	MergeCmd(branch, dir string) *exec.Cmd
@@ -118,6 +119,7 @@ type CommitWriter interface {
 	Stash(msg, dir string) error
 	Commit(msg, dir string) error
 	CommitAllowEmpty(msg, dir string) error
+	CommitAmendTrailers(dir string, trailers []string) error
 	ResetSoft(ref, dir string) error
 }
 
@@ -287,6 +289,18 @@ func (g *ShellGitOps) Commit(msg, dir string) error {
 
 func (g *ShellGitOps) CommitAllowEmpty(msg, dir string) error {
 	return g.cmdGit(dir, "commit", "--no-verify", "-m", msg, "--allow-empty").Run()
+}
+
+func (g *ShellGitOps) CommitAmendTrailers(dir string, trailers []string) error {
+	args := []string{"commit", "--amend", "--no-edit"}
+	for _, t := range trailers {
+		args = append(args, "--trailer", t)
+	}
+	out, err := g.cmdGit(dir, args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git commit --amend: %w\n%s", err, out)
+	}
+	return nil
 }
 
 func (g *ShellGitOps) RevParseHEAD(dir string) (string, error) {

--- a/pkg/orchestrator/internal/gitops/gitops_test.go
+++ b/pkg/orchestrator/internal/gitops/gitops_test.go
@@ -130,8 +130,9 @@ type MockGitOps struct {
 	HasChangesFn       func(dir string) bool
 	StashFn            func(msg, dir string) error
 	CommitFn           func(msg, dir string) error
-	CommitAllowEmptyFn func(msg, dir string) error
-	RevParseHEADFn     func(dir string) (string, error)
+	CommitAllowEmptyFn     func(msg, dir string) error
+	CommitAmendTrailersFn func(dir string, trailers []string) error
+	RevParseHEADFn         func(dir string) (string, error)
 	ResetSoftFn        func(ref, dir string) error
 	MergeCmdFn         func(branch, dir string) *exec.Cmd
 	WorktreePruneFn    func(dir string) error
@@ -167,6 +168,7 @@ func (m *MockGitOps) HasChanges(dir string) bool               { return m.HasCha
 func (m *MockGitOps) Stash(msg, dir string) error              { return m.StashFn(msg, dir) }
 func (m *MockGitOps) Commit(msg, dir string) error             { return m.CommitFn(msg, dir) }
 func (m *MockGitOps) CommitAllowEmpty(msg, dir string) error   { return m.CommitAllowEmptyFn(msg, dir) }
+func (m *MockGitOps) CommitAmendTrailers(dir string, trailers []string) error { return m.CommitAmendTrailersFn(dir, trailers) }
 func (m *MockGitOps) RevParseHEAD(dir string) (string, error)  { return m.RevParseHEADFn(dir) }
 func (m *MockGitOps) ResetSoft(ref, dir string) error          { return m.ResetSoftFn(ref, dir) }
 func (m *MockGitOps) MergeCmd(branch, dir string) *exec.Cmd    { return m.MergeCmdFn(branch, dir) }

--- a/pkg/orchestrator/scaffold.go
+++ b/pkg/orchestrator/scaffold.go
@@ -446,16 +446,12 @@ func (o *Orchestrator) PrepareTestRepo(module, version, orchestratorRoot string)
 		return "", fmt.Errorf("git init: %w", err)
 	}
 
-	addCmd := exec.Command(binGit, "add", "-A")
-	addCmd.Dir = repoDir
-	if err := addCmd.Run(); err != nil {
+	if err := gitStageAll(repoDir); err != nil {
 		os.RemoveAll(workDir)
 		return "", fmt.Errorf("git add: %w", err)
 	}
 
-	commitCmd := exec.Command(binGit, "commit", "-m", "Initial commit from test-clone")
-	commitCmd.Dir = repoDir
-	if err := commitCmd.Run(); err != nil {
+	if err := gitCommit("Initial commit from test-clone", repoDir); err != nil {
 		os.RemoveAll(workDir)
 		return "", fmt.Errorf("git commit: %w", err)
 	}
@@ -486,16 +482,12 @@ func (o *Orchestrator) PrepareTestRepo(module, version, orchestratorRoot string)
 	}
 
 	// Commit scaffold artifacts so the working tree is clean.
-	addCmd2 := exec.Command(binGit, "add", "-A")
-	addCmd2.Dir = repoDir
-	if err := addCmd2.Run(); err != nil {
+	if err := gitStageAll(repoDir); err != nil {
 		os.RemoveAll(workDir)
 		return "", fmt.Errorf("git add scaffold: %w", err)
 	}
 
-	commitCmd2 := exec.Command(binGit, "commit", "-m", "Add orchestrator scaffold")
-	commitCmd2.Dir = repoDir
-	if err := commitCmd2.Run(); err != nil {
+	if err := gitCommit("Add orchestrator scaffold", repoDir); err != nil {
 		os.RemoveAll(workDir)
 		return "", fmt.Errorf("git commit scaffold: %w", err)
 	}


### PR DESCRIPTION
## Summary

Migrates 5 direct git exec.Command calls to the gitops interface. Adds CommitAmendTrailers to the interface for the commit-amend-with-trailers pattern used by stitch outcome recording. Two documented exceptions (git init, git rev-parse --git-common-dir) remain as direct calls.

## Changes

- Replaced 4 exec.Command calls in scaffold.go with gitStageAll/gitCommit wrappers
- Added CommitAmendTrailers to GitOps, CommitWriter interfaces and ShellGitOps implementation
- Updated claude.AppendOutcomeTrailers to accept amend function parameter
- Updated cobbler.go wrapper to pass defaultGitOps.CommitAmendTrailers
- Updated mocks in gitops_test.go and gitdeps_test.go

## Test plan

- [x] `go build ./pkg/orchestrator/...` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)
- [x] No remaining direct git exec.Command outside gitops and documented exceptions

Closes #1632