### PR TITLE
GH-1689: Reduce Claude delegation wrapper indirection in cobbler.go

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -5,68 +5,14 @@ package orchestrator
 
 import (
 	"context"
-	"encoding/json"
 	"os/exec"
 
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
 )
 
 // ---------------------------------------------------------------------------
-// Dependency injection: wire the parent package's logf, binary paths,
-// and helper functions into the internal/claude package at init time.
-// ---------------------------------------------------------------------------
-
-func init() {
-	claude.Log = logf
-	claude.BinGit = binGit
-	claude.BinClaude = binClaude
-}
-
-// ---------------------------------------------------------------------------
-// Type aliases for backward compatibility
-// ---------------------------------------------------------------------------
-
-// Runner executes Claude in a specific mode (CLI or SDK).
-type Runner = claude.Runner
-
-// CLIRunner executes Claude by running the claude binary directly.
-type CLIRunner = claude.CLIRunner
-
-// SDKRunner executes Claude via the Go Agent SDK.
-type SDKRunner = claude.SDKRunner
-
-// ClaudeResult holds token usage from a Claude invocation.
-type ClaudeResult = claude.ClaudeResult
-
-// LocSnapshot holds a point-in-time LOC count.
-type LocSnapshot = claude.LocSnapshot
-
-// InvocationRecord is the JSON blob recorded as a GitHub issue comment.
-type InvocationRecord = claude.InvocationRecord
-
-// HistoryStats is the YAML-serializable stats file.
-type HistoryStats = claude.HistoryStats
-
-// StitchReport is the YAML-serializable stitch report.
-type StitchReport = claude.StitchReport
-
-// claudeTokens holds token counts for an invocation record.
-type claudeTokens = claude.ClaudeTokens
-
-// diffRecord holds file-level diff statistics.
-type diffRecord = claude.DiffRecord
-
-// historyTokens holds token counts in the history stats YAML.
-type historyTokens = claude.HistoryTokens
-
-// historyDiff holds diff statistics in the history stats YAML.
-type historyDiff = claude.HistoryDiff
-
-// FileChange holds per-file diff information.
-type FileChange = claude.FileChange
-
-// ---------------------------------------------------------------------------
-// Orchestrator wrapper methods
+// Orchestrator methods — each wires Config fields into dependency structs
+// before delegating to internal/claude.
 // ---------------------------------------------------------------------------
 
 // historyDir returns the resolved history directory path.
@@ -75,12 +21,12 @@ func (o *Orchestrator) historyDir() string {
 }
 
 // saveHistoryReport writes a stitch report YAML file to the history directory.
