### PR TITLE
GH-1644: Recurring: Run mage test:usecase and fix failures

### DIFF
--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -54,6 +54,12 @@ func cobblerGenLabel(generation string) string {
 	return gh.GenLabel(generation)
 }
 
+// CobblerGenLabel returns the GitHub label name for a generation. Exported
+// for use by e2e tests that need label-safe generation names (GH-1644).
+func CobblerGenLabel(generation string) string {
+	return gh.GenLabel(generation)
+}
+
 func formatIssueFrontMatter(generation string, index, dependsOn int) string {
 	return gh.FormatIssueFrontMatter(generation, index, dependsOn)
 }

--- a/tests/rel01.0/internal/testutil/testutil.go
+++ b/tests/rel01.0/internal/testutil/testutil.go
@@ -460,17 +460,20 @@ func CreateIssue(t testing.TB, dir, title string) string {
 	}
 	generation := GitBranch(t, dir)
 
+	// Use GenLabel to get the label-safe generation name (handles 50-char GitHub limit).
+	genLabel := orchestrator.CobblerGenLabel(generation)
+
 	// Ensure all required labels exist before creating the issue.
 	ensureGitHubLabel(repo, "cobbler-ready", "0075ca", "Cobbler task ready to be picked by stitch")
 	ensureGitHubLabel(repo, "cobbler-in-progress", "e4e669", "Cobbler task currently being worked on")
-	ensureGitHubLabel(repo, "cobbler-gen-"+generation, "ededed", "Cobbler generation "+generation)
+	ensureGitHubLabel(repo, genLabel, "ededed", "Cobbler generation "+generation)
 
 	body := fmt.Sprintf("---\ncobbler_generation: %s\ncobbler_index: 0\n---\n\ncreated by e2e test",
 		generation)
 	cmd := exec.Command("gh", "issue", "create",
 		"--repo", repo,
 		"--title", title,
-		"--label", "cobbler-gen-"+generation,
+		"--label", genLabel,
 		"--label", "cobbler-ready",
 		"--body", body)
 	out, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Summary

Ran `mage test:usecase` (52/57 pass, 5 fail). Fixed 1 regression: e2e `CreateIssue` constructed generation labels that exceeded GitHub's 50-char limit. Other 4 failures are pre-existing Claude/LLM-flaky and GitHub API timing issues.

## Changes

- Exported `CobblerGenLabel` from orchestrator package for e2e test use
- Updated testutil `CreateIssue` to use `GenLabel` truncation instead of raw concatenation

## Test plan

- [x] All unit tests pass (`go test ./pkg/orchestrator/... -count=1`)
- [x] Test packages compile with `usecase` build tag

Closes #1644