### PR TITLE
GH-1694: Eliminate stats wrapper indirection across stats files

### DIFF
--- a/pkg/orchestrator/generator_stats.go
+++ b/pkg/orchestrator/generator_stats.go
@@ -11,12 +11,6 @@ import (
 	st "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/stats"
 )
 
-// generatorIssueStats type alias for backward compatibility.
-type generatorIssueStats = st.GeneratorIssueStats
-
-// stitchCommentData type alias for backward compatibility.
-type stitchCommentData = st.StitchCommentData
-
 // GeneratorStats prints a status report for the current generation run.
 func (o *Orchestrator) GeneratorStats() error {
 	currentBranch, _ := defaultGitOps.CurrentBranch(".")
@@ -39,42 +33,3 @@ func (o *Orchestrator) GeneratorStats() error {
 	})
 }
 
-// parseStitchComment delegates to the internal/stats package.
-func parseStitchComment(body string) stitchCommentData {
-	return st.ParseStitchComment(body)
-}
-
-// countTotalPRDRequirements delegates to the internal/stats package.
-func countTotalPRDRequirements() (int, map[string]int) {
-	return st.CountTotalPRDRequirements()
-}
-
-// buildPRDReleaseMap delegates to the internal/stats package.
-func buildPRDReleaseMap() map[string]string {
-	return st.BuildPRDReleaseMap()
-}
-
-// countDescriptionReqs delegates to the internal/stats package.
-func countDescriptionReqs(description string) int {
-	return st.CountDescriptionReqs(description)
-}
-
-// extractRelease delegates to the internal/stats package.
-func extractRelease(text string) string {
-	return st.ExtractRelease(text)
-}
-
-// formatTokens delegates to the internal/stats package.
-func formatTokens(n int) string {
-	return st.FormatTokens(n)
-}
-
-// formatBytes delegates to the internal/stats package.
-func formatBytes(b int) string {
-	return st.FormatBytes(b)
-}
-
-// extractPRDRefs delegates to the internal/stats package.
-func extractPRDRefs(text string) []string {
-	return st.ExtractPRDRefs(text)
-}

--- a/pkg/orchestrator/generator_stats_test.go
+++ b/pkg/orchestrator/generator_stats_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	gh "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/github"
+	st "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/stats"
 )
 
 // --- parseStitchComment (delegation sanity check) ---