-func (o *Orchestrator) saveHistoryReport(ts string, report StitchReport) {
+func (o *Orchestrator) saveHistoryReport(ts string, report claude.StitchReport) {
 	claude.SaveHistoryReport(o.historyDir(), ts, report)
 }
 
 // saveHistoryStats writes a stats YAML file to the history directory.
-func (o *Orchestrator) saveHistoryStats(ts, phase string, stats HistoryStats) {
+func (o *Orchestrator) saveHistoryStats(ts, phase string, stats claude.HistoryStats) {
 	claude.SaveHistoryStats(o.historyDir(), ts, phase, stats)
 }
 
@@ -95,24 +41,24 @@ func (o *Orchestrator) saveHistoryLog(ts, phase string, rawOutput []byte) {
 }
 
 // captureLOC returns the current Go LOC counts.
-func (o *Orchestrator) captureLOC() LocSnapshot {
+func (o *Orchestrator) captureLOC() claude.LocSnapshot {
 	rec, err := o.CollectStats()
 	if err != nil {
 		logf("captureLOC: collectStats error: %v", err)
-		return LocSnapshot{}
+		return claude.LocSnapshot{}
 	}
-	return LocSnapshot{Production: rec.GoProdLOC, Test: rec.GoTestLOC}
+	return claude.LocSnapshot{Production: rec.GoProdLOC, Test: rec.GoTestLOC}
 }
 
 // captureLOCAt returns Go LOC counts measured in dir.
-func (o *Orchestrator) captureLOCAt(dir string) LocSnapshot {
+func (o *Orchestrator) captureLOCAt(dir string) claude.LocSnapshot {
 	return claude.CaptureLOCAt(dir, o.captureLOC)
 }
 
 // checkClaude verifies that Claude can be invoked.
 func (o *Orchestrator) checkClaude() error {
 	return claude.CheckClaude(claude.CheckClaudeDeps{
-		EffectiveMode:      o.cfg.Cobbler.effectiveMode(),
+		EffectiveMode:       o.cfg.Cobbler.effectiveMode(),
 		EnsureCredentialsFn: o.ensureCredentials,
 	})
 }
@@ -139,12 +85,12 @@ func (o *Orchestrator) logConfig(target string) {
 }
 
 // runner returns a Runner for the configured execution mode.
-func (o *Orchestrator) runner() Runner {
+func (o *Orchestrator) runner() claude.Runner {
 	return claude.NewRunner(o.runClaudeDeps())
 }
 
 // runClaude executes Claude and returns token usage.
-func (o *Orchestrator) runClaude(prompt, dir string, silence bool, extraClaudeArgs ...string) (ClaudeResult, error) {
+func (o *Orchestrator) runClaude(prompt, dir string, silence bool, extraClaudeArgs ...string) (claude.ClaudeResult, error) {
 	return claude.RunClaude(o.runClaudeDeps(), prompt, dir, silence, extraClaudeArgs...)
 }
 
@@ -167,14 +113,14 @@ func (o *Orchestrator) runClaudeDeps() claude.RunClaudeDeps {
 // runMeasureClaude executes Claude with the measure-specific idle timeout,
 // which is higher than the default to accommodate large prompts that cause
 // extended thinking time (GH-1509).
-func (o *Orchestrator) runMeasureClaude(prompt, dir string, silence bool, extraClaudeArgs ...string) (ClaudeResult, error) {
+func (o *Orchestrator) runMeasureClaude(prompt, dir string, silence bool, extraClaudeArgs ...string) (claude.ClaudeResult, error) {
 	deps := o.runClaudeDeps()
 	deps.IdleTimeoutS = o.cfg.Cobbler.MeasureIdleTimeoutSeconds
 	return claude.RunClaude(deps, prompt, dir, silence, extraClaudeArgs...)
 }
 
 // runClaudeSDK executes Claude via the Go Agent SDK.
-func (o *Orchestrator) runClaudeSDK(ctx context.Context, prompt, workDir string, silence bool, extraClaudeArgs ...string) (ClaudeResult, error) {
+func (o *Orchestrator) runClaudeSDK(ctx context.Context, prompt, workDir string, silence bool, extraClaudeArgs ...string) (claude.ClaudeResult, error) {
 	return claude.RunClaudeSDK(o.runClaudeDeps(), ctx, prompt, workDir, silence, extraClaudeArgs...)
 }
 
@@ -206,60 +152,3 @@ func (o *Orchestrator) HistoryClean() error {
 func (o *Orchestrator) CobblerReset() error {
 	return claude.CobblerReset(o.cfg.Cobbler.Dir)
 }
-
-// ---------------------------------------------------------------------------
-// Functions delegated to internal/claude (package-level)
-// ---------------------------------------------------------------------------
-
-// parseClaudeTokens extracts token usage from Claude's stream-json output.
-func parseClaudeTokens(output []byte) ClaudeResult {
-	return claude.ParseClaudeTokens(output)
-}
-
-// extractTextFromStreamJSON concatenates all text blocks from assistant messages.
-func extractTextFromStreamJSON(rawOutput []byte) string {
-	return claude.ExtractTextFromStreamJSON(rawOutput)
-}
-
-// extractYAMLBlock finds the first ```yaml fenced code block in text.
-func extractYAMLBlock(text string) ([]byte, error) {
-	return claude.ExtractYAMLBlock(text)
-}
-
-// filterSDKStderr reads lines from r and replaces rate-limit warnings.
-var filterSDKStderr = claude.FilterSDKStderr
-
-// toolSummary extracts a concise context string from tool input JSON.
-func toolSummary(input json.RawMessage) string {
-	return claude.ToolSummary(input)
-}
-
-// intFromUsage extracts an integer from the ResultMessage usage map.
-func intFromUsage(usage map[string]interface{}, key string) int {
-	return claude.IntFromUsage(usage, key)
-}
-
-// formatOutcomeTrailers returns the set of git trailer strings for rec.
-func formatOutcomeTrailers(rec InvocationRecord) []string {
-	return claude.FormatOutcomeTrailers(rec)
-}
-
-// appendOutcomeTrailers amends the last commit with outcome trailers.
-func appendOutcomeTrailers(worktreeDir string, rec InvocationRecord) error {
-	return claude.AppendOutcomeTrailers(worktreeDir, rec, defaultGitOps.CommitAmendTrailers)
-}
-
-// worktreeBasePath returns the directory used for stitch worktrees.
-func worktreeBasePath() string {
-	return claude.WorktreeBasePath()
-}
-
-// progressWriter wraps a bytes.Buffer, logging concise event summaries.
-type progressWriter = claude.ProgressWriter
-
-// newProgressWriter creates a progressWriter.
-var newProgressWriter = claude.NewProgressWriter
-
-// idleTrackingWriter wraps an io.Writer and records the last write timestamp.
-type idleTrackingWriter = claude.IdleTrackingWriter
-

--- a/pkg/orchestrator/cobbler_test.go
+++ b/pkg/orchestrator/cobbler_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	claudetypes "github.com/schlunsen/claude-agent-sdk-go/types"
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/gitops"
 	"gopkg.in/yaml.v3"
 )
@@ -27,19 +28,19 @@ import (
 // --- StitchReport YAML serialization ---
 
 func TestStitchReport_SerializesAllFields(t *testing.T) {
-	report := StitchReport{
+	report := claude.StitchReport{
 		TaskID:    "mage-abc.1",
 		TaskTitle: "Add widget feature",
 		Status:    "success",
 		Branch:    "task/main-mage-abc.1",
-		Diff:      historyDiff{Files: 3, Insertions: 120, Deletions: 15},
-		Files: []FileChange{
+		Diff:      claude.HistoryDiff{Files: 3, Insertions: 120, Deletions: 15},
+		Files: []claude.FileChange{
 			{Path: "pkg/widget/widget.go", Status: "A", Insertions: 80, Deletions: 0},
 			{Path: "pkg/widget/widget_test.go", Status: "A", Insertions: 40, Deletions: 0},
 			{Path: "go.mod", Status: "M", Insertions: 0, Deletions: 15},
 		},
-		LOCBefore: LocSnapshot{Production: 500, Test: 200},
-		LOCAfter:  LocSnapshot{Production: 580, Test: 240},
+		LOCBefore: claude.LocSnapshot{Production: 500, Test: 200},
+		LOCAfter:  claude.LocSnapshot{Production: 580, Test: 240},
 	}
 
 	data, err := yaml.Marshal(&report)
@@ -48,7 +49,7 @@ func TestStitchReport_SerializesAllFields(t *testing.T) {
 	}
 
 	// Round-trip: unmarshal back and verify fields.
-	var got StitchReport
+	var got claude.StitchReport
 	if err := yaml.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
@@ -215,17 +216,17 @@ func TestSaveHistoryReport_WritesFile(t *testing.T) {
 		},
 	}
 
-	report := StitchReport{
+	report := claude.StitchReport{
 		TaskID:    "test-001",
 		TaskTitle: "Test task",
 		Status:    "success",
 		Branch:    "task/main-test-001",
-		Diff:      historyDiff{Files: 1, Insertions: 10, Deletions: 2},
-		Files: []FileChange{
+		Diff:      claude.HistoryDiff{Files: 1, Insertions: 10, Deletions: 2},
+		Files: []claude.FileChange{
 			{Path: "pkg/foo.go", Status: "M", Insertions: 10, Deletions: 2},
 		},
-		LOCBefore: LocSnapshot{Production: 100, Test: 50},
-		LOCAfter:  LocSnapshot{Production: 108, Test: 50},
+		LOCBefore: claude.LocSnapshot{Production: 100, Test: 50},
+		LOCAfter:  claude.LocSnapshot{Production: 108, Test: 50},
 	}
 
 	ts := "2026-02-24-10-00-00"
@@ -237,7 +238,7 @@ func TestSaveHistoryReport_WritesFile(t *testing.T) {
 		t.Fatalf("read report file: %v", err)
 	}
 
-	var got StitchReport
+	var got claude.StitchReport
 	if err := yaml.Unmarshal(data, &got); err != nil {
 		t.Fatalf("unmarshal report: %v", err)
 	}
@@ -257,7 +258,7 @@ func TestExtractTextFromStreamJSON_SingleAssistantMessage(t *testing.T) {
 {"type":"assistant","message":{"content":[{"type":"text","text":"Here is the output:\n\n` + "```yaml\\n- index: 0\\n  title: Task one\\n```" + `"}]}}
 {"type":"result","usage":{"input_tokens":100,"output_tokens":50}}
 `)
-	text := extractTextFromStreamJSON(raw)
+	text := claude.ExtractTextFromStreamJSON(raw)
 	if text == "" {
 		t.Fatal("expected non-empty text")
 	}
@@ -271,7 +272,7 @@ func TestExtractTextFromStreamJSON_NoAssistantMessages(t *testing.T) {
 	raw := []byte(`{"type":"system","message":"ready"}
 {"type":"result","usage":{"input_tokens":100,"output_tokens":0}}
 `)
-	text := extractTextFromStreamJSON(raw)
+	text := claude.ExtractTextFromStreamJSON(raw)
 	if text != "" {
 		t.Errorf("expected empty text, got: %s", text)
 	}
@@ -281,7 +282,7 @@ func TestExtractTextFromStreamJSON_MultipleTextBlocks(t *testing.T) {
 	t.Parallel()
 	raw := []byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"first "},{"type":"text","text":"second"}]}}
 `)
-	text := extractTextFromStreamJSON(raw)
+	text := claude.ExtractTextFromStreamJSON(raw)
 	if text != "first second" {
 		t.Errorf("expected 'first second', got: %q", text)
 	}
@@ -291,7 +292,7 @@ func TestExtractTextFromStreamJSON_PlainTextFallback(t *testing.T) {
 	t.Parallel()
 	// SDK mode stores plain text in RawOutput — no JSON lines at all.
 	raw := []byte("```yaml\n- title: foo\n```\n")
-	text := extractTextFromStreamJSON(raw)
+	text := claude.ExtractTextFromStreamJSON(raw)
 	if text != string(raw) {
 		t.Errorf("expected raw text passthrough, got: %q", text)
 	}
@@ -302,7 +303,7 @@ func TestExtractTextFromStreamJSON_PlainTextFallback(t *testing.T) {
 func TestExtractYAMLBlock_ValidFencedBlock(t *testing.T) {
 	t.Parallel()
 	text := "Here is the YAML:\n\n```yaml\n- index: 0\n  title: Task one\n  dependency: -1\n```\n\nDone."
-	yaml, err := extractYAMLBlock(text)
+	yaml, err := claude.ExtractYAMLBlock(text)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -315,7 +316,7 @@ func TestExtractYAMLBlock_ValidFencedBlock(t *testing.T) {
 func TestExtractYAMLBlock_YmlFence(t *testing.T) {
 	t.Parallel()
 	text := "```yml\n- index: 0\n```\n"
-	yaml, err := extractYAMLBlock(text)
+	yaml, err := claude.ExtractYAMLBlock(text)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -327,7 +328,7 @@ func TestExtractYAMLBlock_YmlFence(t *testing.T) {
 func TestExtractYAMLBlock_NoFencedBlock(t *testing.T) {
 	t.Parallel()
 	text := "Here is some text with no YAML block."
-	_, err := extractYAMLBlock(text)
+	_, err := claude.ExtractYAMLBlock(text)
 	if err == nil {
 		t.Error("expected error for missing YAML block")
 	}
@@ -336,7 +337,7 @@ func TestExtractYAMLBlock_NoFencedBlock(t *testing.T) {
 func TestExtractYAMLBlock_UnclosedBlock(t *testing.T) {
 	t.Parallel()
 	text := "```yaml\n- index: 0\n  title: Task one"
-	_, err := extractYAMLBlock(text)
+	_, err := claude.ExtractYAMLBlock(text)
 	if err == nil {
 		t.Error("expected error for unclosed YAML block")
 	}
@@ -350,7 +351,7 @@ func TestParseClaudeTokens_ValidResult(t *testing.T) {
 {"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}
 {"type":"result","total_cost_usd":0.0325,"usage":{"input_tokens":1000,"output_tokens":500,"cache_creation_input_tokens":200,"cache_read_input_tokens":300}}
 `)
-	got := parseClaudeTokens(output)
+	got := claude.ParseClaudeTokens(output)
 	if got.InputTokens != 1500 {
 		t.Errorf("InputTokens = %d, want 1500 (1000+200+300)", got.InputTokens)
 	}
@@ -373,7 +374,7 @@ func TestParseClaudeTokens_NoResultEvent(t *testing.T) {
 	output := []byte(`{"type":"system","message":"ready"}
 {"type":"assistant","message":{"content":[{"type":"text","text":"hello"}]}}
 `)
-	got := parseClaudeTokens(output)
+	got := claude.ParseClaudeTokens(output)
 	if got.InputTokens != 0 || got.OutputTokens != 0 {
 		t.Errorf("expected zero tokens for missing result, got in=%d out=%d", got.InputTokens, got.OutputTokens)
 	}
@@ -381,7 +382,7 @@ func TestParseClaudeTokens_NoResultEvent(t *testing.T) {
 
 func TestParseClaudeTokens_EmptyInput(t *testing.T) {
 	t.Parallel()
-	got := parseClaudeTokens([]byte(""))
+	got := claude.ParseClaudeTokens([]byte(""))
 	if got.InputTokens != 0 {
 		t.Errorf("expected zero tokens for empty input, got %d", got.InputTokens)
 	}
@@ -392,18 +393,18 @@ func TestParseClaudeTokens_EmptyInput(t *testing.T) {
 func TestToolSummary_FilePath(t *testing.T) {
 	t.Parallel()
 	input := json.RawMessage(`{"file_path":"pkg/orchestrator/generator.go","content":"hello"}`)
-	got := toolSummary(input)
+	got := claude.ToolSummary(input)
 	if got != "pkg/orchestrator/generator.go" {
-		t.Errorf("toolSummary(file_path) = %q, want %q", got, "pkg/orchestrator/generator.go")
+		t.Errorf("claude.ToolSummary(file_path) = %q, want %q", got, "pkg/orchestrator/generator.go")
 	}
 }
 
 func TestToolSummary_Command(t *testing.T) {
 	t.Parallel()
 	input := json.RawMessage(`{"command":"go test ./..."}`)
-	got := toolSummary(input)
+	got := claude.ToolSummary(input)
 	if got != "go test ./..." {
-		t.Errorf("toolSummary(command) = %q, want %q", got, "go test ./...")
+		t.Errorf("claude.ToolSummary(command) = %q, want %q", got, "go test ./...")
 	}
 }
 
@@ -411,38 +412,38 @@ func TestToolSummary_LongCommandTruncated(t *testing.T) {
 	t.Parallel()
 	longCmd := strings.Repeat("x", 100)
 	input := json.RawMessage(`{"command":"` + longCmd + `"}`)
-	got := toolSummary(input)
+	got := claude.ToolSummary(input)
 	if len(got) != 83 { // 80 + "..."
-		t.Errorf("toolSummary(long command) len = %d, want 83", len(got))
+		t.Errorf("claude.ToolSummary(long command) len = %d, want 83", len(got))
 	}
 	if !strings.HasSuffix(got, "...") {
-		t.Errorf("toolSummary(long command) should end with '...', got %q", got)
+		t.Errorf("claude.ToolSummary(long command) should end with '...', got %q", got)
 	}
 }
 
 func TestToolSummary_Pattern(t *testing.T) {
 	t.Parallel()
 	input := json.RawMessage(`{"pattern":"**/*.go"}`)
-	got := toolSummary(input)
+	got := claude.ToolSummary(input)
 	if got != "**/*.go" {
-		t.Errorf("toolSummary(pattern) = %q, want %q", got, "**/*.go")
+		t.Errorf("claude.ToolSummary(pattern) = %q, want %q", got, "**/*.go")
 	}
 }
 
 func TestToolSummary_EmptyInput(t *testing.T) {
 	t.Parallel()
-	got := toolSummary(json.RawMessage(""))
+	got := claude.ToolSummary(json.RawMessage(""))
 	if got != "" {
-		t.Errorf("toolSummary(empty) = %q, want empty", got)
+		t.Errorf("claude.ToolSummary(empty) = %q, want empty", got)
 	}
 }
 
 func TestToolSummary_NoKnownFields(t *testing.T) {
 	t.Parallel()
 	input := json.RawMessage(`{"unknown_field":"value"}`)
-	got := toolSummary(input)
+	got := claude.ToolSummary(input)
 	if got != "" {
-		t.Errorf("toolSummary(unknown) = %q, want empty", got)
+		t.Errorf("claude.ToolSummary(unknown) = %q, want empty", got)
 	}
 }
 
@@ -450,9 +451,9 @@ func TestToolSummary_PriorityOrder(t *testing.T) {
 	t.Parallel()
 	// file_path should take priority over command
 	input := json.RawMessage(`{"file_path":"foo.go","command":"go build"}`)
-	got := toolSummary(input)
+	got := claude.ToolSummary(input)
 	if got != "foo.go" {
-		t.Errorf("toolSummary(priority) = %q, want %q", got, "foo.go")
+		t.Errorf("claude.ToolSummary(priority) = %q, want %q", got, "foo.go")
 	}
 }
 
@@ -464,7 +465,7 @@ func TestSaveHistoryReport_NoOpWhenHistoryDirEmpty(t *testing.T) {
 	}
 
 	// Should not panic or create any files.
-	o.saveHistoryReport("2026-02-24-10-00-00", StitchReport{
+	o.saveHistoryReport("2026-02-24-10-00-00", claude.StitchReport{
 		TaskID: "test-noop",
 		Status: "success",
 	})
@@ -507,12 +508,12 @@ func TestHistoryDir_Relative(t *testing.T) {
 
 func TestWorktreeBasePath(t *testing.T) {
 	t.Parallel()
-	got := worktreeBasePath()
+	got := claude.WorktreeBasePath()
 	if got == "" {
-		t.Fatal("worktreeBasePath() returned empty string")
+		t.Fatal("claude.WorktreeBasePath() returned empty string")
 	}
 	if !strings.HasSuffix(got, "-worktrees") {
-		t.Errorf("worktreeBasePath() = %q, want suffix '-worktrees'", got)
+		t.Errorf("claude.WorktreeBasePath() = %q, want suffix '-worktrees'", got)
 	}
 }
 
@@ -555,11 +556,11 @@ func TestWorktreeBasePath_FromWorktree(t *testing.T) {
 
 	// Call from main repo.
 	os.Chdir(mainDir)
-	fromMain := worktreeBasePath()
+	fromMain := claude.WorktreeBasePath()
 
 	// Call from inside the worktree.
 	os.Chdir(wtDir)
-	fromWorktree := worktreeBasePath()
+	fromWorktree := claude.WorktreeBasePath()
 
 	if fromMain != expected {
 		t.Errorf("from main: got %q, want %q", fromMain, expected)
@@ -580,9 +581,9 @@ func TestWorktreeBasePath_FallbackOutsideGit(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(orig)
 
-	got := worktreeBasePath()
+	got := claude.WorktreeBasePath()
 	if got == "" {
-		t.Fatal("worktreeBasePath() returned empty string in fallback")
+		t.Fatal("claude.WorktreeBasePath() returned empty string in fallback")
 	}
 	if !strings.HasSuffix(got, "-worktrees") {
 		t.Errorf("fallback: got %q, want suffix '-worktrees'", got)
@@ -602,7 +603,7 @@ func TestSaveHistoryStats_WritesFile(t *testing.T) {
 		HistoryDir: "hist",
 	}}}
 
-	stats := HistoryStats{
+	stats := claude.HistoryStats{
 		Caller: "test",
 		TaskID: "task-001",
 		Status: "success",
@@ -623,7 +624,7 @@ func TestSaveHistoryStats_NoOpWhenEmpty(t *testing.T) {
 	t.Parallel()
 	o := &Orchestrator{cfg: Config{Cobbler: CobblerConfig{HistoryDir: ""}}}
 	// Should not panic.
-	o.saveHistoryStats("ts", "phase", HistoryStats{})
+	o.saveHistoryStats("ts", "phase", claude.HistoryStats{})
 }
 
 // --- saveHistoryPrompt ---
@@ -688,7 +689,7 @@ func TestSaveHistoryReport_MkdirError(t *testing.T) {
 	os.WriteFile(f, []byte("x"), 0o644)
 	o := &Orchestrator{cfg: Config{Cobbler: CobblerConfig{HistoryDir: filepath.Join(f, "sub")}}}
 	// Should not panic; logs the mkdir error and returns.
-	o.saveHistoryReport("ts", StitchReport{})
+	o.saveHistoryReport("ts", claude.StitchReport{})
 }
 
 func TestSaveHistoryStats_MkdirError(t *testing.T) {
@@ -696,7 +697,7 @@ func TestSaveHistoryStats_MkdirError(t *testing.T) {
 	f := filepath.Join(t.TempDir(), "blocker")
 	os.WriteFile(f, []byte("x"), 0o644)
 	o := &Orchestrator{cfg: Config{Cobbler: CobblerConfig{HistoryDir: filepath.Join(f, "sub")}}}
-	o.saveHistoryStats("ts", "phase", HistoryStats{})
+	o.saveHistoryStats("ts", "phase", claude.HistoryStats{})
 }
 
 func TestSaveHistoryPrompt_MkdirError(t *testing.T) {
@@ -821,15 +822,15 @@ func TestEffectiveMode_SDKMode(t *testing.T) {
 
 func TestIntFromUsage_NilMap(t *testing.T) {
 	t.Parallel()
-	if got := intFromUsage(nil, "input_tokens"); got != 0 {
-		t.Errorf("intFromUsage(nil) = %d; want 0", got)
+	if got := claude.IntFromUsage(nil, "input_tokens"); got != 0 {
+		t.Errorf("claude.IntFromUsage(nil) = %d; want 0", got)
 	}
 }
 
 func TestIntFromUsage_MissingKey(t *testing.T) {
 	t.Parallel()
 	m := map[string]interface{}{"output_tokens": float64(100)}
-	if got := intFromUsage(m, "input_tokens"); got != 0 {
+	if got := claude.IntFromUsage(m, "input_tokens"); got != 0 {
 		t.Errorf("intFromUsage missing key = %d; want 0", got)
 	}
 }
@@ -837,7 +838,7 @@ func TestIntFromUsage_MissingKey(t *testing.T) {
 func TestIntFromUsage_Float64(t *testing.T) {
 	t.Parallel()
 	m := map[string]interface{}{"input_tokens": float64(512)}
-	if got := intFromUsage(m, "input_tokens"); got != 512 {
+	if got := claude.IntFromUsage(m, "input_tokens"); got != 512 {
 		t.Errorf("intFromUsage float64 = %d; want 512", got)
 	}
 }
@@ -845,7 +846,7 @@ func TestIntFromUsage_Float64(t *testing.T) {
 func TestIntFromUsage_Int(t *testing.T) {
 	t.Parallel()
 	m := map[string]interface{}{"input_tokens": int(256)}
-	if got := intFromUsage(m, "input_tokens"); got != 256 {
+	if got := claude.IntFromUsage(m, "input_tokens"); got != 256 {
 		t.Errorf("intFromUsage int = %d; want 256", got)
 	}
 }
@@ -853,7 +854,7 @@ func TestIntFromUsage_Int(t *testing.T) {
 func TestIntFromUsage_Int64(t *testing.T) {
 	t.Parallel()
 	m := map[string]interface{}{"input_tokens": int64(1024)}
-	if got := intFromUsage(m, "input_tokens"); got != 1024 {
+	if got := claude.IntFromUsage(m, "input_tokens"); got != 1024 {
 		t.Errorf("intFromUsage int64 = %d; want 1024", got)
 	}
 }
@@ -861,7 +862,7 @@ func TestIntFromUsage_Int64(t *testing.T) {
 func TestIntFromUsage_UnknownType(t *testing.T) {
 	t.Parallel()
 	m := map[string]interface{}{"input_tokens": "not-a-number"}
-	if got := intFromUsage(m, "input_tokens"); got != 0 {
+	if got := claude.IntFromUsage(m, "input_tokens"); got != 0 {
 		t.Errorf("intFromUsage unknown type = %d; want 0", got)
 	}
 }
@@ -873,7 +874,7 @@ func TestSaveHistoryReport_EmptyHistoryDir_NoOp(t *testing.T) {
 	// panicking. No files should be created.
 	o := New(Config{})
 	o.cfg.Cobbler.HistoryDir = "" // override default
-	o.saveHistoryReport("20260101T120000", StitchReport{TaskID: "t1", Status: "success"})
+	o.saveHistoryReport("20260101T120000", claude.StitchReport{TaskID: "t1", Status: "success"})
 	// success: did not panic
 }
 
@@ -881,7 +882,7 @@ func TestSaveHistoryReport_WritesToDisk(t *testing.T) {
 	tmp := t.TempDir()
 	o := New(Config{})
 	o.cfg.Cobbler.HistoryDir = tmp
-	o.saveHistoryReport("20260101T120000", StitchReport{TaskID: "t1", Status: "success"})
+	o.saveHistoryReport("20260101T120000", claude.StitchReport{TaskID: "t1", Status: "success"})
 
 	entries, err := os.ReadDir(tmp)
 	if err != nil {
@@ -898,7 +899,7 @@ func TestSaveHistoryReport_WritesToDisk(t *testing.T) {
 func TestSaveHistoryStats_EmptyHistoryDir_NoOp(t *testing.T) {
 	o := New(Config{})
 	o.cfg.Cobbler.HistoryDir = ""
-	o.saveHistoryStats("20260101T120000", "stitch", HistoryStats{})
+	o.saveHistoryStats("20260101T120000", "stitch", claude.HistoryStats{})
 	// success: did not panic
 }
 
@@ -1021,14 +1022,14 @@ func TestCaptureLOCAt_EmptyDirString_FallsBackToCwd(t *testing.T) {
 
 func TestInvocationRecord_JSONShape(t *testing.T) {
 	t.Parallel()
-	rec := InvocationRecord{
+	rec := claude.InvocationRecord{
 		Caller:    "stitch",
 		StartedAt: "2026-02-27T10:00:00Z",
 		DurationS: 42,
-		Tokens:    claudeTokens{Input: 1500, Output: 500, CacheCreation: 200, CacheRead: 300, CostUSD: 0.0325},
-		LOCBefore: LocSnapshot{Production: 100, Test: 50},
-		LOCAfter:  LocSnapshot{Production: 110, Test: 55},
-		Diff:      diffRecord{Files: 3, Insertions: 20, Deletions: 5},
+		Tokens:    claude.ClaudeTokens{Input: 1500, Output: 500, CacheCreation: 200, CacheRead: 300, CostUSD: 0.0325},
+		LOCBefore: claude.LocSnapshot{Production: 100, Test: 50},
+		LOCAfter:  claude.LocSnapshot{Production: 110, Test: 55},
+		Diff:      claude.DiffRecord{Files: 3, Insertions: 20, Deletions: 5},
 	}
 
 	data, err := json.Marshal(rec)
@@ -1055,7 +1056,7 @@ func TestInvocationRecord_JSONShape(t *testing.T) {
 		t.Errorf("caller = %q, want stitch", caller)
 	}
 
-	var tokens claudeTokens
+	var tokens claude.ClaudeTokens
 	json.Unmarshal(got["tokens"], &tokens)
 	if tokens.Input != 1500 || tokens.Output != 500 {
 		t.Errorf("tokens = %+v, want {Input:1500 Output:500}", tokens)
@@ -1071,7 +1072,7 @@ func TestParseClaudeTokens_MalformedResultEvent(t *testing.T) {
 	t.Parallel()
 	// type="result" line present but usage field is malformed JSON.
 	output := []byte(`{"type":"result","usage":"not_an_object"}`)
-	got := parseClaudeTokens(output)
+	got := claude.ParseClaudeTokens(output)
 	// Malformed result: should return zero values gracefully.
 	if got.InputTokens != 0 || got.OutputTokens != 0 {
 		t.Errorf("malformed result: got in=%d out=%d, want 0 0", got.InputTokens, got.OutputTokens)
@@ -1082,15 +1083,15 @@ func TestParseClaudeTokens_MalformedResultEvent(t *testing.T) {
 
 func TestFormatOutcomeTrailers_ReturnsTenStrings(t *testing.T) {
 	t.Parallel()
-	rec := InvocationRecord{
+	rec := claude.InvocationRecord{
 		Caller:    "stitch",
 		StartedAt: "2026-02-28T00:00:00Z",
 		DurationS: 1234,
-		Tokens:    claudeTokens{Input: 45000, Output: 12000, CacheCreation: 5000, CacheRead: 3000, CostUSD: 0.75},
-		LOCBefore: LocSnapshot{Production: 441, Test: 0},
-		LOCAfter:  LocSnapshot{Production: 520, Test: 45},
+		Tokens:    claude.ClaudeTokens{Input: 45000, Output: 12000, CacheCreation: 5000, CacheRead: 3000, CostUSD: 0.75},
+		LOCBefore: claude.LocSnapshot{Production: 441, Test: 0},
+		LOCAfter:  claude.LocSnapshot{Production: 520, Test: 45},
 	}
-	trailers := formatOutcomeTrailers(rec)
+	trailers := claude.FormatOutcomeTrailers(rec)
 	if len(trailers) != 10 {
 		t.Fatalf("formatOutcomeTrailers: got %d trailers, want 10; trailers=%v", len(trailers), trailers)
 	}
@@ -1115,7 +1116,7 @@ func TestFormatOutcomeTrailers_ReturnsTenStrings(t *testing.T) {
 
 func TestFormatOutcomeTrailers_ZeroRecord(t *testing.T) {
 	t.Parallel()
-	trailers := formatOutcomeTrailers(InvocationRecord{})
+	trailers := claude.FormatOutcomeTrailers(claude.InvocationRecord{})
 	if len(trailers) != 10 {
 		t.Fatalf("zero record: got %d trailers, want 10", len(trailers))
 	}
@@ -1155,13 +1156,13 @@ func TestAppendOutcomeTrailers_AmendsLastCommit(t *testing.T) {
 		}
 	}
 
-	rec := InvocationRecord{
+	rec := claude.InvocationRecord{
 		DurationS: 120,
-		Tokens:    claudeTokens{Input: 1000, Output: 200, CacheCreation: 50, CacheRead: 30, CostUSD: 0.05},
-		LOCBefore: LocSnapshot{Production: 100, Test: 20},
-		LOCAfter:  LocSnapshot{Production: 150, Test: 30},
+		Tokens:    claude.ClaudeTokens{Input: 1000, Output: 200, CacheCreation: 50, CacheRead: 30, CostUSD: 0.05},
+		LOCBefore: claude.LocSnapshot{Production: 100, Test: 20},
+		LOCAfter:  claude.LocSnapshot{Production: 150, Test: 30},
 	}
-	if err := appendOutcomeTrailers(dir, rec); err != nil {
+	if err := claude.AppendOutcomeTrailers(dir, rec, defaultGitOps.CommitAmendTrailers); err != nil {
 		// git commit --amend --trailer requires git >= 2.38; skip if unsupported.
 		t.Skipf("appendOutcomeTrailers: %v", err)
 	}
@@ -1191,7 +1192,7 @@ func TestNewProgressWriter(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
 	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
-	pw := newProgressWriter(&buf, start)
+	pw := claude.NewProgressWriter(&buf, start)
 	if pw == nil {
 		t.Fatal("newProgressWriter returned nil")
 	}
@@ -1214,7 +1215,7 @@ func TestNewProgressWriter(t *testing.T) {
 func TestProgressWriter_Write_PassesThrough(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	pw := newProgressWriter(&buf, time.Now())
+	pw := claude.NewProgressWriter(&buf, time.Now())
 	data := []byte(`{"type":"system"}` + "\n")
 	n, err := pw.Write(data)
 	if err != nil {
@@ -1231,7 +1232,7 @@ func TestProgressWriter_Write_PassesThrough(t *testing.T) {
 func TestProgressWriter_Write_SetsGotFirst(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	pw := newProgressWriter(&buf, time.Now())
+	pw := claude.NewProgressWriter(&buf, time.Now())
 	if pw.GotFirst {
 		t.Fatal("gotFirst should be false before first write")
 	}
@@ -1244,7 +1245,7 @@ func TestProgressWriter_Write_SetsGotFirst(t *testing.T) {
 func TestProgressWriter_Write_AccumulatesPartial(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	pw := newProgressWriter(&buf, time.Now())
+	pw := claude.NewProgressWriter(&buf, time.Now())
 	// Write without newline — should accumulate in partial.
 	pw.Write([]byte(`{"type":"sys`))
 	if len(pw.Partial) == 0 {
@@ -1263,7 +1264,7 @@ func TestProgressWriter_Write_AccumulatesPartial(t *testing.T) {
 func TestProgressWriter_LogLine_EmptyLine(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	pw := newProgressWriter(&buf, time.Now())
+	pw := claude.NewProgressWriter(&buf, time.Now())
 	// Should not panic on empty line.
 	pw.LogLine(nil)
 	pw.LogLine([]byte{})
@@ -1272,7 +1273,7 @@ func TestProgressWriter_LogLine_EmptyLine(t *testing.T) {
 func TestProgressWriter_LogLine_InvalidJSON(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	pw := newProgressWriter(&buf, time.Now())
+	pw := claude.NewProgressWriter(&buf, time.Now())
 	// Should not panic on invalid JSON.
 	pw.LogLine([]byte("not json"))
 	if pw.Turn != 0 {
@@ -1283,7 +1284,7 @@ func TestProgressWriter_LogLine_InvalidJSON(t *testing.T) {
 func TestProgressWriter_LogLine_AssistantTurn(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	pw := newProgressWriter(&buf, time.Now())
+	pw := claude.NewProgressWriter(&buf, time.Now())
 
 	msg := map[string]any{
 		"type": "assistant",
@@ -1303,7 +1304,7 @@ func TestProgressWriter_LogLine_AssistantTurn(t *testing.T) {
 func TestProgressWriter_LogLine_AssistantToolUse(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	pw := newProgressWriter(&buf, time.Now())
+	pw := claude.NewProgressWriter(&buf, time.Now())
 
 	msg := map[string]any{
 		"type": "assistant",
@@ -1323,7 +1324,7 @@ func TestProgressWriter_LogLine_AssistantToolUse(t *testing.T) {
 func TestProgressWriter_LogLine_ResultEvent(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	pw := newProgressWriter(&buf, time.Now())
+	pw := claude.NewProgressWriter(&buf, time.Now())
 	pw.Turn = 3
 
 	msg := map[string]any{
@@ -1347,7 +1348,7 @@ func TestProgressWriter_LogLine_ResultEvent(t *testing.T) {
 func TestProgressWriter_LogLine_LongSnippetTruncated(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	pw := newProgressWriter(&buf, time.Now())
+	pw := claude.NewProgressWriter(&buf, time.Now())
 
 	longText := strings.Repeat("a", 200)
 	msg := map[string]any{
@@ -1370,7 +1371,7 @@ func TestProgressWriter_LogLine_LongSnippetTruncated(t *testing.T) {
 func TestProgressWriter_TurnCount_MultipleAssistantEvents(t *testing.T) {
 	t.Parallel()
 	var buf bytes.Buffer
-	pw := newProgressWriter(&buf, time.Now())
+	pw := claude.NewProgressWriter(&buf, time.Now())
 
 	// Simulate 3 assistant turns followed by a result.
 	assistant := `{"type":"assistant","message":{"content":[{"type":"text","text":"turn"}]}}`
@@ -1385,7 +1386,7 @@ func TestProgressWriter_TurnCount_MultipleAssistantEvents(t *testing.T) {
 	}
 
 	// Verify parseClaudeTokens gets cost from the same buffer.
-	cr := parseClaudeTokens(buf.Bytes())
+	cr := claude.ParseClaudeTokens(buf.Bytes())
 	if cr.CostUSD != 0.50 {
 		t.Errorf("CostUSD = %v, want 0.50", cr.CostUSD)
 	}
@@ -1497,7 +1498,7 @@ func TestIdleTrackingWriter_UpdatesLastWrite(t *testing.T) {
 	before := time.Now().UnixNano()
 	last.Store(before)
 
-	w := &idleTrackingWriter{W: &buf, LastWrite: &last}
+	w := &claude.IdleTrackingWriter{W: &buf, LastWrite: &last}
 	time.Sleep(2 * time.Millisecond) // ensure clock advances
 
 	n, err := w.Write([]byte("hello"))
@@ -1522,7 +1523,7 @@ func TestIdleTrackingWriter_DelegatesWriteError(t *testing.T) {
 	last.Store(time.Now().UnixNano())
 
 	// errWriter always returns an error.
-	w := &idleTrackingWriter{W: &errWriter{}, LastWrite: &last}
+	w := &claude.IdleTrackingWriter{W: &errWriter{}, LastWrite: &last}
 	_, err := w.Write([]byte("x"))
 	if err == nil {
 		t.Error("expected error from underlying writer, got nil")
@@ -1556,9 +1557,9 @@ func TestNew_RespectsExplicitIdleTimeout(t *testing.T) {
 
 // --- runClaudeSDK ---
 
-// fakeSdkQuery returns a sdkQueryFunc that immediately sends msgs on a
+// fakeSdkQuery returns a claude.SdkQueryFunc that immediately sends msgs on a
 // buffered channel and closes it. Use for success-path and error-path tests.
-func fakeSdkQuery(msgs ...claudetypes.Message) sdkQueryFunc {
+func fakeSdkQuery(msgs ...claudetypes.Message) claude.SdkQueryFunc {
 	return func(_ context.Context, _ string, _ *claudetypes.ClaudeAgentOptions) (<-chan claudetypes.Message, error) {
 		ch := make(chan claudetypes.Message, len(msgs))
 		for _, m := range msgs {
@@ -1592,7 +1593,7 @@ func resultMsg(input, output int, costUSD float64) *claudetypes.ResultMessage {
 // newSDKOrchestrator creates an Orchestrator wired to the given fake query
 // function. The config has no real paths; only fields consumed by
 // runClaudeSDK are relevant.
-func newSDKOrchestrator(fn sdkQueryFunc) *Orchestrator {
+func newSDKOrchestrator(fn claude.SdkQueryFunc) *Orchestrator {
 	o := New(Config{})
 	o.sdkQueryFn = fn
 	return o
@@ -1886,7 +1887,7 @@ func TestFilterSDKStderr_RateLimitWarningReplaced(t *testing.T) {
 	}
 	inW.Close()
 
-	go filterSDKStderr(inR, outW, done)
+	go claude.FilterSDKStderr(inR, outW, done)
 	<-done
 	outW.Close()
 
@@ -1925,7 +1926,7 @@ func TestFilterSDKStderr_OtherWarningsPassThrough(t *testing.T) {
 	}
 	inW.Close()
 
-	go filterSDKStderr(inR, outW, done)
+	go claude.FilterSDKStderr(inR, outW, done)
 	<-done
 	outW.Close()
 

--- a/pkg/orchestrator/commands.go
+++ b/pkg/orchestrator/commands.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/gitops" // diffStat alias, diffNameStatus conversion
 )
 
@@ -72,14 +73,14 @@ type diffStat = gitops.DiffStat
 // diffNameStatus runs git diff --name-status and returns per-file entries,
 // converting from gitops.FileChange to claude.FileChange (aliased as
 // FileChange in cobbler.go).
-func diffNameStatus(ref, dir string) ([]FileChange, error) {
+func diffNameStatus(ref, dir string) ([]claude.FileChange, error) {
 	gfc, err := defaultGitOps.DiffNameStatus(ref, dir)
 	if err != nil {
 		return nil, err
 	}
-	files := make([]FileChange, len(gfc))
+	files := make([]claude.FileChange, len(gfc))
 	for i, fc := range gfc {
-		files[i] = FileChange{
+		files[i] = claude.FileChange{
 			Path:       fc.Path,
 			Status:     fc.Status,
 			Insertions: fc.Insertions,

--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 
 	an "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/analysis"
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/generate"
 )
 
@@ -370,7 +371,7 @@ func (o *Orchestrator) GeneratorResume() error {
 
 	// Pre-flight cleanup.
 	logf("resume: pre-flight cleanup")
-	wtBase := worktreeBasePath()
+	wtBase := claude.WorktreeBasePath()
 
 	logf("resume: pruning worktrees")
 	if err := defaultGitOps.WorktreePrune("."); err != nil {
@@ -1415,7 +1416,7 @@ func (o *Orchestrator) GeneratorReset() error {
 		return fmt.Errorf("switching to %s: %w", baseBranch, err)
 	}
 
-	wtBase := worktreeBasePath()
+	wtBase := claude.WorktreeBasePath()
 	ghRepo, _ := detectGitHubRepo(".", o.cfg)
 	genBranches := o.listGenerationBranches()
 	if len(genBranches) > 0 {

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
 	"gopkg.in/yaml.v3"
 )
 
@@ -161,7 +162,7 @@ func (o *Orchestrator) RunMeasure() error {
 	totalCalls := (maxIssues + tasksPerCall - 1) / tasksPerCall // ceiling division
 	logf("measure: maxIssues=%d tasksPerCall=%d totalCalls=%d", maxIssues, tasksPerCall, totalCalls)
 	var allCreatedIDs []string
-	var totalTokens ClaudeResult
+	var totalTokens claude.ClaudeResult
 	maxRetries := o.cfg.Cobbler.MaxMeasureRetries
 
 	// Create a single placeholder issue for the entire measure pass (GH-1467).
@@ -241,7 +242,7 @@ func (o *Orchestrator) RunMeasure() error {
 					i+1, iterDuration.Round(time.Second), err)
 				// Save log and stats even on failure.
 				o.saveHistoryLog(historyTS, "measure", tokens.RawOutput)
-				o.saveHistoryStats(historyTS, "measure", HistoryStats{
+				o.saveHistoryStats(historyTS, "measure", claude.HistoryStats{
 					Caller:        "measure",
 					TaskID:        taskID,
 					Status:        "failed",
@@ -249,7 +250,7 @@ func (o *Orchestrator) RunMeasure() error {
 					StartedAt:     iterStart.UTC().Format(time.RFC3339),
 					Duration:      iterDuration.Round(time.Second).String(),
 					DurationS:     int(iterDuration.Seconds()),
-					Tokens:        historyTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
+					Tokens:        claude.HistoryTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
 					CostUSD:       tokens.CostUSD,
 					NumTurns:      tokens.NumTurns,
 					DurationAPIMs: tokens.DurationAPIMs,
@@ -263,14 +264,14 @@ func (o *Orchestrator) RunMeasure() error {
 
 			// Save remaining history artifacts (log, issues, stats) after Claude.
 			o.saveHistory(historyTS, tokens.RawOutput, outputFile)
-			o.saveHistoryStats(historyTS, "measure", HistoryStats{
+			o.saveHistoryStats(historyTS, "measure", claude.HistoryStats{
 				Caller:        "measure",
 				TaskID:        taskID,
 				Status:        "success",
 				StartedAt:     iterStart.UTC().Format(time.RFC3339),
 				Duration:      iterDuration.Round(time.Second).String(),
 				DurationS:     int(iterDuration.Seconds()),
-				Tokens:        historyTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
+				Tokens:        claude.HistoryTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
 				CostUSD:       tokens.CostUSD,
 				NumTurns:      tokens.NumTurns,
 				DurationAPIMs: tokens.DurationAPIMs,
@@ -280,8 +281,8 @@ func (o *Orchestrator) RunMeasure() error {
 			})
 
 			// Extract YAML from Claude's text output and write to file.
-			textOutput := extractTextFromStreamJSON(tokens.RawOutput)
-			yamlContent, extractErr := extractYAMLBlock(textOutput)
+			textOutput := claude.ExtractTextFromStreamJSON(tokens.RawOutput)
+			yamlContent, extractErr := claude.ExtractYAMLBlock(textOutput)
 			if extractErr != nil {
 				logf("iteration %d YAML extraction failed: %v", i+1, extractErr)
 				if attempt < maxRetries {
@@ -361,22 +362,22 @@ func (o *Orchestrator) RunMeasure() error {
 
 			if err == nil {
 				o.saveHistory(historyTS, tokens.RawOutput, outputFile)
-				o.saveHistoryStats(historyTS, "measure", HistoryStats{
+				o.saveHistoryStats(historyTS, "measure", claude.HistoryStats{
 					Caller:    "measure",
 					TaskID:    fmt.Sprintf("%d", placeholderNum),
 					Status:    "success",
 					StartedAt: retryStart.UTC().Format(time.RFC3339),
 					Duration:  retryDuration.Round(time.Second).String(),
 					DurationS: int(retryDuration.Seconds()),
-					Tokens:    historyTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
+					Tokens:    claude.HistoryTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
 					CostUSD:   tokens.CostUSD,
 					NumTurns:  tokens.NumTurns,
 					LOCBefore: locBefore,
 					LOCAfter:  o.captureLOC(),
 				})
 
-				textOutput := extractTextFromStreamJSON(tokens.RawOutput)
-				yamlContent, extractErr := extractYAMLBlock(textOutput)
+				textOutput := claude.ExtractTextFromStreamJSON(tokens.RawOutput)
+				yamlContent, extractErr := claude.ExtractYAMLBlock(textOutput)
 				if extractErr == nil {
 					if writeErr := os.WriteFile(outputFile, yamlContent, 0o644); writeErr == nil {
 						retryIDs, _, importErr := o.importIssues(outputFile, repo, generation, placeholderNum)

--- a/pkg/orchestrator/orchestrator.go
+++ b/pkg/orchestrator/orchestrator.go
@@ -18,16 +18,11 @@ import (
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/gitops"
 )
 
-// sdkQueryFunc is the function signature for claudesdk.Query.
-// Storing it on the Orchestrator allows tests to inject a fake without a
-// real Claude binary.
-type sdkQueryFunc = claude.SdkQueryFunc
-
 // Orchestrator provides Claude Code orchestration operations.
 // Create one with New() and call its methods from mage targets.
 type Orchestrator struct {
 	cfg        Config
-	sdkQueryFn sdkQueryFunc
+	sdkQueryFn claude.SdkQueryFunc
 	tracker    gh.WorkTracker
 	git        gitops.GitOps
 }
@@ -35,6 +30,11 @@ type Orchestrator struct {
 // New creates an Orchestrator with the given configuration.
 // It applies defaults to any zero-value Config fields.
 func New(cfg Config) *Orchestrator {
+	// Wire parent-package dependencies into internal/claude.
+	claude.Log = logf
+	claude.BinGit = binGit
+	claude.BinClaude = binClaude
+
 	cfg.applyDefaults()
 	return &Orchestrator{
 		cfg:        cfg,

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/generate"
 	"gopkg.in/yaml.v3"
 )
@@ -101,7 +102,7 @@ func (o *Orchestrator) RunStitchN(limit int) (int, error) {
 		logf("ensureCobblerLabels warning: %v", err)
 	}
 
-	worktreeBase := worktreeBasePath()
+	worktreeBase := claude.WorktreeBasePath()
 	logf("worktreeBase=%s", worktreeBase)
 
 	baseBranch, err := defaultGitOps.CurrentBranch(".")
@@ -254,7 +255,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 
 	if claudeErr != nil {
 		logf("doOneTask: Claude failed for %s after %s: %v", task.ID, time.Since(claudeStart).Round(time.Second), claudeErr)
-		o.saveHistoryStats(historyTS, "stitch", HistoryStats{
+		o.saveHistoryStats(historyTS, "stitch", claude.HistoryStats{
 			Caller:    "stitch",
 			TaskID:    task.ID,
 			TaskTitle: task.Title,
@@ -263,7 +264,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 			StartedAt: claudeStart.UTC().Format(time.RFC3339),
 			Duration:  time.Since(taskStart).Round(time.Second).String(),
 			DurationS: int(time.Since(taskStart).Seconds()),
-			Tokens:    historyTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
+			Tokens:    claude.HistoryTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
 			CostUSD:   tokens.CostUSD,
 			LOCBefore: locBefore,
 		})
@@ -275,7 +276,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	// Commit Claude's changes in the worktree.
 	if err := commitWorktreeChanges(task); err != nil {
 		logf("doOneTask: worktree commit failed for %s: %v", task.ID, err)
-		o.saveHistoryStats(historyTS, "stitch", HistoryStats{
+		o.saveHistoryStats(historyTS, "stitch", claude.HistoryStats{
 			Caller:    "stitch",
 			TaskID:    task.ID,
 			TaskTitle: task.Title,
@@ -284,7 +285,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 			StartedAt: claudeStart.UTC().Format(time.RFC3339),
 			Duration:  time.Since(taskStart).Round(time.Second).String(),
 			DurationS: int(time.Since(taskStart).Seconds()),
-			Tokens:    historyTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
+			Tokens:    claude.HistoryTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
 			CostUSD:   tokens.CostUSD,
 			LOCBefore: locBefore,
 		})
@@ -297,11 +298,11 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	logf("doOneTask: locAfter prod=%d test=%d", locAfter.Production, locAfter.Test)
 
 	// Append outcome trailers to the worktree commit before merging.
-	trailerRec := InvocationRecord{
+	trailerRec := claude.InvocationRecord{
 		Caller:    "stitch",
 		StartedAt: claudeStart.UTC().Format(time.RFC3339),
 		DurationS: int(time.Since(claudeStart).Seconds()),
-		Tokens: claudeTokens{
+		Tokens: claude.ClaudeTokens{
 			Input:         tokens.InputTokens,
 			Output:        tokens.OutputTokens,
 			CacheCreation: tokens.CacheCreationTokens,
@@ -312,7 +313,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 		LOCAfter:  locAfter,
 		NumTurns:  tokens.NumTurns,
 	}
-	if err := appendOutcomeTrailers(task.WorktreeDir, trailerRec); err != nil {
+	if err := claude.AppendOutcomeTrailers(task.WorktreeDir, trailerRec, defaultGitOps.CommitAmendTrailers); err != nil {
 		logf("doOneTask: outcome trailer warning for %s: %v", task.ID, err)
 	}
 
@@ -327,7 +328,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	mergeStart := time.Now()
 	if err := mergeBranch(task.BranchName, baseBranch, repoRoot); err != nil {
 		logf("doOneTask: merge failed for %s after %s: %v", task.ID, time.Since(mergeStart).Round(time.Second), err)
-		o.saveHistoryStats(historyTS, "stitch", HistoryStats{
+		o.saveHistoryStats(historyTS, "stitch", claude.HistoryStats{
 			Caller:    "stitch",
 			TaskID:    task.ID,
 			TaskTitle: task.Title,
@@ -336,7 +337,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 			StartedAt: claudeStart.UTC().Format(time.RFC3339),
 			Duration:  time.Since(taskStart).Round(time.Second).String(),
 			DurationS: int(time.Since(taskStart).Seconds()),
-			Tokens:    historyTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
+			Tokens:    claude.HistoryTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
 			CostUSD:   tokens.CostUSD,
 			LOCBefore: locBefore,
 		})
@@ -369,7 +370,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 
 	// Save stitch stats.
 	taskDuration := time.Since(taskStart)
-	o.saveHistoryStats(historyTS, "stitch", HistoryStats{
+	o.saveHistoryStats(historyTS, "stitch", claude.HistoryStats{
 		Caller:        "stitch",
 		TaskID:        task.ID,
 		TaskTitle:     task.Title,
@@ -377,37 +378,37 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 		StartedAt:     claudeStart.UTC().Format(time.RFC3339),
 		Duration:      taskDuration.Round(time.Second).String(),
 		DurationS:     int(taskDuration.Seconds()),
-		Tokens:        historyTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
+		Tokens:        claude.HistoryTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
 		CostUSD:       tokens.CostUSD,
 		NumTurns:      tokens.NumTurns,
 		DurationAPIMs: tokens.DurationAPIMs,
 		SessionID:     tokens.SessionID,
 		LOCBefore:     locBefore,
 		LOCAfter:      locAfter,
-		Diff:          historyDiff{Files: diff.FilesChanged, Insertions: diff.Insertions, Deletions: diff.Deletions},
+		Diff:          claude.HistoryDiff{Files: diff.FilesChanged, Insertions: diff.Insertions, Deletions: diff.Deletions},
 	})
 
 	// Save stitch report with per-file diffstat.
-	o.saveHistoryReport(historyTS, StitchReport{
+	o.saveHistoryReport(historyTS, claude.StitchReport{
 		TaskID:    task.ID,
 		TaskTitle: task.Title,
 		Status:    "success",
 		Branch:    task.BranchName,
-		Diff:      historyDiff{Files: diff.FilesChanged, Insertions: diff.Insertions, Deletions: diff.Deletions},
+		Diff:      claude.HistoryDiff{Files: diff.FilesChanged, Insertions: diff.Insertions, Deletions: diff.Deletions},
 		Files:     fileChanges,
 		LOCBefore: locBefore,
 		LOCAfter:  locAfter,
 	})
 
 	// Close task with metrics.
-	rec := InvocationRecord{
+	rec := claude.InvocationRecord{
 		Caller:    "stitch",
 		StartedAt: claudeStart.UTC().Format(time.RFC3339),
 		DurationS: int(taskDuration.Seconds()),
-		Tokens:    claudeTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens, CostUSD: tokens.CostUSD},
+		Tokens:    claude.ClaudeTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens, CostUSD: tokens.CostUSD},
 		LOCBefore: locBefore,
 		LOCAfter:  locAfter,
-		Diff:      diffRecord{Files: diff.FilesChanged, Insertions: diff.Insertions, Deletions: diff.Deletions},
+		Diff:      claude.DiffRecord{Files: diff.FilesChanged, Insertions: diff.Insertions, Deletions: diff.Deletions},
 		NumTurns:  tokens.NumTurns,
 	}
 	logf("doOneTask: closing task %s", task.ID)
@@ -564,7 +565,7 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 	return string(out), nil
 }
 
-func (o *Orchestrator) closeStitchTask(task stitchTask, rec InvocationRecord, testsPassed bool) {
+func (o *Orchestrator) closeStitchTask(task stitchTask, rec claude.InvocationRecord, testsPassed bool) {
 	logf("closeStitchTask: closing #%d %q", task.GhNumber, task.Title)
 	locDeltaProd := rec.LOCAfter.Production - rec.LOCBefore.Production
 	locDeltaTest := rec.LOCAfter.Test - rec.LOCBefore.Test

--- a/pkg/orchestrator/stitch_test.go
+++ b/pkg/orchestrator/stitch_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
 )
 
 func TestErrTaskReset_MentionsOpen(t *testing.T) {
@@ -902,7 +904,7 @@ func TestCloseStitchTask_GHFailureNoOp(t *testing.T) {
 		Repo:       "fake/repo",
 		Generation: "test-gen",
 	}
-	rec := InvocationRecord{}
+	rec := claude.InvocationRecord{}
 
 	o.closeStitchTask(task, rec, true) // must not panic
 }


### PR DESCRIPTION
## Summary

Eliminates 13 type aliases, 8 package-level pass-through functions, 2 var bindings, and the init() global wiring from cobbler.go. Callers now reference internal/claude types and functions directly. The init() dependency wiring moves to the New() constructor for explicit injection.

## Changes

- Removed 13 type aliases from cobbler.go — callers use `claude.XXX` types directly
- Removed 8 pure pass-through package-level functions — callers call `claude.XXX()` directly
- Removed 2 var bindings (filterSDKStderr, newProgressWriter) and sdkQueryFunc alias
- Replaced `init()` global wiring with explicit DI in `New()` constructor
- Updated stitch.go, measure.go, generator.go, commands.go to import internal/claude
- Updated cobbler_test.go, stitch_test.go to use canonical types/functions

## Stats

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| go_loc_prod | 19,299 | 19,038 | -261 |
| go_loc_test | 34,319 | 34,322 | +3 |
| go_loc | 53,618 | 53,360 | -258 |

## Test plan

- [x] `go test ./pkg/orchestrator/ -count=1` passes
- [x] All 8 modified files compile cleanly
- [x] No regressions — net deletion of indirection code

Closes #1689