### PR TITLE
GH-1687: Eliminate git wrapper indirection in commands.go

### DIFF
--- a/pkg/orchestrator/cobbler_test.go
+++ b/pkg/orchestrator/cobbler_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	claudetypes "github.com/schlunsen/claude-agent-sdk-go/types"
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/gitops"
 	"gopkg.in/yaml.v3"
 )
 
@@ -87,8 +88,8 @@ func TestParseNameStatus_AddedModifiedDeleted(t *testing.T) {
 	nsOutput := "A\tpkg/new.go\nM\tpkg/existing.go\nD\tpkg/removed.go\n"
 	numOutput := "50\t0\tpkg/new.go\n10\t5\tpkg/existing.go\n0\t30\tpkg/removed.go\n"
 
-	numMap := parseNumstat(numOutput)
-	files := parseNameStatus(nsOutput, numMap)
+	numMap := gitops.ParseNumstat(numOutput)
+	files := gitops.ParseNameStatus(nsOutput, numMap)
 
 	if len(files) != 3 {
 		t.Fatalf("got %d files, want 3", len(files))
@@ -125,8 +126,8 @@ func TestParseNameStatus_Renamed(t *testing.T) {
 	nsOutput := "R100\told/path.go\tnew/path.go\n"
 	numOutput := "5\t3\tnew/path.go\n"
 
-	numMap := parseNumstat(numOutput)
-	files := parseNameStatus(nsOutput, numMap)
+	numMap := gitops.ParseNumstat(numOutput)
+	files := gitops.ParseNameStatus(nsOutput, numMap)
 
 	if len(files) != 1 {
 		t.Fatalf("got %d files, want 1", len(files))
@@ -143,7 +144,7 @@ func TestParseNameStatus_Renamed(t *testing.T) {
 }
 
 func TestParseNameStatus_EmptyInput(t *testing.T) {
-	files := parseNameStatus("", nil)
+	files := gitops.ParseNameStatus("", nil)
 	if len(files) != 0 {
 		t.Errorf("got %d files, want 0", len(files))
 	}
@@ -151,7 +152,7 @@ func TestParseNameStatus_EmptyInput(t *testing.T) {
 
 func TestParseNumstat_BinaryFile(t *testing.T) {
 	output := "-\t-\timage.png\n10\t2\tREADME.md\n"
-	m := parseNumstat(output)
+	m := gitops.ParseNumstat(output)
 
 	if entry, ok := m["image.png"]; !ok {
 		t.Error("missing entry for image.png")
@@ -167,7 +168,7 @@ func TestParseNumstat_BinaryFile(t *testing.T) {
 }
 
 func TestParseNumstat_EmptyInput(t *testing.T) {
-	m := parseNumstat("")
+	m := gitops.ParseNumstat("")
 	if len(m) != 0 {
 		t.Errorf("got %d entries, want 0", len(m))
 	}
@@ -175,7 +176,7 @@ func TestParseNumstat_EmptyInput(t *testing.T) {
 
 func TestParseNumstat_ShortLine(t *testing.T) {
 	t.Parallel()
-	m := parseNumstat("10\n")
+	m := gitops.ParseNumstat("10\n")
 	if len(m) != 0 {
 		t.Errorf("got %d entries, want 0 for short line", len(m))
 	}
@@ -184,7 +185,7 @@ func TestParseNumstat_ShortLine(t *testing.T) {
 func TestParseNameStatus_Copied(t *testing.T) {
 	t.Parallel()
 	nsOutput := "C100\told/file.go\tnew/file.go\n"
-	files := parseNameStatus(nsOutput, nil)
+	files := gitops.ParseNameStatus(nsOutput, nil)
 	if len(files) != 1 {
 		t.Fatalf("got %d files, want 1", len(files))
 	}
@@ -198,7 +199,7 @@ func TestParseNameStatus_Copied(t *testing.T) {
 
 func TestParseNameStatus_ShortLine(t *testing.T) {
 	t.Parallel()
-	files := parseNameStatus("M\n", nil)
+	files := gitops.ParseNameStatus("M\n", nil)
 	if len(files) != 0 {
 		t.Errorf("got %d files, want 0 for line with no tab-separated path", len(files))
 	}

--- a/pkg/orchestrator/commands.go
+++ b/pkg/orchestrator/commands.go
@@ -8,7 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
-	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/gitops"
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/gitops" // diffStat alias, diffNameStatus conversion
 )
 
 // Binary names.
@@ -66,88 +66,13 @@ func init() {
 	}
 }
 
-// Git helpers.
-// Each function accepts a dir string parameter; when dir is non-empty it is
-// forwarded to exec.Cmd.Dir so the command runs in that directory rather than
-// the process-wide working directory. Pass "" to use the existing CWD (the
-// original behaviour, preserved for callers that rely on os.Chdir).
-//
-// All git functions delegate to the defaultGitOps instance.
-
-func gitCheckout(branch, dir string) error        { return defaultGitOps.Checkout(branch, dir) }
-func gitCheckoutNew(branch, dir string) error      { return defaultGitOps.CheckoutNew(branch, dir) }
-func gitCreateBranch(name, dir string) error       { return defaultGitOps.CreateBranch(name, dir) }
-func gitDeleteBranch(name, dir string) error       { return defaultGitOps.DeleteBranch(name, dir) }
-func gitForceDeleteBranch(name, dir string) error  { return defaultGitOps.ForceDeleteBranch(name, dir) }
-func gitBranchExists(name, dir string) bool        { return defaultGitOps.BranchExists(name, dir) }
-func gitListBranches(pattern, dir string) []string { return defaultGitOps.ListBranches(pattern, dir) }
-func gitTag(name, dir string) error                { return defaultGitOps.Tag(name, dir) }
-func gitDeleteTag(name, dir string) error          { return defaultGitOps.DeleteTag(name, dir) }
-func gitListTags(pattern, dir string) []string     { return defaultGitOps.ListTags(pattern, dir) }
-func gitLsFiles(dir string) []string               { return defaultGitOps.LsFiles(dir) }
-func gitStageAll(dir string) error                 { return defaultGitOps.StageAll(dir) }
-func gitStageDir(path, dir string) error           { return defaultGitOps.StageDir(path, dir) }
-func gitUnstageAll(dir string) error               { return defaultGitOps.UnstageAll(dir) }
-func gitHasChanges(dir string) bool                { return defaultGitOps.HasChanges(dir) }
-func gitStash(msg, dir string) error               { return defaultGitOps.Stash(msg, dir) }
-func gitCommit(msg, dir string) error              { return defaultGitOps.Commit(msg, dir) }
-func gitCommitAllowEmpty(msg, dir string) error    { return defaultGitOps.CommitAllowEmpty(msg, dir) }
-func gitResetSoft(ref, dir string) error           { return defaultGitOps.ResetSoft(ref, dir) }
-func gitWorktreePrune(dir string) error            { return defaultGitOps.WorktreePrune(dir) }
-
-// gitTagAt creates a tag pointing at the given ref (commit, tag, or branch).
-func gitTagAt(name, ref, dir string) error { return defaultGitOps.TagAt(name, ref, dir) }
-
-// gitRenameTag creates newName at the same commit as oldName, then
-// deletes oldName. Returns an error if the new tag cannot be created.
-func gitRenameTag(oldName, newName, dir string) error {
-	return defaultGitOps.RenameTag(oldName, newName, dir)
-}
-
-func gitRevParseHEAD(dir string) (string, error) { return defaultGitOps.RevParseHEAD(dir) }
-
-func gitMergeCmd(branch, dir string) *exec.Cmd { return defaultGitOps.MergeCmd(branch, dir) }
-
-// gitWorktreeAdd returns a Cmd that adds a worktree at worktreeDir on branch.
-// dir is the repository root used as cmd.Dir (empty means process CWD).
-func gitWorktreeAdd(worktreeDir, branch, dir string) *exec.Cmd {
-	return defaultGitOps.WorktreeAdd(worktreeDir, branch, dir)
-}
-
-// gitWorktreeRemove removes the worktree at worktreeDir.
-// dir is the repository root used as cmd.Dir (empty means process CWD).
-func gitWorktreeRemove(worktreeDir, dir string) error {
-	return defaultGitOps.WorktreeRemove(worktreeDir, dir)
-}
-
-func gitCurrentBranch(dir string) (string, error) { return defaultGitOps.CurrentBranch(dir) }
-
-// gitLsTreeFiles returns the list of file paths tracked at the given ref.
-func gitLsTreeFiles(ref, dir string) ([]string, error) {
-	return defaultGitOps.LsTreeFiles(ref, dir)
-}
-
-// gitShowFileContent returns the raw content of a file at the given ref.
-func gitShowFileContent(ref, path, dir string) ([]byte, error) {
-	return defaultGitOps.ShowFileContent(ref, path, dir)
-}
-
-// FileChange is defined in internal/claude and aliased in cobbler.go.
-
 // diffStat holds parsed output from git diff --shortstat.
 type diffStat = gitops.DiffStat
 
-// gitDiffShortstat runs git diff --shortstat against the given ref and
-// parses the output (e.g. "5 files changed, 100 insertions(+), 20 deletions(-)").
-func gitDiffShortstat(ref, dir string) (diffStat, error) {
-	return defaultGitOps.DiffShortstat(ref, dir)
-}
-
-// gitDiffNameStatus runs git diff --name-status and --numstat against the
-// given ref and returns per-file entries with path, status, insertions, and
-// deletions. The two commands are combined to produce complete file-level
-// change records.
-func gitDiffNameStatus(ref, dir string) ([]FileChange, error) {
+// diffNameStatus runs git diff --name-status and returns per-file entries,
+// converting from gitops.FileChange to claude.FileChange (aliased as
+// FileChange in cobbler.go).
+func diffNameStatus(ref, dir string) ([]FileChange, error) {
 	gfc, err := defaultGitOps.DiffNameStatus(ref, dir)
 	if err != nil {
 		return nil, err
@@ -162,28 +87,6 @@ func gitDiffNameStatus(ref, dir string) ([]FileChange, error) {
 		}
 	}
 	return files, nil
-}
-
-// parseBranchList parses the output of git branch --list or git tag --list.
-func parseBranchList(output string) []string {
-	return gitops.ParseBranchList(output)
-}
-
-// parseDiffShortstat extracts file/insertion/deletion counts from
-// git diff --shortstat output.
-func parseDiffShortstat(s string) diffStat {
-	return gitops.ParseDiffShortstat(s)
-}
-
-// parseNumstat parses git diff --numstat output into a map keyed by file path.
-func parseNumstat(output string) map[string]gitops.NumstatEntry {
-	return gitops.ParseNumstat(output)
-}
-
-// parseNameStatus parses git diff --name-status output and merges it with
-// numstat data to produce FileChange entries.
-func parseNameStatus(output string, numMap map[string]gitops.NumstatEntry) []gitops.FileChange {
-	return gitops.ParseNameStatus(output, numMap)
 }
 
 // Go helpers.

--- a/pkg/orchestrator/commands_test.go
+++ b/pkg/orchestrator/commands_test.go
@@ -9,13 +9,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/gitops"
 )
 
 // --- parseBranchList ---
 
 func TestParseBranchList_StripsMarkers(t *testing.T) {
 	input := "  main\n* current\n+ other\n"
-	got := parseBranchList(input)
+	got := gitops.ParseBranchList(input)
 	want := []string{"main", "current", "other"}
 	if len(got) != len(want) {
 		t.Fatalf("got %v, want %v", got, want)
@@ -28,14 +30,14 @@ func TestParseBranchList_StripsMarkers(t *testing.T) {
 }
 
 func TestParseBranchList_EmptyInput(t *testing.T) {
-	got := parseBranchList("")
+	got := gitops.ParseBranchList("")
 	if len(got) != 0 {
 		t.Errorf("got %v, want empty slice", got)
 	}
 }
 
 func TestParseBranchList_SkipsBlankLines(t *testing.T) {
-	got := parseBranchList("main\n\n  \nfeature\n")
+	got := gitops.ParseBranchList("main\n\n  \nfeature\n")
 	if len(got) != 2 || got[0] != "main" || got[1] != "feature" {
 		t.Errorf("got %v, want [main feature]", got)
 	}
@@ -43,7 +45,7 @@ func TestParseBranchList_SkipsBlankLines(t *testing.T) {
 
 func TestParseBranchList_GenerationPattern(t *testing.T) {
 	input := "  generation-20260214.0\n  generation-20260215.1\n"
-	got := parseBranchList(input)
+	got := gitops.ParseBranchList(input)
 	if len(got) != 2 {
 		t.Fatalf("got %v, want 2 entries", got)
 	}
@@ -56,7 +58,7 @@ func TestParseBranchList_GenerationPattern(t *testing.T) {
 
 func TestParseDiffShortstat_FullOutput(t *testing.T) {
 	s := " 5 files changed, 100 insertions(+), 20 deletions(-)\n"
-	ds := parseDiffShortstat(s)
+	ds := gitops.ParseDiffShortstat(s)
 	if ds.FilesChanged != 5 {
 		t.Errorf("FilesChanged: got %d, want 5", ds.FilesChanged)
 	}
@@ -70,7 +72,7 @@ func TestParseDiffShortstat_FullOutput(t *testing.T) {
 
 func TestParseDiffShortstat_InsertionsOnly(t *testing.T) {
 	s := " 3 files changed, 42 insertions(+)\n"
-	ds := parseDiffShortstat(s)
+	ds := gitops.ParseDiffShortstat(s)
 	if ds.FilesChanged != 3 {
 		t.Errorf("FilesChanged: got %d, want 3", ds.FilesChanged)
 	}
@@ -83,7 +85,7 @@ func TestParseDiffShortstat_InsertionsOnly(t *testing.T) {
 }
 
 func TestParseDiffShortstat_Empty(t *testing.T) {
-	ds := parseDiffShortstat("")
+	ds := gitops.ParseDiffShortstat("")
 	if ds.FilesChanged != 0 || ds.Insertions != 0 || ds.Deletions != 0 {
 		t.Errorf("empty input: got %+v, want all zeros", ds)
 	}
@@ -91,7 +93,7 @@ func TestParseDiffShortstat_Empty(t *testing.T) {
 
 func TestParseDiffShortstat_SingleFile(t *testing.T) {
 	s := " 1 file changed, 1 insertion(+), 1 deletion(-)\n"
-	ds := parseDiffShortstat(s)
+	ds := gitops.ParseDiffShortstat(s)
 	if ds.FilesChanged != 1 {
 		t.Errorf("FilesChanged: got %d, want 1", ds.FilesChanged)
 	}
@@ -161,16 +163,16 @@ func TestCommandsInit_PopulatesPath(t *testing.T) {
 func TestGitTagAt(t *testing.T) {
 	initTestGitRepo(t)
 
-	head, err := gitRevParseHEAD("")
+	head, err := defaultGitOps.RevParseHEAD("")
 	if err != nil {
 		t.Fatalf("gitRevParseHEAD: %v", err)
 	}
 
-	if err := gitTagAt("v1.2.3", head, ""); err != nil {
+	if err := defaultGitOps.TagAt("v1.2.3", head, ""); err != nil {
 		t.Fatalf("gitTagAt: %v", err)
 	}
 
-	tags := gitListTags("v1.2.3", "")
+	tags := defaultGitOps.ListTags("v1.2.3", "")
 	if len(tags) != 1 || tags[0] != "v1.2.3" {
 		t.Errorf("gitListTags after gitTagAt: got %v, want [v1.2.3]", tags)
 	}
@@ -192,11 +194,11 @@ func TestGitStash(t *testing.T) {
 	}
 
 	const stashMsg = "my-test-stash"
-	if err := gitStash(stashMsg, ""); err != nil {
+	if err := defaultGitOps.Stash(stashMsg, ""); err != nil {
 		t.Fatalf("gitStash: %v", err)
 	}
 
-	if gitHasChanges("") {
+	if defaultGitOps.HasChanges("") {
 		t.Error("gitHasChanges: want false after stash, got true")
 	}
 
@@ -220,7 +222,7 @@ func TestGitStageDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := gitStageDir("mydir", ""); err != nil {
+	if err := defaultGitOps.StageDir("mydir", ""); err != nil {
 		t.Fatalf("gitStageDir: %v", err)
 	}
 
@@ -236,16 +238,16 @@ func TestGitStageDir(t *testing.T) {
 func TestGitCommitAllowEmpty(t *testing.T) {
 	initTestGitRepo(t)
 
-	head1, err := gitRevParseHEAD("")
+	head1, err := defaultGitOps.RevParseHEAD("")
 	if err != nil {
 		t.Fatalf("gitRevParseHEAD before: %v", err)
 	}
 
-	if err := gitCommitAllowEmpty("empty commit", ""); err != nil {
+	if err := defaultGitOps.CommitAllowEmpty("empty commit", ""); err != nil {
 		t.Fatalf("gitCommitAllowEmpty: %v", err)
 	}
 
-	head2, err := gitRevParseHEAD("")
+	head2, err := defaultGitOps.RevParseHEAD("")
 	if err != nil {
 		t.Fatalf("gitRevParseHEAD after: %v", err)
 	}
@@ -266,7 +268,7 @@ func TestGitLsTreeFiles(t *testing.T) {
 	gitRun(t, "add", "-A")
 	gitRun(t, "commit", "--no-verify", "-m", "add two files")
 
-	files, err := gitLsTreeFiles("HEAD", "")
+	files, err := defaultGitOps.LsTreeFiles("HEAD", "")
 	if err != nil {
 		t.Fatalf("gitLsTreeFiles: %v", err)
 	}
@@ -293,7 +295,7 @@ func TestGitShowFileContent(t *testing.T) {
 	gitRun(t, "add", "-A")
 	gitRun(t, "commit", "--no-verify", "-m", "add hello file")
 
-	got, err := gitShowFileContent("HEAD", "hello.txt", "")
+	got, err := defaultGitOps.ShowFileContent("HEAD", "hello.txt", "")
 	if err != nil {
 		t.Fatalf("gitShowFileContent: %v", err)
 	}
@@ -316,7 +318,7 @@ func TestGitDiffShortstat(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ds, err := gitDiffShortstat("HEAD", "")
+	ds, err := defaultGitOps.DiffShortstat("HEAD", "")
 	if err != nil {
 		t.Fatalf("gitDiffShortstat: %v", err)
 	}
@@ -338,7 +340,7 @@ func TestGitDiffNameStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	changes, err := gitDiffNameStatus("HEAD", "")
+	changes, err := diffNameStatus("HEAD", "")
 	if err != nil {
 		t.Fatalf("gitDiffNameStatus: %v", err)
 	}

--- a/pkg/orchestrator/compare.go
+++ b/pkg/orchestrator/compare.go
@@ -25,7 +25,7 @@ func (o *Orchestrator) Compare(argA, argB, utility string) error {
 		Log:            logf,
 		GitBin:         binGit,
 		GoBin:          binGo,
-		RemoveWorktree: gitWorktreeRemove,
+		RemoveWorktree: defaultGitOps.WorktreeRemove,
 	}
 	return compare.Run(argA, argB, utility, deps)
 }

--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -320,7 +320,7 @@ func (o *Orchestrator) GeneratorRun(cycles int) error {
 		return err
 	}
 
-	currentBranch, err := gitCurrentBranch(".")
+	currentBranch, err := defaultGitOps.CurrentBranch(".")
 	if err != nil {
 		return fmt.Errorf("getting current branch: %w", err)
 	}
@@ -354,7 +354,7 @@ func (o *Orchestrator) GeneratorResume() error {
 	if !strings.HasPrefix(branch, o.cfg.Generation.Prefix) {
 		return fmt.Errorf("not a generation branch: %s\nSet generation.branch in configuration.yaml", branch)
 	}
-	if !gitBranchExists(branch, ".") {
+	if !defaultGitOps.BranchExists(branch, ".") {
 		return fmt.Errorf("branch does not exist: %s", branch)
 	}
 
@@ -373,7 +373,7 @@ func (o *Orchestrator) GeneratorResume() error {
 	wtBase := worktreeBasePath()
 
 	logf("resume: pruning worktrees")
-	if err := gitWorktreePrune("."); err != nil {
+	if err := defaultGitOps.WorktreePrune("."); err != nil {
 		logf("resume: warning: worktree prune: %v", err)
 	}
 
@@ -557,9 +557,9 @@ func (o *Orchestrator) checkAutoAdvanceRelease() (bool, string) {
 	}
 
 	// Commit the changes on the current branch.
-	_ = gitStageAll(".")
+	_ = defaultGitOps.StageAll(".")
 	msg := fmt.Sprintf("Auto-advance release %s: all use cases complete\n\nMarked use cases as implemented in road-map.yaml.\nRemoved %s from project.releases in configuration.yaml.", target.Version, target.Version)
-	if err := gitCommit(msg, "."); err != nil {
+	if err := defaultGitOps.Commit(msg, "."); err != nil {
 		logf("checkAutoAdvanceRelease: commit failed: %v", err)
 	}
 
@@ -632,10 +632,10 @@ func (o *Orchestrator) validateAndMarkUCs() {
 		return
 	}
 
-	_ = gitStageAll(".")
+	_ = defaultGitOps.StageAll(".")
 	msg := fmt.Sprintf("Mark validated UCs as implemented in release %s\n\nUCs with complete requirements: %s",
 		target.Version, strings.Join(marked, ", "))
-	if err := gitCommit(msg, "."); err != nil {
+	if err := defaultGitOps.Commit(msg, "."); err != nil {
 		logf("validateAndMarkUCs: commit failed: %v", err)
 	}
 }
@@ -681,13 +681,13 @@ func validateUCImplemented(ucID string) bool {
 // branch, deletes Go files, reinitializes the Go module, and commits the clean
 // state. Any clean branch is a valid starting point (prd002 R2.1).
 func (o *Orchestrator) GeneratorStart() error {
-	baseBranch, err := gitCurrentBranch(".")
+	baseBranch, err := defaultGitOps.CurrentBranch(".")
 	if err != nil {
 		return fmt.Errorf("getting current branch: %w", err)
 	}
 
 	// Reject dirty worktrees — a generation must start from a clean state.
-	if gitHasChanges(".") {
+	if defaultGitOps.HasChanges(".") {
 		return fmt.Errorf("worktree has uncommitted changes on %s; commit or stash before starting a generation", baseBranch)
 	}
 
@@ -722,7 +722,7 @@ func (o *Orchestrator) GeneratorStart() error {
 
 	// Tag the current base branch state before the generation begins.
 	logf("generator:start: tagging current state as %s", startTag)
-	if err := gitTag(startTag, "."); err != nil {
+	if err := defaultGitOps.Tag(startTag, "."); err != nil {
 		return fmt.Errorf("tagging base branch: %w", err)
 	}
 
@@ -739,15 +739,15 @@ func (o *Orchestrator) GeneratorStart() error {
 	worktreeDir := filepath.Join(filepath.Dir(repoRoot), genName)
 	logf("generator:start: creating worktree at %s", worktreeDir)
 
-	if err := gitCreateBranch(genName, "."); err != nil {
+	if err := defaultGitOps.CreateBranch(genName, "."); err != nil {
 		return fmt.Errorf("creating branch: %w", err)
 	}
-	cmd := gitWorktreeAdd(worktreeDir, genName, ".")
+	cmd := defaultGitOps.WorktreeAdd(worktreeDir, genName, ".")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		// Clean up the branch if worktree creation fails.
-		_ = gitDeleteBranch(genName, ".")
+		_ = defaultGitOps.DeleteBranch(genName, ".")
 		return fmt.Errorf("creating worktree: %w", err)
 	}
 
@@ -758,7 +758,7 @@ func (o *Orchestrator) GeneratorStart() error {
 	}
 
 	// Record branch point so intermediate commits can be squashed.
-	branchSHA, err := gitRevParseHEAD(".")
+	branchSHA, err := defaultGitOps.RevParseHEAD(".")
 	if err != nil {
 		return fmt.Errorf("getting branch HEAD: %w", err)
 	}
@@ -806,10 +806,10 @@ func (o *Orchestrator) GeneratorStart() error {
 
 	// Squash intermediate commits into one clean commit.
 	logf("generator:start: squashing into single commit")
-	if err := gitResetSoft(branchSHA, "."); err != nil {
+	if err := defaultGitOps.ResetSoft(branchSHA, "."); err != nil {
 		return fmt.Errorf("squashing start commits: %w", err)
 	}
-	_ = gitStageAll(".")
+	_ = defaultGitOps.StageAll(".")
 	var msg string
 	if o.cfg.Generation.PreserveSources {
 		msg = fmt.Sprintf("Start generation: %s\n\nBase branch: %s. Sources preserved (preserve_sources=true).\nTagged previous state as %s.", genName, baseBranch, genName)
@@ -818,7 +818,7 @@ func (o *Orchestrator) GeneratorStart() error {
 	}
 	// Use allow-empty because a specs-only repo may have no Go files
 	// to delete, leaving no changes to commit after source reset.
-	if err := gitCommitAllowEmpty(msg, "."); err != nil {
+	if err := defaultGitOps.CommitAllowEmpty(msg, "."); err != nil {
 		return fmt.Errorf("committing clean state: %w", err)
 	}
 
@@ -881,7 +881,7 @@ func findGenerationWorktree(prefix string) string {
 // worktree. Returns the worktree path (empty if none found) and any error.
 func enterGenerationWorktree() (string, error) {
 	// If we're already on a generation branch, no need to search.
-	if branch, err := gitCurrentBranch("."); err == nil {
+	if branch, err := defaultGitOps.CurrentBranch("."); err == nil {
 		if strings.HasPrefix(branch, "generation-") {
 			return "", nil
 		}
@@ -928,11 +928,11 @@ func (o *Orchestrator) GeneratorStop() error {
 
 	branch := o.cfg.Generation.Branch
 	if branch != "" {
-		if !gitBranchExists(branch, ".") {
+		if !defaultGitOps.BranchExists(branch, ".") {
 			return fmt.Errorf("branch does not exist: %s", branch)
 		}
 	} else {
-		current, err := gitCurrentBranch(".")
+		current, err := defaultGitOps.CurrentBranch(".")
 		if err != nil {
 			return fmt.Errorf("getting current branch: %w", err)
 		}
@@ -972,7 +972,7 @@ func (o *Orchestrator) GeneratorStop() error {
 	}
 
 	// Capture the caller's branch before switching to the generation branch.
-	callerBranch, err := gitCurrentBranch(".")
+	callerBranch, err := defaultGitOps.CurrentBranch(".")
 	if err != nil {
 		return fmt.Errorf("getting current branch: %w", err)
 	}
@@ -996,14 +996,14 @@ func (o *Orchestrator) GeneratorStop() error {
 	// Commit any uncommitted history files (orchestrator logs, late stats)
 	// so they are captured in the finished tag for post-hoc analysis (GH-1452).
 	if hdir := o.historyDir(); hdir != "" {
-		if err := gitStageDir(hdir, "."); err == nil && gitHasChanges(".") {
+		if err := defaultGitOps.StageDir(hdir, "."); err == nil && defaultGitOps.HasChanges(".") {
 			logf("generator:stop: committing history files before tagging")
-			_ = gitCommit("Commit history files before generator:stop tag", ".")
+			_ = defaultGitOps.Commit("Commit history files before generator:stop tag", ".")
 		}
 	}
 
 	logf("generator:stop: tagging as %s", finishedTag)
-	if err := gitTag(finishedTag, "."); err != nil {
+	if err := defaultGitOps.Tag(finishedTag, "."); err != nil {
 		return fmt.Errorf("tagging generation: %w", err)
 	}
 
@@ -1016,7 +1016,7 @@ func (o *Orchestrator) GeneratorStop() error {
 	} else {
 		// Legacy path: switch to the base branch in the current repo.
 		logf("generator:stop: switching to %s", baseBranch)
-		if err := gitCheckout(baseBranch, "."); err != nil {
+		if err := defaultGitOps.Checkout(baseBranch, "."); err != nil {
 			return fmt.Errorf("checking out %s: %w", baseBranch, err)
 		}
 	}
@@ -1034,10 +1034,10 @@ func (o *Orchestrator) GeneratorStop() error {
 	// checked out in any worktree (GH-1608).
 	if worktreeDir != "" {
 		logf("generator:stop: removing worktree %s", worktreeDir)
-		if err := gitWorktreeRemove(worktreeDir, "."); err != nil {
+		if err := defaultGitOps.WorktreeRemove(worktreeDir, "."); err != nil {
 			logf("generator:stop: worktree remove warning: %v", err)
 		}
-		_ = gitWorktreePrune(".")
+		_ = defaultGitOps.WorktreePrune(".")
 	}
 
 	if err := o.mergeGeneration(branch, baseBranch); err != nil {
@@ -1073,19 +1073,19 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 		_ = o.resetGoSources(branch) // best-effort; merge will overwrite these files
 	}
 
-	_ = gitStageAll(".") // best-effort; commit below handles empty index
+	_ = defaultGitOps.StageAll(".") // best-effort; commit below handles empty index
 	var prepareMsg string
 	if o.cfg.Generation.PreserveSources {
 		prepareMsg = fmt.Sprintf("Prepare %s for generation merge (preserve_sources)\n\nSources preserved. Merging %s.", baseBranch, branch)
 	} else {
 		prepareMsg = fmt.Sprintf("Prepare %s for generation merge: delete Go code\n\nDocumentation preserved for merge. Code will be replaced by %s.", baseBranch, branch)
 	}
-	if err := gitCommitAllowEmpty(prepareMsg, "."); err != nil {
+	if err := defaultGitOps.CommitAllowEmpty(prepareMsg, "."); err != nil {
 		return fmt.Errorf("committing prepare step: %w", err)
 	}
 
 	logf("generator:stop: merging into %s", baseBranch)
-	cmd := gitMergeCmd(branch, ".")
+	cmd := defaultGitOps.MergeCmd(branch, ".")
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -1100,7 +1100,7 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 
 	mergedTag := branch + "-merged"
 	logf("generator:stop: tagging %s as %s", baseBranch, mergedTag)
-	if err := gitTag(mergedTag, "."); err != nil {
+	if err := defaultGitOps.Tag(mergedTag, "."); err != nil {
 		return fmt.Errorf("tagging merge: %w", err)
 	}
 
@@ -1114,12 +1114,12 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 	if err := o.HistoryClean(); err != nil {
 		logf("generator:stop: warning cleaning history: %v", err)
 	}
-	_ = gitStageAll(".")
+	_ = defaultGitOps.StageAll(".")
 	cleanupMsg := fmt.Sprintf("Reset %s to specs-only after v1 tag\n\nGenerated code preserved at version tags. Branch restored to documentation-only state.", baseBranch)
-	_ = gitCommit(cleanupMsg, ".") // best-effort; may be empty if nothing changed
+	_ = defaultGitOps.Commit(cleanupMsg, ".") // best-effort; may be empty if nothing changed
 
 	logf("generator:stop: deleting branch %s", branch)
-	_ = gitForceDeleteBranch(branch, ".") // force-delete: safe -d fails after specs-only reset
+	_ = defaultGitOps.ForceDeleteBranch(branch, ".") // force-delete: safe -d fails after specs-only reset
 	return nil
 }
 
@@ -1161,7 +1161,7 @@ func (o *Orchestrator) resetImplementedReleases() error {
 	if len(cleared) == 0 && len(revertedUCs) == 0 {
 		return nil
 	}
-	_ = gitStageAll(".")
+	_ = defaultGitOps.StageAll(".")
 	var parts []string
 	if len(cleared) > 0 {
 		parts = append(parts, fmt.Sprintf("Releases: %s", strings.Join(cleared, ", ")))
@@ -1170,7 +1170,7 @@ func (o *Orchestrator) resetImplementedReleases() error {
 		parts = append(parts, fmt.Sprintf("UCs: %s", strings.Join(revertedUCs, ", ")))
 	}
 	msg := fmt.Sprintf("Reset statuses to spec_complete after generator:stop\n\n%s", strings.Join(parts, "\n"))
-	if err := gitCommit(msg, "."); err != nil {
+	if err := defaultGitOps.Commit(msg, "."); err != nil {
 		return fmt.Errorf("commit release reset: %w", err)
 	}
 	logf("resetImplementedReleases: cleared %d release(s), reverted %d UC(s)", len(cleared), len(revertedUCs))
@@ -1180,7 +1180,7 @@ func (o *Orchestrator) resetImplementedReleases() error {
 // restoreFromStartTag restores Go source files that existed on main at the
 // given start tag but are missing after the merge.
 func (o *Orchestrator) restoreFromStartTag(startTag string) error {
-	startFiles, err := gitLsTreeFiles(startTag, ".")
+	startFiles, err := defaultGitOps.LsTreeFiles(startTag, ".")
 	if err != nil {
 		return fmt.Errorf("listing files at %s: %w", startTag, err)
 	}
@@ -1197,7 +1197,7 @@ func (o *Orchestrator) restoreFromStartTag(startTag string) error {
 			continue
 		}
 
-		content, err := gitShowFileContent(startTag, path, ".")
+		content, err := defaultGitOps.ShowFileContent(startTag, path, ".")
 		if err != nil {
 			logf("generator:stop: could not read %s from %s: %v", path, startTag, err)
 			continue
@@ -1221,10 +1221,10 @@ func (o *Orchestrator) restoreFromStartTag(startTag string) error {
 	}
 
 	logf("generator:stop: restored %d file(s) from earlier generations", len(restored))
-	_ = gitStageAll(".")
+	_ = defaultGitOps.StageAll(".")
 	msg := fmt.Sprintf("Restore %d file(s) from earlier generations\n\nFiles restored from %s:\n%s",
 		len(restored), startTag, strings.Join(restored, "\n"))
-	if err := gitCommit(msg, "."); err != nil {
+	if err := defaultGitOps.Commit(msg, "."); err != nil {
 		return fmt.Errorf("committing restored files: %w", err)
 	}
 	return nil
@@ -1232,13 +1232,13 @@ func (o *Orchestrator) restoreFromStartTag(startTag string) error {
 
 // listGenerationBranches returns all generation-* branch names.
 func (o *Orchestrator) listGenerationBranches() []string {
-	return gitListBranches(o.cfg.Generation.Prefix+"*", ".")
+	return defaultGitOps.ListBranches(o.cfg.Generation.Prefix+"*", ".")
 }
 
 // cleanupUnmergedTags renames tags for generations that were never
 // merged into a single -abandoned tag.
 func (o *Orchestrator) cleanupUnmergedTags() {
-	tags := gitListTags(o.cfg.Generation.Prefix+"*", ".")
+	tags := defaultGitOps.ListTags(o.cfg.Generation.Prefix+"*", ".")
 	if len(tags) == 0 {
 		return
 	}
@@ -1261,11 +1261,11 @@ func (o *Orchestrator) cleanupUnmergedTags() {
 			abTag := name + "-abandoned"
 			if t != abTag {
 				logf("generator:reset: marking abandoned: %s -> %s", t, abTag)
-				_ = gitRenameTag(t, abTag, ".") // best-effort; tag may not exist
+				_ = defaultGitOps.RenameTag(t, abTag, ".") // best-effort; tag may not exist
 			}
 		} else {
 			logf("generator:reset: removing tag %s", t)
-			_ = gitDeleteTag(t, ".") // best-effort cleanup
+			_ = defaultGitOps.DeleteTag(t, ".") // best-effort cleanup
 		}
 	}
 }
@@ -1273,7 +1273,7 @@ func (o *Orchestrator) cleanupUnmergedTags() {
 // resolveBranch determines which branch to work on.
 func (o *Orchestrator) resolveBranch(explicit string) (string, error) {
 	if explicit != "" {
-		if !gitBranchExists(explicit, ".") {
+		if !defaultGitOps.BranchExists(explicit, ".") {
 			return "", fmt.Errorf("branch does not exist: %s", explicit)
 		}
 		return explicit, nil
@@ -1282,7 +1282,7 @@ func (o *Orchestrator) resolveBranch(explicit string) (string, error) {
 	branches := o.listGenerationBranches()
 	switch len(branches) {
 	case 0:
-		return gitCurrentBranch(".")
+		return defaultGitOps.CurrentBranch(".")
 	case 1:
 		return branches[0], nil
 	default:
@@ -1294,8 +1294,8 @@ func (o *Orchestrator) resolveBranch(explicit string) (string, error) {
 // GeneratorList shows active branches and past generations.
 func (o *Orchestrator) GeneratorList() error {
 	branches := o.listGenerationBranches()
-	tags := gitListTags(o.cfg.Generation.Prefix+"*", ".")
-	current, _ := gitCurrentBranch(".")
+	tags := defaultGitOps.ListTags(o.cfg.Generation.Prefix+"*", ".")
+	current, _ := defaultGitOps.CurrentBranch(".")
 
 	nameSet := make(map[string]bool)
 	branchSet := make(map[string]bool)
@@ -1364,11 +1364,11 @@ func (o *Orchestrator) GeneratorSwitch() error {
 	if target != baseBranch && !strings.HasPrefix(target, o.cfg.Generation.Prefix) {
 		return fmt.Errorf("not a generation branch or %s: %s", baseBranch, target)
 	}
-	if !gitBranchExists(target, ".") {
+	if !defaultGitOps.BranchExists(target, ".") {
 		return fmt.Errorf("branch does not exist: %s", target)
 	}
 
-	current, err := gitCurrentBranch(".")
+	current, err := defaultGitOps.CurrentBranch(".")
 	if err != nil {
 		return fmt.Errorf("getting current branch: %w", err)
 	}
@@ -1398,15 +1398,15 @@ func (o *Orchestrator) GeneratorReset() error {
 		if err := os.Chdir(repoRoot); err != nil {
 			return fmt.Errorf("switching to main repo: %w", err)
 		}
-		_ = gitWorktreeRemove(worktreeDir, ".")
-		_ = gitWorktreePrune(".")
+		_ = defaultGitOps.WorktreeRemove(worktreeDir, ".")
+		_ = defaultGitOps.WorktreePrune(".")
 		// worktree path cleaned up via worktree remove (GH-1608)
 	} else {
 		// Check if there's a generation worktree to remove.
 		if wtPath := findGenerationWorktree(o.cfg.Generation.Prefix); wtPath != "" {
 			logf("generator:reset: removing generation worktree %s", wtPath)
-			_ = gitWorktreeRemove(wtPath, ".")
-			_ = gitWorktreePrune(".")
+			_ = defaultGitOps.WorktreeRemove(wtPath, ".")
+			_ = defaultGitOps.WorktreePrune(".")
 		}
 	}
 
@@ -1437,7 +1437,7 @@ func (o *Orchestrator) GeneratorReset() error {
 		}
 	}
 
-	if err := gitWorktreePrune("."); err != nil {
+	if err := defaultGitOps.WorktreePrune("."); err != nil {
 		logf("generator:reset: warning: worktree prune: %v", err)
 	}
 
@@ -1452,11 +1452,11 @@ func (o *Orchestrator) GeneratorReset() error {
 		// Prune again to ensure worktree registrations are fully cleaned up
 		// before deleting branches (GH-1608). Without this, git may refuse
 		// to delete a branch it still thinks is checked out in a worktree.
-		_ = gitWorktreePrune(".")
+		_ = defaultGitOps.WorktreePrune(".")
 		logf("generator:reset: removing %d generation branch(es)", len(genBranches))
 		for _, gb := range genBranches {
 			logf("generator:reset: deleting branch %s", gb)
-			_ = gitForceDeleteBranch(gb, ".")
+			_ = defaultGitOps.ForceDeleteBranch(gb, ".")
 		}
 	}
 
@@ -1479,8 +1479,8 @@ func (o *Orchestrator) GeneratorReset() error {
 	}
 
 	logf("generator:reset: committing clean state")
-	_ = gitStageAll(".")                                                  // best-effort; commit below handles empty index
-	_ = gitCommitAllowEmpty("Generator reset: return to clean state", ".") // best-effort; reset is complete regardless
+	_ = defaultGitOps.StageAll(".")                                                  // best-effort; commit below handles empty index
+	_ = defaultGitOps.CommitAllowEmpty("Generator reset: return to clean state", ".") // best-effort; reset is complete regardless
 
 	logf("generator:reset: done, only %s branch remains", baseBranch)
 	return nil

--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -19,7 +19,7 @@ type stitchCommentData = st.StitchCommentData
 
 // GeneratorStats prints a status report for the current generation run.
 func (o *Orchestrator) GeneratorStats() error {
-	currentBranch, _ := gitCurrentBranch(".")
+	currentBranch, _ := defaultGitOps.CurrentBranch(".")
 	return st.PrintGeneratorStats(st.GeneratorStatsDeps{
 		Log:                    logf,
 		ListGenerationBranches: o.listGenerationBranches,
@@ -34,7 +34,7 @@ func (o *Orchestrator) GeneratorStats() error {
 		HistoryDir: o.historyDir(),
 		CobblerDir: o.cfg.Cobbler.Dir,
 		ReadBranchFile: func(branch, path string) ([]byte, error) {
-			return gitShowFileContent(branch, path, ".")
+			return defaultGitOps.ShowFileContent(branch, path, ".")
 		},
 	})
 }

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -451,7 +451,7 @@ func TestCleanupDirs_EmptyList(t *testing.T) {
 func TestEnsureOnBranch_AlreadyOnBranch(t *testing.T) {
 	initTestGitRepo(t)
 
-	current, err := gitCurrentBranch("")
+	current, err := defaultGitOps.CurrentBranch("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -464,7 +464,7 @@ func TestEnsureOnBranch_AlreadyOnBranch(t *testing.T) {
 func TestEnsureOnBranch_SwitchesBranch(t *testing.T) {
 	initTestGitRepo(t)
 
-	if err := gitCreateBranch("test-branch", ""); err != nil {
+	if err := defaultGitOps.CreateBranch("test-branch", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -472,7 +472,7 @@ func TestEnsureOnBranch_SwitchesBranch(t *testing.T) {
 		t.Fatalf("ensureOnBranch(test-branch) error = %v", err)
 	}
 
-	current, err := gitCurrentBranch("")
+	current, err := defaultGitOps.CurrentBranch("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -486,7 +486,7 @@ func TestEnsureOnBranch_SwitchesBranch(t *testing.T) {
 func TestSaveAndSwitchBranch_AlreadyOnTarget(t *testing.T) {
 	initTestGitRepo(t)
 
-	current, _ := gitCurrentBranch("")
+	current, _ := defaultGitOps.CurrentBranch("")
 	if err := saveAndSwitchBranch(current); err != nil {
 		t.Errorf("saveAndSwitchBranch(current) error = %v", err)
 	}
@@ -495,7 +495,7 @@ func TestSaveAndSwitchBranch_AlreadyOnTarget(t *testing.T) {
 func TestSaveAndSwitchBranch_CleanSwitch(t *testing.T) {
 	initTestGitRepo(t)
 
-	if err := gitCreateBranch("target", ""); err != nil {
+	if err := defaultGitOps.CreateBranch("target", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -503,7 +503,7 @@ func TestSaveAndSwitchBranch_CleanSwitch(t *testing.T) {
 		t.Fatalf("saveAndSwitchBranch(target) error = %v", err)
 	}
 
-	current, err := gitCurrentBranch("")
+	current, err := defaultGitOps.CurrentBranch("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -519,7 +519,7 @@ func TestSaveAndSwitchBranch_DirtyWorkingTree(t *testing.T) {
 	exec.Command("git", "add", "tracked.txt").Run()
 	exec.Command("git", "commit", "--no-verify", "-m", "add tracked file").Run()
 
-	if err := gitCreateBranch("other", ""); err != nil {
+	if err := defaultGitOps.CreateBranch("other", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -529,7 +529,7 @@ func TestSaveAndSwitchBranch_DirtyWorkingTree(t *testing.T) {
 		t.Fatalf("saveAndSwitchBranch with dirty tree error = %v", err)
 	}
 
-	current, err := gitCurrentBranch("")
+	current, err := defaultGitOps.CurrentBranch("")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -543,7 +543,7 @@ func TestSaveAndSwitchBranch_DirtyWorkingTree(t *testing.T) {
 func TestResolveBranch_ExplicitBranchExists(t *testing.T) {
 	initTestGitRepo(t)
 
-	if err := gitCreateBranch("explicit-branch", ""); err != nil {
+	if err := defaultGitOps.CreateBranch("explicit-branch", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -576,7 +576,7 @@ func TestResolveBranch_NoGenerationBranches(t *testing.T) {
 		t.Fatalf("resolveBranch() error = %v", err)
 	}
 
-	current, _ := gitCurrentBranch("")
+	current, _ := defaultGitOps.CurrentBranch("")
 	if got != current {
 		t.Errorf("resolveBranch() = %q, want current branch %q", got, current)
 	}
@@ -585,7 +585,7 @@ func TestResolveBranch_NoGenerationBranches(t *testing.T) {
 func TestResolveBranch_SingleGenerationBranch(t *testing.T) {
 	initTestGitRepo(t)
 
-	if err := gitCreateBranch("generation-2026-02-28-12-00-00", ""); err != nil {
+	if err := defaultGitOps.CreateBranch("generation-2026-02-28-12-00-00", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -602,8 +602,8 @@ func TestResolveBranch_SingleGenerationBranch(t *testing.T) {
 func TestResolveBranch_MultipleGenerationBranches(t *testing.T) {
 	initTestGitRepo(t)
 
-	gitCreateBranch("generation-2026-02-28-12-00-00", "")
-	gitCreateBranch("generation-2026-02-28-13-00-00", "")
+	defaultGitOps.CreateBranch("generation-2026-02-28-12-00-00", "")
+	defaultGitOps.CreateBranch("generation-2026-02-28-13-00-00", "")
 
 	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
 	_, err := o.resolveBranch("")
@@ -630,9 +630,9 @@ func TestListGenerationBranches_NoBranches(t *testing.T) {
 func TestListGenerationBranches_WithBranches(t *testing.T) {
 	initTestGitRepo(t)
 
-	gitCreateBranch("generation-2026-02-28-12-00-00", "")
-	gitCreateBranch("generation-2026-02-28-13-00-00", "")
-	gitCreateBranch("other-branch", "")
+	defaultGitOps.CreateBranch("generation-2026-02-28-12-00-00", "")
+	defaultGitOps.CreateBranch("generation-2026-02-28-13-00-00", "")
+	defaultGitOps.CreateBranch("other-branch", "")
 
 	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
 	got := o.listGenerationBranches()
@@ -743,7 +743,7 @@ func TestGeneratorStart_CustomName(t *testing.T) {
 		t.Fatalf("GeneratorStart() error = %v", err)
 	}
 
-	branch, err := gitCurrentBranch("")
+	branch, err := defaultGitOps.CurrentBranch("")
 	if err != nil {
 		t.Fatalf("gitCurrentBranch: %v", err)
 	}
@@ -752,7 +752,7 @@ func TestGeneratorStart_CustomName(t *testing.T) {
 	}
 
 	// Verify lifecycle tag was created.
-	tags := gitListTags("generation-gh-42-start", "")
+	tags := defaultGitOps.ListTags("generation-gh-42-start", "")
 	if len(tags) != 1 {
 		t.Errorf("expected start tag, got %v", tags)
 	}
@@ -776,7 +776,7 @@ func TestGeneratorStart_EnvNameOverridesConfig(t *testing.T) {
 		t.Fatalf("GeneratorStart() error = %v", err)
 	}
 
-	branch, err := gitCurrentBranch("")
+	branch, err := defaultGitOps.CurrentBranch("")
 	if err != nil {
 		t.Fatalf("gitCurrentBranch: %v", err)
 	}
@@ -848,7 +848,7 @@ func TestGeneratorStart_CreatesWorktree(t *testing.T) {
 	}
 
 	// The worktree should be on the generation branch.
-	branch, err := gitCurrentBranch("")
+	branch, err := defaultGitOps.CurrentBranch("")
 	if err != nil {
 		t.Fatalf("gitCurrentBranch in worktree: %v", err)
 	}
@@ -857,7 +857,7 @@ func TestGeneratorStart_CreatesWorktree(t *testing.T) {
 	}
 
 	// The main repo should still be on main.
-	mainBranch, err := gitCurrentBranch(repoDir)
+	mainBranch, err := defaultGitOps.CurrentBranch(repoDir)
 	if err != nil {
 		t.Fatalf("gitCurrentBranch in main repo: %v", err)
 	}
@@ -937,8 +937,8 @@ func TestGeneratorStop_CleansUpWorktree(t *testing.T) {
 	if err := os.WriteFile(testFile, []byte("generated\n"), 0o644); err != nil {
 		t.Fatalf("writing test file: %v", err)
 	}
-	_ = gitStageAll(".")
-	_ = gitCommit("Add test output", ".")
+	_ = defaultGitOps.StageAll(".")
+	_ = defaultGitOps.Commit("Add test output", ".")
 
 	if err := o.GeneratorStop(); err != nil {
 		t.Fatalf("GeneratorStop() error = %v", err)
@@ -956,7 +956,7 @@ func TestGeneratorStop_CleansUpWorktree(t *testing.T) {
 	}
 
 	// The main repo should be on the base branch.
-	branch, err := gitCurrentBranch("")
+	branch, err := defaultGitOps.CurrentBranch("")
 	if err != nil {
 		t.Fatalf("gitCurrentBranch: %v", err)
 	}
@@ -970,7 +970,7 @@ func TestGeneratorStop_CleansUpWorktree(t *testing.T) {
 	}
 
 	// The generation branch should be deleted.
-	if gitBranchExists("generation-stop-test", "") {
+	if defaultGitOps.BranchExists("generation-stop-test", "") {
 		t.Errorf("generation branch still exists after GeneratorStop")
 	}
 
@@ -1095,7 +1095,7 @@ func TestGeneratorSwitch_AlreadyOnBranch(t *testing.T) {
 	initTestGitRepo(t)
 
 	branch := "generation-2026-02-28-12-00-00"
-	if err := gitCheckoutNew(branch, ""); err != nil {
+	if err := defaultGitOps.CheckoutNew(branch, ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1107,7 +1107,7 @@ func TestGeneratorSwitch_AlreadyOnBranch(t *testing.T) {
 		t.Errorf("GeneratorSwitch() already on branch error = %v", err)
 	}
 
-	current, _ := gitCurrentBranch("")
+	current, _ := defaultGitOps.CurrentBranch("")
 	if current != branch {
 		t.Errorf("current branch = %q, want %q", current, branch)
 	}
@@ -1116,7 +1116,7 @@ func TestGeneratorSwitch_AlreadyOnBranch(t *testing.T) {
 func TestGeneratorSwitch_SwitchToMain(t *testing.T) {
 	initTestGitRepo(t)
 
-	if err := gitCheckoutNew("generation-2026-02-28-12-00-00", ""); err != nil {
+	if err := defaultGitOps.CheckoutNew("generation-2026-02-28-12-00-00", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1129,7 +1129,7 @@ func TestGeneratorSwitch_SwitchToMain(t *testing.T) {
 		t.Errorf("GeneratorSwitch() to main error = %v", err)
 	}
 
-	current, _ := gitCurrentBranch("")
+	current, _ := defaultGitOps.CurrentBranch("")
 	if current != "main" {
 		t.Errorf("current branch = %q, want %q", current, "main")
 	}
@@ -1163,14 +1163,14 @@ func TestGeneratorReset_UsesConfiguredBaseBranch(t *testing.T) {
 func TestCleanupUnmergedTags_MergedNotTouched(t *testing.T) {
 	initTestGitRepo(t)
 
-	gitTag("generation-2026-02-28-12-00-00-start", "")
-	gitTag("generation-2026-02-28-12-00-00-finished", "")
-	gitTag("generation-2026-02-28-12-00-00-merged", "")
+	defaultGitOps.Tag("generation-2026-02-28-12-00-00-start", "")
+	defaultGitOps.Tag("generation-2026-02-28-12-00-00-finished", "")
+	defaultGitOps.Tag("generation-2026-02-28-12-00-00-merged", "")
 
 	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
 	o.cleanupUnmergedTags()
 
-	tags := gitListTags("generation-2026-02-28-12-00-00-*", "")
+	tags := defaultGitOps.ListTags("generation-2026-02-28-12-00-00-*", "")
 	if len(tags) != 3 {
 		t.Errorf("expected 3 tags after cleanup, got %d: %v", len(tags), tags)
 	}
@@ -1179,13 +1179,13 @@ func TestCleanupUnmergedTags_MergedNotTouched(t *testing.T) {
 func TestCleanupUnmergedTags_UnmergedAbandoned(t *testing.T) {
 	initTestGitRepo(t)
 
-	gitTag("generation-2026-02-28-12-00-00-start", "")
-	gitTag("generation-2026-02-28-12-00-00-finished", "")
+	defaultGitOps.Tag("generation-2026-02-28-12-00-00-start", "")
+	defaultGitOps.Tag("generation-2026-02-28-12-00-00-finished", "")
 
 	o := &Orchestrator{cfg: Config{Generation: GenerationConfig{Prefix: "generation-"}}}
 	o.cleanupUnmergedTags()
 
-	tags := gitListTags("generation-2026-02-28-12-00-00-*", "")
+	tags := defaultGitOps.ListTags("generation-2026-02-28-12-00-00-*", "")
 	found := false
 	for _, tag := range tags {
 		if tag == "generation-2026-02-28-12-00-00-abandoned" {
@@ -1288,12 +1288,12 @@ func TestGitCurrentBranch_ExplicitDir(t *testing.T) {
 	dir := t.TempDir()
 	initTestGitRepoInDir(t, dir)
 
-	branch, err := gitCurrentBranch(dir)
+	branch, err := defaultGitOps.CurrentBranch(dir)
 	if err != nil {
-		t.Fatalf("gitCurrentBranch(%q) error = %v", dir, err)
+		t.Fatalf("defaultGitOps.CurrentBranch(%q) error = %v", dir, err)
 	}
 	if branch == "" {
-		t.Errorf("gitCurrentBranch(%q) returned empty branch", dir)
+		t.Errorf("defaultGitOps.CurrentBranch(%q) returned empty branch", dir)
 	}
 }
 
@@ -1447,7 +1447,7 @@ func TestCleanupUnmergedTags_AllMerged(t *testing.T) {
 	o.cleanupUnmergedTags()
 
 	// All tags should still exist (nothing abandoned).
-	tags := gitListTags("generation-*", ".")
+	tags := defaultGitOps.ListTags("generation-*", ".")
 	if len(tags) != 3 {
 		t.Errorf("expected 3 tags after cleanup of all-merged, got %d: %v", len(tags), tags)
 	}

--- a/pkg/orchestrator/issues_gh.go
+++ b/pkg/orchestrator/issues_gh.go
@@ -29,7 +29,7 @@ func ghTracker(cfg Config) *gh.GitHubTracker {
 	return &gh.GitHubTracker{
 		Log:          logf,
 		GhBin:        binGh,
-		BranchExists: gitBranchExists,
+		BranchExists: defaultGitOps.BranchExists,
 		Cfg: gh.RepoConfig{
 			IssuesRepo: cfg.Cobbler.IssuesRepo,
 			ModulePath: cfg.Project.ModulePath,
@@ -44,7 +44,7 @@ func ghTrackerNoCfg() *gh.GitHubTracker {
 	return &gh.GitHubTracker{
 		Log:          logf,
 		GhBin:        binGh,
-		BranchExists: gitBranchExists,
+		BranchExists: defaultGitOps.BranchExists,
 	}
 }
 

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -143,7 +143,7 @@ func (o *Orchestrator) RunMeasure() error {
 
 	// Get initial state: open GitHub issues for this generation.
 	existingIssues, _ := listActiveIssuesContext(repo, generation)
-	commitSHA, _ := gitRevParseHEAD(".") // empty string on error is acceptable for logging
+	commitSHA, _ := defaultGitOps.RevParseHEAD(".") // empty string on error is acceptable for logging
 
 	logf("existing issues context len=%d, maxMeasureIssues=%d, commit=%s",
 		len(existingIssues), o.cfg.Cobbler.MaxMeasureIssues, commitSHA)

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -43,7 +43,7 @@ func New(cfg Config) *Orchestrator {
 			gh.Deps{
 				Log:          logf,
 				GhBin:        binGh,
-				BranchExists: gitBranchExists,
+				BranchExists: defaultGitOps.BranchExists,
 			},
 			gh.RepoConfig{
 				IssuesRepo: cfg.Cobbler.IssuesRepo,

--- a/pkg/orchestrator/scaffold.go
+++ b/pkg/orchestrator/scaffold.go
@@ -446,12 +446,12 @@ func (o *Orchestrator) PrepareTestRepo(module, version, orchestratorRoot string)
 		return "", fmt.Errorf("git init: %w", err)
 	}
 
-	if err := gitStageAll(repoDir); err != nil {
+	if err := defaultGitOps.StageAll(repoDir); err != nil {
 		os.RemoveAll(workDir)
 		return "", fmt.Errorf("git add: %w", err)
 	}
 
-	if err := gitCommit("Initial commit from test-clone", repoDir); err != nil {
+	if err := defaultGitOps.Commit("Initial commit from test-clone", repoDir); err != nil {
 		os.RemoveAll(workDir)
 		return "", fmt.Errorf("git commit: %w", err)
 	}
@@ -482,12 +482,12 @@ func (o *Orchestrator) PrepareTestRepo(module, version, orchestratorRoot string)
 	}
 
 	// Commit scaffold artifacts so the working tree is clean.
-	if err := gitStageAll(repoDir); err != nil {
+	if err := defaultGitOps.StageAll(repoDir); err != nil {
 		os.RemoveAll(workDir)
 		return "", fmt.Errorf("git add scaffold: %w", err)
 	}
 
-	if err := gitCommit("Add orchestrator scaffold", repoDir); err != nil {
+	if err := defaultGitOps.Commit("Add orchestrator scaffold", repoDir); err != nil {
 		os.RemoveAll(workDir)
 		return "", fmt.Errorf("git commit scaffold: %w", err)
 	}

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -104,7 +104,7 @@ func (o *Orchestrator) RunStitchN(limit int) (int, error) {
 	worktreeBase := worktreeBasePath()
 	logf("worktreeBase=%s", worktreeBase)
 
-	baseBranch, err := gitCurrentBranch(".")
+	baseBranch, err := defaultGitOps.CurrentBranch(".")
 	if err != nil {
 		return 0, fmt.Errorf("getting current branch: %w", err)
 	}
@@ -184,7 +184,7 @@ func (o *Orchestrator) recoverStaleTasks(baseBranch, worktreeBase, repo, generat
 	orphanedIssues := resetOrphanedIssues(baseBranch, repo, generation)
 
 	logf("recoverStaleTasks: pruning worktrees")
-	if err := gitWorktreePrune("."); err != nil {
+	if err := defaultGitOps.WorktreePrune("."); err != nil {
 		logf("recoverStaleTasks: worktree prune warning: %v", err)
 	}
 
@@ -317,7 +317,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	}
 
 	// Capture pre-merge HEAD for diffstat.
-	preMergeRef, err := gitRevParseHEAD(".")
+	preMergeRef, err := defaultGitOps.RevParseHEAD(".")
 	if err != nil {
 		logf("doOneTask: warning getting pre-merge ref: %v", err)
 	}
@@ -346,12 +346,12 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	logf("doOneTask: merge completed in %s", time.Since(mergeStart).Round(time.Second))
 
 	// Capture per-file diff stats.
-	diff, diffErr := gitDiffShortstat(preMergeRef, ".")
+	diff, diffErr := defaultGitOps.DiffShortstat(preMergeRef, ".")
 	if diffErr != nil {
 		logf("doOneTask: warning getting diff shortstat: %v", diffErr)
 	}
 	logf("doOneTask: diff files=%d ins=%d del=%d", diff.FilesChanged, diff.Insertions, diff.Deletions)
-	fileChanges, fcErr := gitDiffNameStatus(preMergeRef, ".")
+	fileChanges, fcErr := diffNameStatus(preMergeRef, ".")
 	if fcErr != nil {
 		logf("doOneTask: warning getting file changes: %v", fcErr)
 	}
@@ -523,7 +523,7 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 	taskContext := fmt.Sprintf("Task ID: %s\nType: %s\nTitle: %s",
 		task.ID, task.IssueType, task.Title)
 
-	repoFiles := gitLsFiles(task.WorktreeDir)
+	repoFiles := defaultGitOps.LsFiles(task.WorktreeDir)
 
 	// Load OOD context.
 	oodContracts, oodProtocols := loadOODPromptContext()
@@ -585,10 +585,10 @@ func (o *Orchestrator) closeStitchTask(task stitchTask, rec InvocationRecord, te
 	// Pass test result so failures are tracked as complete_with_failures (GH-1388).
 	if err := generate.UpdateRequirementsFile(o.cfg.Cobbler.Dir, task.Description, task.GhNumber, testsPassed); err != nil {
 		logf("closeStitchTask: warning updating requirements: %v", err)
-	} else if gitHasChanges(".") {
+	} else if defaultGitOps.HasChanges(".") {
 		// Commit requirement state immediately so it survives interruptions (GH-1385).
-		_ = gitStageAll(".")
-		_ = gitCommit(fmt.Sprintf("Update requirement states after #%d", task.GhNumber), ".")
+		_ = defaultGitOps.StageAll(".")
+		_ = defaultGitOps.Commit(fmt.Sprintf("Update requirement states after #%d", task.GhNumber), ".")
 	}
 
 	if err := closeCobblerIssue(task.Repo, task.GhNumber, task.Generation); err != nil {
@@ -663,7 +663,7 @@ func (o *Orchestrator) resetTask(task stitchTask, reason string) {
 		logf("resetTask: skipping force branch delete for %s (worktree not removed)", task.BranchName)
 		return
 	}
-	if err := gitForceDeleteBranch(task.BranchName, "."); err != nil {
+	if err := defaultGitOps.ForceDeleteBranch(task.BranchName, "."); err != nil {
 		logf("resetTask: WARNING force branch delete failed for %s: %v", task.BranchName, err)
 	}
 }

--- a/pkg/orchestrator/stitch_test.go
+++ b/pkg/orchestrator/stitch_test.go
@@ -613,8 +613,8 @@ func TestCreateWorktree_CreatesWorktreeAndBranch(t *testing.T) {
 		t.Fatalf("createWorktree() error = %v", err)
 	}
 	t.Cleanup(func() {
-		gitWorktreeRemove(task.WorktreeDir, "")
-		gitDeleteBranch(task.BranchName, "")
+		defaultGitOps.WorktreeRemove(task.WorktreeDir, "")
+		defaultGitOps.DeleteBranch(task.BranchName, "")
 	})
 
 	// Verify the worktree directory exists.
@@ -623,7 +623,7 @@ func TestCreateWorktree_CreatesWorktreeAndBranch(t *testing.T) {
 	}
 
 	// Verify the branch was created.
-	if !gitBranchExists(task.BranchName, "") {
+	if !defaultGitOps.BranchExists(task.BranchName, "") {
 		t.Errorf("branch %q should exist after createWorktree()", task.BranchName)
 	}
 }
@@ -758,7 +758,7 @@ func TestRecoverStaleBranches_WithStaleBranch(t *testing.T) {
 	branchName := "task/main-99999"
 	gitRun(t, "branch", branchName)
 
-	if !gitBranchExists(branchName, "") {
+	if !defaultGitOps.BranchExists(branchName, "") {
 		t.Fatal("setup: branch should exist")
 	}
 
@@ -769,7 +769,7 @@ func TestRecoverStaleBranches_WithStaleBranch(t *testing.T) {
 	}
 
 	// The stale branch should have been force-deleted.
-	if gitBranchExists(branchName, "") {
+	if defaultGitOps.BranchExists(branchName, "") {
 		t.Error("stale branch should have been deleted after recovery")
 	}
 }
@@ -792,7 +792,7 @@ func TestRecoverStaleBranches_WithWorktree(t *testing.T) {
 	}
 
 	// Worktree and branch should be cleaned up.
-	if gitBranchExists(branchName, "") {
+	if defaultGitOps.BranchExists(branchName, "") {
 		t.Error("stale branch should have been deleted")
 	}
 	if _, err := os.Stat(worktreeDir); !os.IsNotExist(err) {
@@ -837,7 +837,7 @@ func TestRecoverStaleTasks_WithStaleBranch(t *testing.T) {
 	}
 
 	// Branch should have been cleaned up.
-	if gitBranchExists(branchName, "") {
+	if defaultGitOps.BranchExists(branchName, "") {
 		t.Error("stale branch should have been recovered")
 	}
 }
@@ -883,7 +883,7 @@ func TestResetTask_WithRealWorktree(t *testing.T) {
 	if _, err := os.Stat(worktreeDir); !os.IsNotExist(err) {
 		t.Error("worktree directory should have been removed")
 	}
-	if gitBranchExists(branchName, "") {
+	if defaultGitOps.BranchExists(branchName, "") {
 		t.Error("branch should have been force-deleted")
 	}
 }
@@ -925,8 +925,8 @@ func TestCreateWorktree_ExistingBranch(t *testing.T) {
 		t.Fatalf("createWorktree() with existing branch error = %v", err)
 	}
 	t.Cleanup(func() {
-		gitWorktreeRemove(task.WorktreeDir, "")
-		gitDeleteBranch(task.BranchName, "")
+		defaultGitOps.WorktreeRemove(task.WorktreeDir, "")
+		defaultGitOps.DeleteBranch(task.BranchName, "")
 	})
 
 	if _, err := os.Stat(task.WorktreeDir); os.IsNotExist(err) {
@@ -962,7 +962,7 @@ func TestCleanupWorktree_RealWorktree(t *testing.T) {
 		t.Error("worktree directory should have been removed")
 	}
 	// Branch should be deleted.
-	if gitBranchExists(branchName, "") {
+	if defaultGitOps.BranchExists(branchName, "") {
 		t.Errorf("branch %q should have been deleted", branchName)
 	}
 }
@@ -990,7 +990,7 @@ func TestCreateWorktree_Success(t *testing.T) {
 	}
 
 	// Branch should exist.
-	if !gitBranchExists(task.BranchName, ".") {
+	if !defaultGitOps.BranchExists(task.BranchName, ".") {
 		t.Error("branch should exist after createWorktree")
 	}
 
@@ -1022,13 +1022,13 @@ func TestGitBranchExists_ChecksLocalBranches(t *testing.T) {
 	_ = initTestGitRepo(t)
 
 	// Branch does not exist → gitBranchExists returns false.
-	if gitBranchExists("task/main-nonexistent", ".") {
+	if defaultGitOps.BranchExists("task/main-nonexistent", ".") {
 		t.Error("non-existent branch should not exist")
 	}
 
 	// Create a branch → exists.
 	gitRun(t, "branch", "task/main-99999")
-	if !gitBranchExists("task/main-99999", ".") {
+	if !defaultGitOps.BranchExists("task/main-99999", ".") {
 		t.Error("created branch should exist")
 	}
 }

--- a/pkg/orchestrator/tag_test.go
+++ b/pkg/orchestrator/tag_test.go
@@ -138,7 +138,7 @@ func TestTag_CreatesGitTag(t *testing.T) {
 	cfg := Config{}
 	cfg.applyDefaults()
 	// Set BaseBranch to whatever our test repo branch is.
-	current, err := gitCurrentBranch(".")
+	current, err := defaultGitOps.CurrentBranch(".")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +152,7 @@ func TestTag_CreatesGitTag(t *testing.T) {
 	}
 
 	// Verify the git tag was created.
-	tags := gitListTags("v0.*", ".")
+	tags := defaultGitOps.ListTags("v0.*", ".")
 	if len(tags) == 0 {
 		t.Error("expected at least one v0.* tag after Tag()")
 	}
@@ -162,7 +162,7 @@ func TestTag_VersionFileWriteError(t *testing.T) {
 	// Not parallel: uses os.Chdir via setupTagRepo.
 	setupTagRepo(t, nil)
 
-	current, err := gitCurrentBranch(".")
+	current, err := defaultGitOps.CurrentBranch(".")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/orchestrator/testloader.go
+++ b/pkg/orchestrator/testloader.go
@@ -49,7 +49,7 @@ func ResolverFromArg(arg string) BinaryResolver {
 		Log:            logf,
 		GitBin:         binGit,
 		GoBin:          binGo,
-		RemoveWorktree: gitWorktreeRemove,
+		RemoveWorktree: defaultGitOps.WorktreeRemove,
 	}
 	return compare.ResolverFromArg(arg, deps)
 }


### PR DESCRIPTION
## Summary

Remove 31 pure pass-through git wrapper functions from `commands.go` that added a full indirection layer to every git operation. All callers now use `defaultGitOps.Method()` directly. Parse helper wrappers replaced with direct `gitops.ParseFoo()` calls.

## Changes

- Deleted 31 git wrapper functions from `pkg/orchestrator/commands.go` (e.g. `gitCheckout`, `gitCommit`, `gitBranchExists`)
- Updated 9 production files to call `defaultGitOps.Method()` directly
- Updated 4 test files to use `defaultGitOps.Method()` and `gitops.ParseFoo()` directly
- Retained `diffNameStatus()` which performs a type conversion between `gitops.FileChange` and `claude.FileChange`
- Kept `defaultGitOps`, `diffStat` type alias, constants, and Go helpers unchanged

## Stats

- Production LOC: 19396 → 19145 (-251)
- Test LOC: 34316 → 34319 (+3)
- Net: -248 lines
- 15 files changed

## Test plan

- [x] `go vet ./pkg/orchestrator/...` passes
- [x] `go test ./pkg/orchestrator/ -count=1` passes (17.3s)
- [x] `go build ./...` passes

Closes #1687