@@ -16,7 +17,7 @@ import (
 func TestParseStitchComment_Completed(t *testing.T) {
 	t.Parallel()
 	body := "Stitch completed in 5m 32s. LOC delta: +45 prod, +17 test. Cost: $0.42."
-	d := parseStitchComment(body)
+	d := st.ParseStitchComment(body)
 	if d.CostUSD != 0.42 {
 		t.Errorf("CostUSD = %v, want 0.42", d.CostUSD)
 	}
@@ -34,7 +35,7 @@ func TestParseStitchComment_Completed(t *testing.T) {
 func TestParseStitchComment_Failed(t *testing.T) {
 	t.Parallel()
 	body := "Stitch failed after 2m 10s. Error: Claude failure."
-	d := parseStitchComment(body)
+	d := st.ParseStitchComment(body)
 	if d.DurationS != 2*60+10 {
 		t.Errorf("DurationS = %d, want %d", d.DurationS, 2*60+10)
 	}
@@ -46,7 +47,7 @@ func TestParseStitchComment_Failed(t *testing.T) {
 func TestParseStitchComment_SubMinuteDuration(t *testing.T) {
 	t.Parallel()
 	body := "Stitch completed in 45s. LOC delta: +0 prod, +0 test. Cost: $0.10."
-	d := parseStitchComment(body)
+	d := st.ParseStitchComment(body)
 	if d.DurationS != 45 {
 		t.Errorf("DurationS = %d, want 45", d.DurationS)
 	}
@@ -58,7 +59,7 @@ func TestParseStitchComment_SubMinuteDuration(t *testing.T) {
 func TestParseStitchComment_WithTurns(t *testing.T) {
 	t.Parallel()
 	body := "Stitch completed in 3m 15s. LOC delta: +20 prod, +10 test. Cost: $0.55. Turns: 12."
-	d := parseStitchComment(body)
+	d := st.ParseStitchComment(body)
 	if d.NumTurns != 12 {
 		t.Errorf("NumTurns = %d, want 12", d.NumTurns)
 	}
@@ -76,7 +77,7 @@ func TestParseStitchComment_WithTurns(t *testing.T) {
 func TestParseStitchComment_NegativeLOC(t *testing.T) {
 	t.Parallel()
 	body := "Stitch completed in 1m 5s. LOC delta: -12 prod, +30 test. Cost: $0.20. Turns: 5."
-	d := parseStitchComment(body)
+	d := st.ParseStitchComment(body)
 	if d.LocDeltaProd != -12 {
 		t.Errorf("LocDeltaProd = %d, want -12", d.LocDeltaProd)
 	}
@@ -87,7 +88,7 @@ func TestParseStitchComment_NegativeLOC(t *testing.T) {
 
 func TestParseStitchComment_NoMatch(t *testing.T) {
 	t.Parallel()
-	d := parseStitchComment("unrelated comment text")
+	d := st.ParseStitchComment("unrelated comment text")
 	if d.CostUSD != 0 || d.DurationS != 0 || d.NumTurns != 0 {
 		t.Errorf("expected zero values, got cost=%v dur=%d turns=%d", d.CostUSD, d.DurationS, d.NumTurns)
 	}
@@ -96,7 +97,7 @@ func TestParseStitchComment_NoMatch(t *testing.T) {
 func TestParseStitchComment_PromptBytes(t *testing.T) {
 	t.Parallel()
 	body := "Stitch started. Branch: `generation-main`, prompt: 524288 bytes."
-	d := parseStitchComment(body)
+	d := st.ParseStitchComment(body)
 	if d.PromptBytes != 524288 {
 		t.Errorf("PromptBytes = %d, want 524288", d.PromptBytes)
 	}
@@ -105,7 +106,7 @@ func TestParseStitchComment_PromptBytes(t *testing.T) {
 func TestParseStitchComment_PromptBytes_NoMatch(t *testing.T) {
 	t.Parallel()
 	body := "Stitch completed in 5m 32s. LOC delta: +45 prod, +17 test. Cost: $0.42."
-	d := parseStitchComment(body)
+	d := st.ParseStitchComment(body)
 	if d.PromptBytes != 0 {
 		t.Errorf("PromptBytes = %d, want 0", d.PromptBytes)
 	}
@@ -114,7 +115,7 @@ func TestParseStitchComment_PromptBytes_NoMatch(t *testing.T) {
 func TestParseStitchComment_Tokens(t *testing.T) {
 	t.Parallel()
 	body := "Stitch completed in 3m 15s. LOC delta: +20 prod, +10 test. Cost: $0.55. Turns: 12. Tokens: 125000in 5000out."
-	d := parseStitchComment(body)
+	d := st.ParseStitchComment(body)
 	if d.InputTokens != 125000 {
 		t.Errorf("InputTokens = %d, want 125000", d.InputTokens)
 	}
@@ -126,7 +127,7 @@ func TestParseStitchComment_Tokens(t *testing.T) {
 func TestParseStitchComment_Tokens_NoMatch(t *testing.T) {
 	t.Parallel()
 	body := "Stitch completed in 5m 32s. LOC delta: +45 prod, +17 test. Cost: $0.42."
-	d := parseStitchComment(body)
+	d := st.ParseStitchComment(body)
 	if d.InputTokens != 0 {
 		t.Errorf("InputTokens = %d, want 0", d.InputTokens)
 	}
@@ -154,9 +155,9 @@ func TestFormatBytes(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := formatBytes(tc.bytes)
+			got := st.FormatBytes(tc.bytes)
 			if got != tc.want {
-				t.Errorf("formatBytes(%d) = %q, want %q", tc.bytes, got, tc.want)
+				t.Errorf("st.FormatBytes(%d) = %q, want %q", tc.bytes, got, tc.want)
 			}
 		})
 	}
@@ -181,9 +182,9 @@ func TestFormatTokens(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := formatTokens(tc.tokens)
+			got := st.FormatTokens(tc.tokens)
 			if got != tc.want {
-				t.Errorf("formatTokens(%d) = %q, want %q", tc.tokens, got, tc.want)
+				t.Errorf("st.FormatTokens(%d) = %q, want %q", tc.tokens, got, tc.want)
 			}
 		})
 	}
@@ -208,9 +209,9 @@ func TestExtractRelease(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := extractRelease(tc.text)
+			got := st.ExtractRelease(tc.text)
 			if got != tc.want {
-				t.Errorf("extractRelease(%q) = %q, want %q", tc.text, got, tc.want)
+				t.Errorf("st.ExtractRelease(%q) = %q, want %q", tc.text, got, tc.want)
 			}
 		})
 	}
@@ -246,14 +247,14 @@ func TestExtractPRDRefs(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		got := extractPRDRefs(tc.text)
+		got := st.ExtractPRDRefs(tc.text)
 		if len(got) != len(tc.want) {
-			t.Errorf("extractPRDRefs(%q): got %v, want %v", tc.text, got, tc.want)
+			t.Errorf("st.ExtractPRDRefs(%q): got %v, want %v", tc.text, got, tc.want)
 			continue
 		}
 		for i := range got {
 			if got[i] != tc.want[i] {
-				t.Errorf("extractPRDRefs(%q)[%d]: got %q, want %q", tc.text, i, got[i], tc.want[i])
+				t.Errorf("st.ExtractPRDRefs(%q)[%d]: got %q, want %q", tc.text, i, got[i], tc.want[i])
 			}
 		}
 	}
@@ -323,7 +324,7 @@ requirements:
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(dir)
 
-	total, byPRD := countTotalPRDRequirements()
+	total, byPRD := st.CountTotalPRDRequirements()
 	if total != 3 {
 		t.Errorf("total = %d, want 3", total)
 	}
@@ -339,7 +340,7 @@ func TestCountTotalPRDRequirements_NoPRDs(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(dir)
 
-	total, byPRD := countTotalPRDRequirements()
+	total, byPRD := st.CountTotalPRDRequirements()
 	if total != 0 {
 		t.Errorf("total = %d, want 0", total)
 	}
@@ -386,9 +387,9 @@ func TestCountDescriptionReqs(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			got := countDescriptionReqs(tc.desc)
+			got := st.CountDescriptionReqs(tc.desc)
 			if got != tc.want {
-				t.Errorf("countDescriptionReqs() = %d, want %d", got, tc.want)
+				t.Errorf("st.CountDescriptionReqs() = %d, want %d", got, tc.want)
 			}
 		})
 	}
@@ -443,7 +444,7 @@ out_of_scope: []
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(dir)
 
-	m := buildPRDReleaseMap()
+	m := st.BuildPRDReleaseMap()
 	if m["prd001-orchestrator-core"] != "01.0" {
 		t.Errorf("prd001-orchestrator-core release = %q, want %q", m["prd001-orchestrator-core"], "01.0")
 	}
@@ -462,7 +463,7 @@ func TestBuildPRDReleaseMap_NoUseCases(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(dir)
 
-	m := buildPRDReleaseMap()
+	m := st.BuildPRDReleaseMap()
 	if len(m) != 0 {
 		t.Errorf("expected empty map, got %v", m)
 	}
@@ -493,7 +494,7 @@ out_of_scope: []
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(dir)
 
-	m := buildPRDReleaseMap()
+	m := st.BuildPRDReleaseMap()
 	if len(m) != 0 {
 		t.Errorf("expected empty map for malformed filename, got %v", m)
 	}
@@ -511,7 +512,7 @@ func TestBuildPRDReleaseMap_InvalidYAML(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(dir)
 
-	m := buildPRDReleaseMap()
+	m := st.BuildPRDReleaseMap()
 	if len(m) != 0 {
 		t.Errorf("expected empty map for invalid YAML, got %v", m)
 	}
@@ -543,7 +544,7 @@ out_of_scope: []
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(dir)
 
-	m := buildPRDReleaseMap()
+	m := st.BuildPRDReleaseMap()
 	if len(m) != 0 {
 		t.Errorf("expected empty map for non-numeric PRD refs, got %v", m)
 	}

--- a/pkg/orchestrator/outcomes.go
+++ b/pkg/orchestrator/outcomes.go
@@ -12,9 +12,6 @@ import (
 // OutcomeRecord holds parsed outcome trailer data from a single task commit.
 type OutcomeRecord = st.OutcomeRecord
 
-// outcomeSep delimits commit blocks in the git log output used by Outcomes.
-const outcomeSep = st.OutcomeSep
-
 // Outcomes scans all git branches for commits that carry outcome trailers
 // and prints a summary table to stdout.
 func (o *Orchestrator) Outcomes() error {
@@ -22,24 +19,4 @@ func (o *Orchestrator) Outcomes() error {
 		Log:    logf,
 		GitBin: binGit,
 	})
-}
-
-// parseOutcomeRecords delegates to the internal/stats package.
-func parseOutcomeRecords(logOutput string) []OutcomeRecord {
-	return st.ParseOutcomeRecords(logOutput)
-}
-
-// parseOneOutcomeBlock delegates to the internal/stats package.
-func parseOneOutcomeBlock(block string) *OutcomeRecord {
-	return st.ParseOneOutcomeBlock(block)
-}
-
-// extractBranchFromRefs delegates to the internal/stats package.
-func extractBranchFromRefs(refs string) string {
-	return st.ExtractBranchFromRefs(refs)
-}
-
-// formatDuration delegates to the internal/stats package.
-func formatDuration(seconds int) string {
-	return st.FormatDuration(seconds)
 }

--- a/pkg/orchestrator/outcomes_test.go
+++ b/pkg/orchestrator/outcomes_test.go
@@ -8,13 +8,15 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	st "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/stats"
 )
 
 // --- parseOutcomeRecords ---
 
 func TestParseOutcomeRecords_SingleRecord(t *testing.T) {
 	t.Parallel()
-	logOutput := outcomeSep + "\n" +
+	logOutput := st.OutcomeSep + "\n" +
 		"HEAD -> task/gen-main-atlas-001\n" +
 		"Tokens-Input: 45000\n" +
 		"Tokens-Output: 12000\n" +
@@ -27,7 +29,7 @@ func TestParseOutcomeRecords_SingleRecord(t *testing.T) {
 		"Loc-Test-After: 45\n" +
 		"Duration-Seconds: 1234\n"
 
-	records := parseOutcomeRecords(logOutput)
+	records := st.ParseOutcomeRecords(logOutput)
 	if len(records) != 1 {
 		t.Fatalf("got %d records, want 1", len(records))
 	}
@@ -58,10 +60,10 @@ func TestParseOutcomeRecords_SingleRecord(t *testing.T) {
 func TestParseOutcomeRecords_SkipsCommitsWithoutTokensInput(t *testing.T) {
 	t.Parallel()
 	// Block without Tokens-Input trailer should be skipped.
-	logOutput := outcomeSep + "\n" +
+	logOutput := st.OutcomeSep + "\n" +
 		"HEAD -> main\n" +
 		"Some-Other-Trailer: value\n" +
-		outcomeSep + "\n" +
+		st.OutcomeSep + "\n" +
 		"task/gen-main-atlas-002\n" +
 		"Tokens-Input: 1000\n" +
 		"Tokens-Output: 200\n" +
@@ -74,7 +76,7 @@ func TestParseOutcomeRecords_SkipsCommitsWithoutTokensInput(t *testing.T) {
 		"Loc-Test-After: 0\n" +
 		"Duration-Seconds: 60\n"
 
-	records := parseOutcomeRecords(logOutput)
+	records := st.ParseOutcomeRecords(logOutput)
 	if len(records) != 1 {
 		t.Fatalf("got %d records, want 1 (second block only)", len(records))
 	}
@@ -85,7 +87,7 @@ func TestParseOutcomeRecords_SkipsCommitsWithoutTokensInput(t *testing.T) {
 
 func TestParseOutcomeRecords_EmptyInput(t *testing.T) {
 	t.Parallel()
-	records := parseOutcomeRecords("")
+	records := st.ParseOutcomeRecords("")
 	if len(records) != 0 {
 		t.Errorf("got %d records for empty input, want 0", len(records))
 	}
@@ -106,9 +108,9 @@ func TestExtractBranchFromRefs_HeadArrow(t *testing.T) {
 		{"", ""},
 	}
 	for _, tc := range tests {
-		got := extractBranchFromRefs(tc.refs)
+		got := st.ExtractBranchFromRefs(tc.refs)
 		if got != tc.want {
-			t.Errorf("extractBranchFromRefs(%q) = %q, want %q", tc.refs, got, tc.want)
+			t.Errorf("st.ExtractBranchFromRefs(%q) = %q, want %q", tc.refs, got, tc.want)
 		}
 	}
 }
@@ -129,9 +131,9 @@ func TestFormatDuration(t *testing.T) {
 		{1234, "20m34s"},
 	}
 	for _, tc := range cases {
-		got := formatDuration(tc.seconds)
+		got := st.FormatDuration(tc.seconds)
 		if got != tc.want {
-			t.Errorf("formatDuration(%d) = %q, want %q", tc.seconds, got, tc.want)
+			t.Errorf("st.FormatDuration(%d) = %q, want %q", tc.seconds, got, tc.want)
 		}
 	}
 }

--- a/pkg/orchestrator/prompt_files.go
+++ b/pkg/orchestrator/prompt_files.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	st "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/stats"
 )
 
 // contextFileEntry describes a single file included in the assembled Claude prompt.
@@ -145,6 +147,6 @@ func (o *Orchestrator) resolveContextFileEntries() []contextFileEntry {
 
 // safeCountLines calls countLines and discards the error, returning 0 on failure.
 func safeCountLines(path string) int {
-	n, _ := countLines(path)
+	n, _ := st.CountLines(path)
 	return n
 }

--- a/pkg/orchestrator/release_stats.go
+++ b/pkg/orchestrator/release_stats.go
@@ -10,26 +10,8 @@ import (
 	st "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/stats"
 )
 
-// releaseRow type alias for backward compatibility.
-type releaseRow = st.ReleaseRow
-
 // ReleaseStats prints a table of roadmap releases with per-release PRD and
 // requirement counts.
 func (o *Orchestrator) ReleaseStats() error {
 	return st.PrintReleaseStats()
-}
-
-// buildReleaseRows delegates to the internal/stats package.
-func buildReleaseRows() ([]releaseRow, error) {
-	return st.BuildReleaseRows()
-}
-
-// releaseAllUCsDone delegates to the internal/stats package.
-func releaseAllUCsDone(statuses []string) bool {
-	return st.ReleaseAllUCsDone(statuses)
-}
-
-// releaseAnyUCDone delegates to the internal/stats package.
-func releaseAnyUCDone(statuses []string) bool {
-	return st.ReleaseAnyUCDone(statuses)
 }

--- a/pkg/orchestrator/release_stats_test.go
+++ b/pkg/orchestrator/release_stats_test.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	st "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/stats"
 )
 
 func TestBuildReleaseRows(t *testing.T) {
@@ -108,7 +110,7 @@ out_of_scope: []
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(dir)
 
-	rows, err := buildReleaseRows()
+	rows, err := st.BuildReleaseRows()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -157,7 +159,7 @@ func TestBuildReleaseRows_NoRoadmap(t *testing.T) {
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(dir)
 
-	rows, err := buildReleaseRows()
+	rows, err := st.BuildReleaseRows()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -179,8 +181,8 @@ func TestReleaseAllUCsDone(t *testing.T) {
 		{[]string{"implemented"}, true},
 	}
 	for _, tc := range tests {
-		if got := releaseAllUCsDone(tc.statuses); got != tc.want {
-			t.Errorf("releaseAllUCsDone(%v) = %v, want %v", tc.statuses, got, tc.want)
+		if got := st.ReleaseAllUCsDone(tc.statuses); got != tc.want {
+			t.Errorf("st.ReleaseAllUCsDone(%v) = %v, want %v", tc.statuses, got, tc.want)
 		}
 	}
 }
@@ -197,8 +199,8 @@ func TestReleaseAnyUCDone(t *testing.T) {
 		{[]string{"implemented"}, true},
 	}
 	for _, tc := range tests {
-		if got := releaseAnyUCDone(tc.statuses); got != tc.want {
-			t.Errorf("releaseAnyUCDone(%v) = %v, want %v", tc.statuses, got, tc.want)
+		if got := st.ReleaseAnyUCDone(tc.statuses); got != tc.want {
+			t.Errorf("st.ReleaseAnyUCDone(%v) = %v, want %v", tc.statuses, got, tc.want)
 		}
 	}
 }
@@ -289,7 +291,7 @@ out_of_scope: []
 	t.Cleanup(func() { os.Chdir(orig) })
 	os.Chdir(dir)
 
-	rows, err := buildReleaseRows()
+	rows, err := st.BuildReleaseRows()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/pkg/orchestrator/stats.go
+++ b/pkg/orchestrator/stats.go
@@ -33,12 +33,3 @@ func (o *Orchestrator) statsDeps() st.StatsDeps {
 	}
 }
 
-// countLines delegates to the internal/stats package.
-func countLines(path string) (int, error) {
-	return st.CountLines(path)
-}
-
-// countWordsInFile delegates to the internal/stats package.
-func countWordsInFile(path string) (int, error) {
-	return st.CountWordsInFile(path)
-}

--- a/pkg/orchestrator/stats_test.go
+++ b/pkg/orchestrator/stats_test.go
@@ -9,6 +9,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	st "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/stats"
 )
 
 // --- CollectStats ---
@@ -90,7 +92,7 @@ func TestCountLines_MultipleLines(t *testing.T) {
 	path := filepath.Join(dir, "test.go")
 	os.WriteFile(path, []byte("line 1\nline 2\nline 3\n"), 0644)
 
-	got, err := countLines(path)
+	got, err := st.CountLines(path)
 	if err != nil {
 		t.Fatalf("countLines: %v", err)
 	}
@@ -105,12 +107,12 @@ func TestCountLines_EmptyFile(t *testing.T) {
 	path := filepath.Join(dir, "empty.go")
 	os.WriteFile(path, []byte(""), 0644)
 
-	got, err := countLines(path)
+	got, err := st.CountLines(path)
 	if err != nil {
 		t.Fatalf("countLines: %v", err)
 	}
 	if got != 0 {
-		t.Errorf("countLines(empty) = %d, want 0", got)
+		t.Errorf("st.CountLines(empty) = %d, want 0", got)
 	}
 }
 
@@ -120,20 +122,20 @@ func TestCountLines_NoTrailingNewline(t *testing.T) {
 	path := filepath.Join(dir, "noeol.go")
 	os.WriteFile(path, []byte("line 1\nline 2"), 0644)
 
-	got, err := countLines(path)
+	got, err := st.CountLines(path)
 	if err != nil {
 		t.Fatalf("countLines: %v", err)
 	}
 	if got != 2 {
-		t.Errorf("countLines(no-eol) = %d, want 2", got)
+		t.Errorf("st.CountLines(no-eol) = %d, want 2", got)
 	}
 }
 
 func TestCountLines_MissingFile(t *testing.T) {
 	t.Parallel()
-	_, err := countLines("/nonexistent/file.go")
+	_, err := st.CountLines("/nonexistent/file.go")
 	if err == nil {
-		t.Error("countLines(missing) should return error")
+		t.Error("st.CountLines(missing) should return error")
 	}
 }
 
@@ -145,7 +147,7 @@ func TestCountWordsInFile_Basic(t *testing.T) {
 	path := filepath.Join(dir, "words.txt")
 	os.WriteFile(path, []byte("hello world foo bar"), 0644)
 
-	got, err := countWordsInFile(path)
+	got, err := st.CountWordsInFile(path)
 	if err != nil {
 		t.Fatalf("countWordsInFile: %v", err)
 	}
@@ -160,12 +162,12 @@ func TestCountWordsInFile_MultipleSpaces(t *testing.T) {
 	path := filepath.Join(dir, "spaces.txt")
 	os.WriteFile(path, []byte("  hello   world  \n\n  foo  "), 0644)
 
-	got, err := countWordsInFile(path)
+	got, err := st.CountWordsInFile(path)
 	if err != nil {
 		t.Fatalf("countWordsInFile: %v", err)
 	}
 	if got != 3 {
-		t.Errorf("countWordsInFile(multi-space) = %d, want 3", got)
+		t.Errorf("st.CountWordsInFile(multi-space) = %d, want 3", got)
 	}
 }
 
@@ -175,20 +177,20 @@ func TestCountWordsInFile_Empty(t *testing.T) {
 	path := filepath.Join(dir, "empty.txt")
 	os.WriteFile(path, []byte(""), 0644)
 
-	got, err := countWordsInFile(path)
+	got, err := st.CountWordsInFile(path)
 	if err != nil {
 		t.Fatalf("countWordsInFile: %v", err)
 	}
 	if got != 0 {
-		t.Errorf("countWordsInFile(empty) = %d, want 0", got)
+		t.Errorf("st.CountWordsInFile(empty) = %d, want 0", got)
 	}
 }
 
 func TestCountWordsInFile_MissingFile(t *testing.T) {
 	t.Parallel()
-	_, err := countWordsInFile("/nonexistent/file.txt")
+	_, err := st.CountWordsInFile("/nonexistent/file.txt")
 	if err == nil {
-		t.Error("countWordsInFile(missing) should return error")
+		t.Error("st.CountWordsInFile(missing) should return error")
 	}
 }
 

--- a/pkg/orchestrator/token_stats.go
+++ b/pkg/orchestrator/token_stats.go
@@ -41,7 +41,3 @@ func (o *Orchestrator) enumerateContextFiles() []st.FileTokenStat {
 	return files
 }
 
-// sortedKeys delegates to the internal/stats package.
-func sortedKeys(m map[string]int) []string {
-	return st.SortedKeys(m)
-}

--- a/pkg/orchestrator/token_stats_test.go
+++ b/pkg/orchestrator/token_stats_test.go
@@ -8,21 +8,23 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	st "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/stats"
 )
 
 // --- sortedKeys ---
 
 func TestSortedKeys_Empty(t *testing.T) {
 	t.Parallel()
-	got := sortedKeys(map[string]int{})
+	got := st.SortedKeys(map[string]int{})
 	if len(got) != 0 {
-		t.Errorf("sortedKeys(empty) = %v, want []", got)
+		t.Errorf("st.SortedKeys(empty) = %v, want []", got)
 	}
 }
 
 func TestSortedKeys_Sorted(t *testing.T) {
 	t.Parallel()
-	got := sortedKeys(map[string]int{"c": 3, "a": 1, "b": 2})
+	got := st.SortedKeys(map[string]int{"c": 3, "a": 1, "b": 2})
 	want := []string{"a", "b", "c"}
 	if len(got) != len(want) {
 		t.Fatalf("sortedKeys len = %d, want %d", len(got), len(want))
@@ -36,9 +38,9 @@ func TestSortedKeys_Sorted(t *testing.T) {
 
 func TestSortedKeys_SingleKey(t *testing.T) {
 	t.Parallel()
-	got := sortedKeys(map[string]int{"only": 42})
+	got := st.SortedKeys(map[string]int{"only": 42})
 	if len(got) != 1 || got[0] != "only" {
-		t.Errorf("sortedKeys(single) = %v, want [only]", got)
+		t.Errorf("st.SortedKeys(single) = %v, want [only]", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Eliminates 14 pass-through wrapper functions, 4 unexported type aliases, and 1 constant alias across 5 stats-related files that delegated to internal/stats with no added logic. Exported type aliases (OutcomeRecord, StatsRecord, FileTokenStat) are preserved as public API.

## Changes

- Removed wrappers from outcomes.go (4 functions + 1 constant), generator_stats.go (8 functions + 2 type aliases), release_stats.go (3 functions + 1 type alias), stats.go (2 functions), token_stats.go (1 function)
- Updated call sites in 5 test files and prompt_files.go to use st.X() directly
- Added st import to test files and prompt_files.go

## Stats

- go_loc_prod: 18820 → 18723 (−97)
- go_loc_test: 34333 → 34342 (+9, import lines)
- go_loc: 53153 → 53065 (−88 net)

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] Documentation reviewed for consistency

Closes #1694