### PR TITLE
GH-1695: Eliminate context/prompt wrapper indirection

### DIFF
--- a/pkg/orchestrator/analyze.go
+++ b/pkg/orchestrator/analyze.go
@@ -11,6 +11,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	an "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/analysis"
+	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
 )
 
 // Type aliases for backward-compatible re-exports.
@@ -23,7 +24,7 @@ func (o *Orchestrator) collectAnalyzeResult() (AnalyzeResult, an.AnalyzeCounts, 
 		Log:                    logf,
 		Releases:               o.cfg.Project.Releases,
 		ValidateDocSchemas:     o.validateDocSchemas,
-		ValidatePromptTemplate: validatePromptTemplate,
+		ValidatePromptTemplate: ictx.ValidatePromptTemplate,
 	})
 }
 
@@ -33,7 +34,7 @@ func (o *Orchestrator) Analyze() error {
 		Log:                    logf,
 		Releases:               o.cfg.Project.Releases,
 		ValidateDocSchemas:     o.validateDocSchemas,
-		ValidatePromptTemplate: validatePromptTemplate,
+		ValidatePromptTemplate: ictx.ValidatePromptTemplate,
 	})
 }
 
@@ -46,8 +47,8 @@ func (o *Orchestrator) validateDocSchemas() []string {
 	var errs []string
 
 	// Validate standard documentation files.
-	for _, path := range resolveStandardFiles() {
-		switch classifyContextFile(path) {
+	for _, path := range ictx.ResolveStandardFiles() {
+		switch ictx.ClassifyContextFile(path) {
 		case "vision":
 			errs = append(errs, validateYAMLStrict[VisionDoc](path)...)
 		case "architecture":
@@ -84,10 +85,10 @@ func (o *Orchestrator) validateDocSchemas() []string {
 	errs = append(errs, validateYAMLStrict[TestingDoc]("pkg/orchestrator/constitutions/testing.yaml")...)
 
 	// Prompts (simple YAML mapping with text fields).
-	errs = append(errs, validatePromptTemplate("docs/prompts/measure.yaml")...)
-	errs = append(errs, validatePromptTemplate("docs/prompts/stitch.yaml")...)
-	errs = append(errs, validatePromptTemplate("pkg/orchestrator/prompts/measure.yaml")...)
-	errs = append(errs, validatePromptTemplate("pkg/orchestrator/prompts/stitch.yaml")...)
+	errs = append(errs, ictx.ValidatePromptTemplate("docs/prompts/measure.yaml")...)
+	errs = append(errs, ictx.ValidatePromptTemplate("docs/prompts/stitch.yaml")...)
+	errs = append(errs, ictx.ValidatePromptTemplate("pkg/orchestrator/prompts/measure.yaml")...)
+	errs = append(errs, ictx.ValidatePromptTemplate("pkg/orchestrator/prompts/stitch.yaml")...)
 
 	return errs
 }

--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -5,7 +5,6 @@ package orchestrator
 
 import (
 	ctx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
-	"gopkg.in/yaml.v3"
 )
 
 // ---------------------------------------------------------------------------
@@ -144,33 +143,9 @@ type Risk = ctx.Risk
 type ContextIssue = ctx.ContextIssue
 type NamedDoc = ctx.NamedDoc
 
-// Release filter types.
-type releaseFilter = ctx.ReleaseFilter
-
-// ---------------------------------------------------------------------------
-// Constants re-exported from internal/context.
-// ---------------------------------------------------------------------------
-
-const defaultMeasureContext = ctx.DefaultMeasureContext
-const defaultStitchContext = ctx.DefaultStitchContext
-const defaultMaxContextBytes = ctx.DefaultMaxContextBytes
-
-// ---------------------------------------------------------------------------
-// Variable re-exports from internal/context.
-// ---------------------------------------------------------------------------
-
-var standardContextPatterns = ctx.StandardContextPatterns
-var typedDocPaths = ctx.TypedDocPaths
-
-// ---------------------------------------------------------------------------
-// Function delegates — unexported wrappers that preserve the original
-// call signatures used throughout the parent package.
-// ---------------------------------------------------------------------------
-
-func loadPhaseContext(path string) (*PhaseContext, error) {
-	return ctx.LoadPhaseContext(path)
-}
-
+// buildProjectContext converts parent-package ProjectConfig to the internal
+// ContextConfig before delegating to ctx.BuildProjectContext. This wrapper
+// exists because the parent and internal packages define separate config structs.
 func buildProjectContext(existingIssuesJSON string, project ProjectConfig, phaseCtx *PhaseContext) (*ProjectContext, error) {
 	return ctx.BuildProjectContext(existingIssuesJSON, ContextConfig{
 		ContextInclude: project.ContextInclude,
@@ -182,115 +157,11 @@ func buildProjectContext(existingIssuesJSON string, project ProjectConfig, phase
 	}, phaseCtx, dirCobbler)
 }
 
+// selectNextPendingUseCase converts parent-package ProjectConfig to the
+// internal ContextConfig before delegating. Same rationale as buildProjectContext.
 func selectNextPendingUseCase(cfg ProjectConfig) (*UseCaseDoc, error) {
 	return ctx.SelectNextPendingUseCase(ContextConfig{
 		Releases: cfg.Releases,
 		Release:  cfg.Release,
 	})
 }
-
-func loadYAML[T any](path string) *T {
-	return ctx.LoadYAML[T](path)
-}
-
-func loadNamedDoc(path string) *NamedDoc {
-	return ctx.LoadNamedDoc(path)
-}
-
-func parseIssuesJSON(jsonStr string) []ContextIssue {
-	return ctx.ParseIssuesJSON(jsonStr)
-}
-
-func numberLines(content string) string {
-	return ctx.NumberLines(content)
-}
-
-func loadSourceFiles(dirs []string) []SourceFile {
-	return ctx.LoadSourceFiles(dirs)
-}
-
-func parseContextSources(text string) []string {
-	return ctx.ParseContextSources(text)
-}
-
-func resolveContextSources(sources string) []string {
-	return ctx.ResolveContextSources(sources)
-}
-
-func resolveFileSet(text string) map[string]bool {
-	return ctx.ResolveFileSet(text)
-}
-
-func classifyContextFile(path string) string {
-	return ctx.ClassifyContextFile(path)
-}
-
-func ensureTypedDocs(files []string) []string {
-	return ctx.EnsureTypedDocs(files)
-}
-
-func resolveStandardFiles() []string {
-	return ctx.ResolveStandardFiles()
-}
-
-func newReleaseFilter(releases []string, release string) releaseFilter {
-	return ctx.NewReleaseFilter(releases, release)
-}
-
-func extractFileRelease(path string) string {
-	return ctx.ExtractFileRelease(path)
-}
-
-func fileMatchesRelease(path string, rf releaseFilter) bool {
-	return ctx.FileMatchesRelease(path, rf)
-}
-
-func prdIDsFromUseCases(useCases []*UseCaseDoc) map[string]bool {
-	return ctx.PRDIDsFromUseCases(useCases)
-}
-
-func ucStatusDone(status string) bool {
-	return ctx.UCStatusDone(status)
-}
-
-func parseTouchpointPackages(touchpoints []map[string]string) []string {
-	return ctx.ParseTouchpointPackages(touchpoints)
-}
-
-func loadContextFileInto(c *ProjectContext, path string, rf releaseFilter) {
-	ctx.LoadContextFileInto(c, path, rf)
-}
-
-func stripParenthetical(s string) string {
-	return ctx.StripParenthetical(s)
-}
-
-func sourceFileMatchesAny(sf SourceFile, suffixes []string) bool {
-	return ctx.SourceFileMatchesAny(sf, suffixes)
-}
-
-func filterSourceFiles(sources []SourceFile, requiredPaths []string) []SourceFile {
-	return ctx.FilterSourceFiles(sources, requiredPaths)
-}
-
-func applyContextBudget(c *ProjectContext, budget int, requiredPaths []string) {
-	ctx.ApplyContextBudget(c, budget, requiredPaths)
-}
-
-func summarizeGoHeaders(content string) string {
-	return ctx.SummarizeGoHeaders(content)
-}
-
-func summarizeCustom(command, filePath, fullContent string) string {
-	return ctx.SummarizeCustom(command, filePath, fullContent)
-}
-
-func loadOODPromptContext() ([]OODPackageContractRef, []ArchSharedProtocol) {
-	return ctx.LoadOODPromptContext()
-}
-
-func loadPRDSemanticModel() *yaml.Node {
-	return ctx.LoadPRDSemanticModel()
-}
-
-// safeCountLines stays in prompt_files.go (not delegated here).

--- a/pkg/orchestrator/context_test.go
+++ b/pkg/orchestrator/context_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
 	"gopkg.in/yaml.v3"
 )
 
@@ -18,7 +19,7 @@ import (
 // ---------------------------------------------------------------------------
 
 func TestLoadPhaseContext_MissingFile(t *testing.T) {
-	pc, err := loadPhaseContext("/nonexistent/measure_context.yaml")
+	pc, err := ictx.LoadPhaseContext("/nonexistent/measure_context.yaml")
 	if err != nil {
 		t.Fatalf("expected nil error for missing file, got: %v", err)
 	}
@@ -39,7 +40,7 @@ release: "01.0"
 		t.Fatal(err)
 	}
 
-	pc, err := loadPhaseContext(path)
+	pc, err := ictx.LoadPhaseContext(path)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -68,7 +69,7 @@ func TestLoadPhaseContext_ExcludeSourceFields(t *testing.T) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	pc, err := loadPhaseContext(path)
+	pc, err := ictx.LoadPhaseContext(path)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -87,7 +88,7 @@ func TestLoadPhaseContext_MalformedFile(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	pc, err := loadPhaseContext(path)
+	pc, err := ictx.LoadPhaseContext(path)
 	if err == nil {
 		t.Fatal("expected error for malformed YAML")
 	}
@@ -184,7 +185,7 @@ func TestBuildProjectContext_PhaseContextPartialOverride(t *testing.T) {
 
 func TestNumberLines_Normal(t *testing.T) {
 	input := "package main\n\nimport \"fmt\"\n\nfunc main() {\n\tfmt.Println(\"hello\")\n}\n"
-	got := numberLines(input)
+	got := ictx.NumberLines(input)
 	want := "1 | package main\n3 | import \"fmt\"\n5 | func main() {\n6 | \tfmt.Println(\"hello\")\n7 | }"
 	if got != want {
 		t.Errorf("numberLines:\ngot:  %q\nwant: %q", got, want)
@@ -193,7 +194,7 @@ func TestNumberLines_Normal(t *testing.T) {
 
 func TestNumberLines_BlankLinesOmitted(t *testing.T) {
 	input := "a\n\n\nb\n"
-	got := numberLines(input)
+	got := ictx.NumberLines(input)
 	want := "1 | a\n4 | b"
 	if got != want {
 		t.Errorf("numberLines:\ngot:  %q\nwant: %q", got, want)
@@ -202,7 +203,7 @@ func TestNumberLines_BlankLinesOmitted(t *testing.T) {
 
 func TestNumberLines_SingleLine(t *testing.T) {
 	input := "package main\n"
-	got := numberLines(input)
+	got := ictx.NumberLines(input)
 	want := "1 | package main"
 	if got != want {
 		t.Errorf("numberLines:\ngot:  %q\nwant: %q", got, want)
@@ -210,7 +211,7 @@ func TestNumberLines_SingleLine(t *testing.T) {
 }
 
 func TestNumberLines_Empty(t *testing.T) {
-	got := numberLines("")
+	got := ictx.NumberLines("")
 	if got != "" {
 		t.Errorf("numberLines empty: got %q, want empty", got)
 	}
@@ -218,7 +219,7 @@ func TestNumberLines_Empty(t *testing.T) {
 
 func TestNumberLines_WhitespaceOnlyLines(t *testing.T) {
 	input := "a\n  \n\t\nb\n"
-	got := numberLines(input)
+	got := ictx.NumberLines(input)
 	want := "1 | a\n4 | b"
 	if got != want {
 		t.Errorf("numberLines:\ngot:  %q\nwant: %q", got, want)
@@ -258,17 +259,17 @@ func TestFileMatchesRelease(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		rf := releaseFilter{MaxRelease: tt.release}
-		got := fileMatchesRelease(tt.path, rf)
+		rf := ictx.ReleaseFilter{MaxRelease: tt.release}
+		got := ictx.FileMatchesRelease(tt.path, rf)
 		if got != tt.want {
-			t.Errorf("fileMatchesRelease(%q, maxRelease=%q) = %v, want %v",
+			t.Errorf("ictx.FileMatchesRelease(%q, maxRelease=%q) = %v, want %v",
 				tt.path, tt.release, got, tt.want)
 		}
 	}
 }
 
 func TestFileMatchesRelease_ReleaseSet(t *testing.T) {
-	set := releaseFilter{ReleaseSet: map[string]bool{"01.0": true, "03.0": true}}
+	set := ictx.ReleaseFilter{ReleaseSet: map[string]bool{"01.0": true, "03.0": true}}
 
 	tests := []struct {
 		path string
@@ -289,9 +290,9 @@ func TestFileMatchesRelease_ReleaseSet(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := fileMatchesRelease(tt.path, set)
+		got := ictx.FileMatchesRelease(tt.path, set)
 		if got != tt.want {
-			t.Errorf("fileMatchesRelease(%q, set{01.0,03.0}) = %v, want %v",
+			t.Errorf("ictx.FileMatchesRelease(%q, set{01.0,03.0}) = %v, want %v",
 				tt.path, got, tt.want)
 		}
 	}
@@ -299,7 +300,7 @@ func TestFileMatchesRelease_ReleaseSet(t *testing.T) {
 
 func TestNewReleaseFilter(t *testing.T) {
 	// Releases list takes precedence over Release string.
-	rf := newReleaseFilter([]string{"01.0", "02.0"}, "03.0")
+	rf := ictx.NewReleaseFilter([]string{"01.0", "02.0"}, "03.0")
 	if rf.ReleaseSet == nil {
 		t.Fatal("expected ReleaseSet to be set when Releases is non-empty")
 	}
@@ -311,7 +312,7 @@ func TestNewReleaseFilter(t *testing.T) {
 	}
 
 	// Empty Releases falls back to Release string.
-	rf2 := newReleaseFilter(nil, "02.0")
+	rf2 := ictx.NewReleaseFilter(nil, "02.0")
 	if rf2.ReleaseSet != nil {
 		t.Error("expected nil ReleaseSet when Releases is empty")
 	}
@@ -320,7 +321,7 @@ func TestNewReleaseFilter(t *testing.T) {
 	}
 
 	// Both empty → no filtering.
-	rf3 := newReleaseFilter(nil, "")
+	rf3 := ictx.NewReleaseFilter(nil, "")
 	if rf3.Active() {
 		t.Error("expected inactive filter when both are empty")
 	}
@@ -340,9 +341,9 @@ func TestExtractFileRelease(t *testing.T) {
 		{"prd001-core.yaml", ""},
 	}
 	for _, tt := range tests {
-		got := extractFileRelease(tt.path)
+		got := ictx.ExtractFileRelease(tt.path)
 		if got != tt.want {
-			t.Errorf("extractFileRelease(%q) = %q, want %q", tt.path, got, tt.want)
+			t.Errorf("ictx.ExtractFileRelease(%q) = %q, want %q", tt.path, got, tt.want)
 		}
 	}
 }
@@ -394,7 +395,7 @@ func TestResolveStandardFiles(t *testing.T) {
 		os.WriteFile(f, []byte("id: test"), 0o644)
 	}
 
-	resolved := resolveStandardFiles()
+	resolved := ictx.ResolveStandardFiles()
 
 	// All standard files should be included.
 	resolvedSet := make(map[string]bool)
@@ -427,10 +428,10 @@ func TestLoadContextFileIntoSetsFilePath(t *testing.T) {
 	os.WriteFile("docs/road-map.yaml", []byte("id: test\ntitle: Test Roadmap"), 0o644)
 
 	ctx := &ProjectContext{Specs: &SpecsCollection{}}
-	noFilter := releaseFilter{}
-	loadContextFileInto(ctx, "docs/VISION.yaml", noFilter)
-	loadContextFileInto(ctx, "docs/ARCHITECTURE.yaml", noFilter)
-	loadContextFileInto(ctx, "docs/road-map.yaml", noFilter)
+	noFilter := ictx.ReleaseFilter{}
+	ictx.LoadContextFileInto(ctx, "docs/VISION.yaml", noFilter)
+	ictx.LoadContextFileInto(ctx, "docs/ARCHITECTURE.yaml", noFilter)
+	ictx.LoadContextFileInto(ctx, "docs/road-map.yaml", noFilter)
 
 	if ctx.Vision == nil || ctx.Vision.File != "docs/VISION.yaml" {
 		t.Errorf("Vision.File = %q, want %q", ctx.Vision.File, "docs/VISION.yaml")
@@ -490,15 +491,15 @@ func TestParseIssuesJSON(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := parseIssuesJSON(tc.input)
+			got := ictx.ParseIssuesJSON(tc.input)
 			if tc.wantNil {
 				if got != nil {
-					t.Errorf("parseIssuesJSON(%q) = %v, want nil", tc.input, got)
+					t.Errorf("ictx.ParseIssuesJSON(%q) = %v, want nil", tc.input, got)
 				}
 				return
 			}
 			if len(got) != tc.wantLen {
-				t.Errorf("parseIssuesJSON() len = %d, want %d", len(got), tc.wantLen)
+				t.Errorf("ictx.ParseIssuesJSON() len = %d, want %d", len(got), tc.wantLen)
 			}
 		})
 	}
@@ -520,10 +521,10 @@ func TestLoadContextFileInto_SpecAux(t *testing.T) {
 	os.WriteFile(filepath.Join("docs", "specs", "utilities.yaml"), []byte("name: utilities\n"), 0o644)
 
 	ctx := &ProjectContext{Specs: &SpecsCollection{}}
-	noFilter := releaseFilter{}
-	loadContextFileInto(ctx, filepath.Join("docs", "specs", "dependency-map.yaml"), noFilter)
-	loadContextFileInto(ctx, filepath.Join("docs", "specs", "sources.yaml"), noFilter)
-	loadContextFileInto(ctx, filepath.Join("docs", "specs", "utilities.yaml"), noFilter)
+	noFilter := ictx.ReleaseFilter{}
+	ictx.LoadContextFileInto(ctx, filepath.Join("docs", "specs", "dependency-map.yaml"), noFilter)
+	ictx.LoadContextFileInto(ctx, filepath.Join("docs", "specs", "sources.yaml"), noFilter)
+	ictx.LoadContextFileInto(ctx, filepath.Join("docs", "specs", "utilities.yaml"), noFilter)
 
 	if ctx.Specs.DependencyMap == nil {
 		t.Error("Specs.DependencyMap should be set for dependency-map.yaml")
@@ -552,8 +553,8 @@ func TestLoadContextFileInto_Engineering(t *testing.T) {
 	os.WriteFile(filepath.Join("docs", "engineering", "eng01-testing.yaml"), []byte("id: eng01\ntitle: Testing Guide\n"), 0o644)
 
 	ctx := &ProjectContext{Specs: &SpecsCollection{}}
-	noFilter := releaseFilter{}
-	loadContextFileInto(ctx, filepath.Join("docs", "engineering", "eng01-testing.yaml"), noFilter)
+	noFilter := ictx.ReleaseFilter{}
+	ictx.LoadContextFileInto(ctx, filepath.Join("docs", "engineering", "eng01-testing.yaml"), noFilter)
 
 	if len(ctx.Engineering) != 1 {
 		t.Fatalf("Engineering len = %d, want 1", len(ctx.Engineering))
@@ -572,8 +573,8 @@ func TestLoadContextFileInto_Extra(t *testing.T) {
 	os.WriteFile("notes.yaml", []byte("name: notes\n"), 0o644)
 
 	ctx := &ProjectContext{Specs: &SpecsCollection{}}
-	noFilter := releaseFilter{}
-	loadContextFileInto(ctx, "notes.yaml", noFilter)
+	noFilter := ictx.ReleaseFilter{}
+	ictx.LoadContextFileInto(ctx, "notes.yaml", noFilter)
 
 	if len(ctx.Extra) != 1 {
 		t.Fatalf("Extra len = %d, want 1", len(ctx.Extra))
@@ -620,7 +621,7 @@ func TestPrdIDsFromUseCases(t *testing.T) {
 		},
 	}
 
-	ids := prdIDsFromUseCases(useCases)
+	ids := ictx.PRDIDsFromUseCases(useCases)
 	if !ids["prd001-core"] {
 		t.Error("expected prd001-core in referenced PRDs")
 	}
@@ -632,7 +633,7 @@ func TestPrdIDsFromUseCases(t *testing.T) {
 	}
 
 	// Nil use cases should return nil.
-	if got := prdIDsFromUseCases(nil); got != nil {
+	if got := ictx.PRDIDsFromUseCases(nil); got != nil {
 		t.Errorf("expected nil for nil use cases, got %v", got)
 	}
 }
@@ -1005,7 +1006,7 @@ func TestEnsureTypedDocs_AddsMissingDocs(t *testing.T) {
 
 	// Start with an empty file list — ensureTypedDocs should add typed docs
 	// that exist on disk.
-	files := ensureTypedDocs(nil)
+	files := ictx.EnsureTypedDocs(nil)
 
 	// VISION, ARCHITECTURE, and road-map.yaml exist in the test fixture.
 	found := make(map[string]bool)
@@ -1029,7 +1030,7 @@ func TestEnsureTypedDocs_DoesNotDuplicate(t *testing.T) {
 
 	// Start with VISION already in the list.
 	files := []string{"docs/VISION.yaml"}
-	result := ensureTypedDocs(files)
+	result := ictx.EnsureTypedDocs(files)
 
 	count := 0
 	for _, f := range result {
@@ -1049,7 +1050,7 @@ func TestEnsureTypedDocs_SkipsMissingFiles(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(origDir)
 
-	files := ensureTypedDocs(nil)
+	files := ictx.EnsureTypedDocs(nil)
 	if len(files) != 0 {
 		t.Errorf("got %d files, want 0 (no typed docs exist in temp dir)", len(files))
 	}
@@ -1067,7 +1068,7 @@ func TestLoadNamedDoc_MarkdownFile(t *testing.T) {
 	content := "# Do Work\n\nUse this command:\n\n```bash\ncurl http://example.com\n```\n"
 	os.WriteFile(mdPath, []byte(content), 0o644)
 
-	doc := loadNamedDoc(mdPath)
+	doc := ictx.LoadNamedDoc(mdPath)
 	if doc == nil {
 		t.Fatal("loadNamedDoc returned nil for markdown file")
 	}
@@ -1087,7 +1088,7 @@ func TestLoadNamedDoc_TextFile(t *testing.T) {
 	txtPath := filepath.Join(dir, "readme.txt")
 	os.WriteFile(txtPath, []byte("plain text"), 0o644)
 
-	doc := loadNamedDoc(txtPath)
+	doc := ictx.LoadNamedDoc(txtPath)
 	if doc == nil {
 		t.Fatal("loadNamedDoc returned nil for .txt file")
 	}
@@ -1101,7 +1102,7 @@ func TestLoadNamedDoc_YAMLFileStillWorks(t *testing.T) {
 	yamlPath := filepath.Join(dir, "config.yaml")
 	os.WriteFile(yamlPath, []byte("id: test\ntitle: Test Doc"), 0o644)
 
-	doc := loadNamedDoc(yamlPath)
+	doc := ictx.LoadNamedDoc(yamlPath)
 	if doc == nil {
 		t.Fatal("loadNamedDoc returned nil for YAML file")
 	}
@@ -1137,8 +1138,8 @@ func TestClassifyContextFile_AllTypes(t *testing.T) {
 		{"random/file.yaml", "extra"},
 	}
 	for _, tc := range cases {
-		if got := classifyContextFile(tc.path); got != tc.want {
-			t.Errorf("classifyContextFile(%q) = %q, want %q", tc.path, got, tc.want)
+		if got := ictx.ClassifyContextFile(tc.path); got != tc.want {
+			t.Errorf("ictx.ClassifyContextFile(%q) = %q, want %q", tc.path, got, tc.want)
 		}
 	}
 }
@@ -1155,7 +1156,7 @@ func TestFilterSourceFiles_ExactMatch(t *testing.T) {
 	}
 	required := []string{"pkg/orchestrator/stitch.go", "pkg/orchestrator/context.go"}
 
-	got := filterSourceFiles(sources, required)
+	got := ictx.FilterSourceFiles(sources, required)
 	if len(got) != 2 {
 		t.Fatalf("filterSourceFiles: got %d files, want 2", len(got))
 	}
@@ -1174,7 +1175,7 @@ func TestFilterSourceFiles_SuffixMatch(t *testing.T) {
 	}
 	required := []string{"pkg/bar/foo.go"}
 
-	got := filterSourceFiles(sources, required)
+	got := ictx.FilterSourceFiles(sources, required)
 	if len(got) != 1 {
 		t.Fatalf("filterSourceFiles suffix: got %d files, want 1", len(got))
 	}
@@ -1190,12 +1191,12 @@ func TestFilterSourceFiles_EmptyRequired(t *testing.T) {
 		{File: "pkg/c.go"},
 	}
 
-	got := filterSourceFiles(sources, nil)
+	got := ictx.FilterSourceFiles(sources, nil)
 	if len(got) != 3 {
 		t.Errorf("filterSourceFiles empty required: got %d, want 3 (all files)", len(got))
 	}
 
-	got2 := filterSourceFiles(sources, []string{})
+	got2 := ictx.FilterSourceFiles(sources, []string{})
 	if len(got2) != 3 {
 		t.Errorf("filterSourceFiles empty slice: got %d, want 3", len(got2))
 	}
@@ -1208,7 +1209,7 @@ func TestFilterSourceFiles_NoMatch(t *testing.T) {
 	}
 	required := []string{"pkg/nonexistent.go"}
 
-	got := filterSourceFiles(sources, required)
+	got := ictx.FilterSourceFiles(sources, required)
 	if len(got) != 0 {
 		t.Errorf("filterSourceFiles no match: got %d, want 0", len(got))
 	}
@@ -1232,9 +1233,9 @@ func TestStripParenthetical(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		got := stripParenthetical(tt.input)
+		got := ictx.StripParenthetical(tt.input)
 		if got != tt.want {
-			t.Errorf("stripParenthetical(%q) = %q, want %q", tt.input, got, tt.want)
+			t.Errorf("ictx.StripParenthetical(%q) = %q, want %q", tt.input, got, tt.want)
 		}
 	}
 }
@@ -1303,7 +1304,7 @@ func TestApplyContextBudget_RemovesNonRequired(t *testing.T) {
 	fullSize := len(data)
 	budget := fullSize / 2
 
-	applyContextBudget(ctx, budget, required)
+	ictx.ApplyContextBudget(ctx, budget, required)
 
 	// a.go must be preserved (it's required).
 	found := false
@@ -1330,7 +1331,7 @@ func TestApplyContextBudget_ZeroBudget(t *testing.T) {
 		},
 	}
 
-	applyContextBudget(ctx, 0, nil)
+	ictx.ApplyContextBudget(ctx, 0, nil)
 
 	if len(ctx.SourceCode) != 2 {
 		t.Errorf("zero budget should not remove files, got %d", len(ctx.SourceCode))
@@ -1347,7 +1348,7 @@ func TestApplyContextBudget_PreservesRequired(t *testing.T) {
 	}
 	required := []string{"pkg/a.go", "pkg/b.go"}
 
-	applyContextBudget(ctx, 1, required) // impossibly small budget
+	ictx.ApplyContextBudget(ctx, 1, required) // impossibly small budget
 
 	if len(ctx.SourceCode) != 2 {
 		t.Errorf("all-required: expected 2 files preserved, got %d", len(ctx.SourceCode))
@@ -1361,7 +1362,7 @@ func TestApplyContextBudget_UnderBudget(t *testing.T) {
 		},
 	}
 
-	applyContextBudget(ctx, 1000000, nil)
+	ictx.ApplyContextBudget(ctx, 1000000, nil)
 
 	if len(ctx.SourceCode) != 1 {
 		t.Errorf("under budget should not remove files, got %d", len(ctx.SourceCode))
@@ -1377,7 +1378,7 @@ func TestApplyContextBudget_ExactlyAtLimit(t *testing.T) {
 	data, _ := yaml.Marshal(ctx)
 	exactSize := len(data)
 
-	applyContextBudget(ctx, exactSize, nil)
+	ictx.ApplyContextBudget(ctx, exactSize, nil)
 
 	if len(ctx.SourceCode) != 1 {
 		t.Errorf("at-limit: expected 1 file, got %d", len(ctx.SourceCode))
@@ -1386,7 +1387,7 @@ func TestApplyContextBudget_ExactlyAtLimit(t *testing.T) {
 
 func TestApplyContextBudget_NilContext(t *testing.T) {
 	// Should not panic.
-	applyContextBudget(nil, 100, nil)
+	ictx.ApplyContextBudget(nil, 100, nil)
 }
 
 func TestApplyContextBudget_NegativeBudget(t *testing.T) {
@@ -1397,7 +1398,7 @@ func TestApplyContextBudget_NegativeBudget(t *testing.T) {
 		},
 	}
 
-	applyContextBudget(ctx, -1, nil)
+	ictx.ApplyContextBudget(ctx, -1, nil)
 
 	if len(ctx.SourceCode) != 2 {
 		t.Errorf("negative budget should disable enforcement, got %d files", len(ctx.SourceCode))
@@ -1417,7 +1418,7 @@ func TestApplyContextBudget_DefaultBudget(t *testing.T) {
 	ctx := &ProjectContext{SourceCode: sources}
 
 	required := []string{"pkg/file000.go"}
-	applyContextBudget(ctx, 0, required)
+	ictx.ApplyContextBudget(ctx, 0, required)
 
 	// Required file must survive.
 	found := false
@@ -1622,7 +1623,7 @@ type MyType struct {
 
 type privateType struct{}
 `
-	got := summarizeGoHeaders(src)
+	got := ictx.SummarizeGoHeaders(src)
 
 	// Exported func signature must be present.
 	if !strings.Contains(got, "func Exported() string") {
@@ -1667,7 +1668,7 @@ var DefaultTimeout = 30
 
 var secretKey = "shh"
 `
-	got := summarizeGoHeaders(src)
+	got := ictx.SummarizeGoHeaders(src)
 	if !strings.Contains(got, "Version") {
 		t.Errorf("exported const Version should be kept, got:\n%s", got)
 	}
@@ -1687,7 +1688,7 @@ var secretKey = "shh"
 func TestSummarizeGoHeaders_InvalidInput(t *testing.T) {
 	t.Parallel()
 	src := "this is not valid Go source!!!"
-	got := summarizeGoHeaders(src)
+	got := ictx.SummarizeGoHeaders(src)
 	if got != src {
 		t.Errorf("invalid Go input should be returned unchanged, got:\n%s", got)
 	}
@@ -1702,7 +1703,7 @@ func TestSummarizeCustom_Output(t *testing.T) {
 	os.WriteFile(filePath, []byte("package foo\n"), 0o644)
 
 	// "echo hello" appended with filePath → output contains "hello".
-	out := summarizeCustom("echo hello", filePath, "original content")
+	out := ictx.SummarizeCustom("echo hello", filePath, "original content")
 	if !strings.Contains(out, "hello") {
 		t.Errorf("expected command output, got: %q", out)
 	}
@@ -1717,7 +1718,7 @@ func TestSummarizeCustom_FallbackOnFailure(t *testing.T) {
 	os.WriteFile(filePath, []byte("package foo\n"), 0o644)
 
 	fullContent := "original full content"
-	got := summarizeCustom("false", filePath, fullContent)
+	got := ictx.SummarizeCustom("false", filePath, fullContent)
 	if got != fullContent {
 		t.Errorf("failing command should fall back to full content, got: %q", got)
 	}
@@ -1728,7 +1729,7 @@ func TestSummarizeCustom_FallbackOnFailure(t *testing.T) {
 func TestSummarizeCustom_EmptyCommand(t *testing.T) {
 	t.Parallel()
 	full := "original content"
-	got := summarizeCustom("", "any/path.go", full)
+	got := ictx.SummarizeCustom("", "any/path.go", full)
 	if got != full {
 		t.Errorf("empty command should return full content, got: %q", got)
 	}
@@ -1801,7 +1802,7 @@ func TestParseTouchpointPackages_EmDash(t *testing.T) {
 		{"T1": "cmd/du \u2014 prd009-du R1, R2, R3"},
 		{"T2": "pkg/sys \u2014 prd003-sys"},
 	}
-	got := parseTouchpointPackages(touchpoints)
+	got := ictx.ParseTouchpointPackages(touchpoints)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 packages, got %v", got)
 	}
@@ -1815,7 +1816,7 @@ func TestParseTouchpointPackages_EnDash(t *testing.T) {
 	touchpoints := []map[string]string{
 		{"T1": "pkg/format \u2013 prd007-format R1"},
 	}
-	got := parseTouchpointPackages(touchpoints)
+	got := ictx.ParseTouchpointPackages(touchpoints)
 	if len(got) != 1 || got[0] != "pkg/format" {
 		t.Errorf("expected [pkg/format], got %v", got)
 	}
@@ -1826,7 +1827,7 @@ func TestParseTouchpointPackages_MultiplePathsCommaSeparated(t *testing.T) {
 	touchpoints := []map[string]string{
 		{"T1": "cmd/cp, cmd/mv \u2014 prd001-cp R1"},
 	}
-	got := parseTouchpointPackages(touchpoints)
+	got := ictx.ParseTouchpointPackages(touchpoints)
 	if len(got) != 2 {
 		t.Fatalf("expected 2 packages, got %v", got)
 	}
@@ -1842,7 +1843,7 @@ func TestParseTouchpointPackages_NoDash_Ignored(t *testing.T) {
 		{"T1": "Config (workflow fields): prd001-orchestrator-core R1"},
 		{"T2": "Prompt templates: prd003-cobbler-workflows R5"},
 	}
-	got := parseTouchpointPackages(touchpoints)
+	got := ictx.ParseTouchpointPackages(touchpoints)
 	if len(got) != 0 {
 		t.Errorf("expected no packages for colon-separated touchpoints, got %v", got)
 	}
@@ -1853,7 +1854,7 @@ func TestParseTouchpointPackages_TrailingSlashNormalized(t *testing.T) {
 	touchpoints := []map[string]string{
 		{"T1": "pkg/util/ \u2014 prd002-util R1"},
 	}
-	got := parseTouchpointPackages(touchpoints)
+	got := ictx.ParseTouchpointPackages(touchpoints)
 	if len(got) != 1 || got[0] != "pkg/util" {
 		t.Errorf("expected [pkg/util] (trailing slash stripped), got %v", got)
 	}
@@ -1861,10 +1862,10 @@ func TestParseTouchpointPackages_TrailingSlashNormalized(t *testing.T) {
 
 func TestParseTouchpointPackages_Empty(t *testing.T) {
 	t.Parallel()
-	if got := parseTouchpointPackages(nil); got != nil {
+	if got := ictx.ParseTouchpointPackages(nil); got != nil {
 		t.Errorf("expected nil for nil input, got %v", got)
 	}
-	if got := parseTouchpointPackages([]map[string]string{}); got != nil {
+	if got := ictx.ParseTouchpointPackages([]map[string]string{}); got != nil {
 		t.Errorf("expected nil for empty input, got %v", got)
 	}
 }
@@ -2011,8 +2012,8 @@ func TestUCStatusDone(t *testing.T) {
 		{"", false},
 	}
 	for _, tc := range cases {
-		if got := ucStatusDone(tc.status); got != tc.want {
-			t.Errorf("ucStatusDone(%q) = %v, want %v", tc.status, got, tc.want)
+		if got := ictx.UCStatusDone(tc.status); got != tc.want {
+			t.Errorf("ictx.UCStatusDone(%q) = %v, want %v", tc.status, got, tc.want)
 		}
 	}
 }

--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -18,6 +18,7 @@ import (
 
 	an "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/analysis"
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
+	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/generate"
 	gh "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/github"
 )
@@ -523,7 +524,7 @@ func (o *Orchestrator) RunCycles(label string) error {
 // configuration.yaml). Changes are committed on the current branch. Returns
 // (true, version) if a release was advanced, (false, "") otherwise.
 func (o *Orchestrator) checkAutoAdvanceRelease() (bool, string) {
-	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
+	rm := ictx.LoadYAML[RoadmapDoc]("docs/road-map.yaml")
 	if rm == nil {
 		return false, ""
 	}
@@ -532,7 +533,7 @@ func (o *Orchestrator) checkAutoAdvanceRelease() (bool, string) {
 	var target *RoadmapRelease
 	for i := range rm.Releases {
 		rel := &rm.Releases[i]
-		if !ucStatusDone(rel.Status) {
+		if !ictx.UCStatusDone(rel.Status) {
 			target = rel
 			break
 		}
@@ -546,7 +547,7 @@ func (o *Orchestrator) checkAutoAdvanceRelease() (bool, string) {
 		return false, ""
 	}
 	for _, uc := range target.UseCases {
-		if !ucStatusDone(uc.Status) {
+		if !ictx.UCStatusDone(uc.Status) {
 			return false, ""
 		}
 	}
@@ -579,7 +580,7 @@ func (o *Orchestrator) checkAutoAdvanceRelease() (bool, string) {
 // markActiveReleaseUCsDone pair that blindly marked all UCs when no open issues
 // remained (GH-1361).
 func (o *Orchestrator) validateAndMarkUCs() {
-	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
+	rm := ictx.LoadYAML[RoadmapDoc]("docs/road-map.yaml")
 	if rm == nil {
 		return
 	}
@@ -588,7 +589,7 @@ func (o *Orchestrator) validateAndMarkUCs() {
 	var target *RoadmapRelease
 	for i := range rm.Releases {
 		rel := &rm.Releases[i]
-		if !ucStatusDone(rel.Status) {
+		if !ictx.UCStatusDone(rel.Status) {
 			target = rel
 			break
 		}
@@ -599,7 +600,7 @@ func (o *Orchestrator) validateAndMarkUCs() {
 
 	var marked []string
 	for _, uc := range target.UseCases {
-		if ucStatusDone(uc.Status) {
+		if ictx.UCStatusDone(uc.Status) {
 			continue
 		}
 
@@ -1132,7 +1133,7 @@ func (o *Orchestrator) mergeGeneration(branch, baseBranch string) error {
 // validateAndMarkUCs even when the release itself is not yet implemented
 // (GH-1469).
 func (o *Orchestrator) resetImplementedReleases() error {
-	rm := loadYAML[RoadmapDoc]("docs/road-map.yaml")
+	rm := ictx.LoadYAML[RoadmapDoc]("docs/road-map.yaml")
 	if rm == nil {
 		return nil
 	}
@@ -1151,7 +1152,7 @@ func (o *Orchestrator) resetImplementedReleases() error {
 		// not yet implemented (GH-1469). validateAndMarkUCs promotes UCs
 		// one at a time during the run; generator:stop must undo them.
 		for _, uc := range rel.UseCases {
-			if ucStatusDone(uc.Status) {
+			if ictx.UCStatusDone(uc.Status) {
 				if err := updateRoadmapSingleUCStatus(rel.Version, uc.ID, "spec_complete"); err != nil {
 					logf("resetImplementedReleases: revert UC %s in %s failed: %v", uc.ID, rel.Version, err)
 					continue

--- a/pkg/orchestrator/issues_gh_test.go
+++ b/pkg/orchestrator/issues_gh_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
 	gh "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/github"
 )
 
@@ -24,7 +25,7 @@ func TestIssuesContextJSON_ParseableByParseIssuesJSON(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// Verify the output is parseable by parseIssuesJSON (the function that was broken).
-	parsed := parseIssuesJSON(jsonStr)
+	parsed := ictx.ParseIssuesJSON(jsonStr)
 	if len(parsed) != 1 {
 		t.Fatalf("parseIssuesJSON returned %d issues, want 1; input: %s", len(parsed), jsonStr)
 	}

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
+	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
 	gh "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/github"
 	"gopkg.in/yaml.v3"
 )
@@ -417,7 +418,7 @@ func (o *Orchestrator) RunMeasure() error {
 }
 
 func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limit int, validationErrors ...string) (string, error) {
-	tmpl, err := parsePromptTemplate(orDefault(o.cfg.Cobbler.MeasurePrompt, defaultMeasurePrompt))
+	tmpl, err := ictx.ParsePromptTemplate(orDefault(o.cfg.Cobbler.MeasurePrompt, defaultMeasurePrompt))
 	if err != nil {
 		return "", fmt.Errorf("measure prompt YAML: %w", err)
 	}
@@ -426,7 +427,7 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 
 	// Load per-phase context file (prd003 R9.8).
 	measureCtxPath := filepath.Join(o.cfg.Cobbler.Dir, "measure_context.yaml")
-	phaseCtx, phaseErr := loadPhaseContext(measureCtxPath)
+	phaseCtx, phaseErr := ictx.LoadPhaseContext(measureCtxPath)
 	if phaseErr != nil {
 		return "", fmt.Errorf("loading measure context: %w", phaseErr)
 	}
@@ -468,7 +469,7 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 		if err != nil {
 			logf("buildMeasurePrompt: road-map source selection error: %v", err)
 		} else if uc != nil {
-			pkgPaths := parseTouchpointPackages(uc.Touchpoints)
+			pkgPaths := ictx.ParseTouchpointPackages(uc.Touchpoints)
 			if len(pkgPaths) > 0 {
 				var patterns []string
 				for _, p := range pkgPaths {
@@ -501,7 +502,7 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 	var measureContracts []OODPackageContractRef
 	sourceMode := phaseCtx.SourceMode
 	if sourceMode == "headers" || sourceMode == "custom" {
-		contracts, _ := loadOODPromptContext()
+		contracts, _ := ictx.LoadOODPromptContext()
 		if len(contracts) > 0 {
 			measureContracts = contracts
 			logf("buildMeasurePrompt: injecting %d package_contracts (source_mode=%s)", len(contracts), sourceMode)
@@ -511,11 +512,11 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 	doc := MeasurePromptDoc{
 		Role:                    tmpl.Role,
 		ProjectContext:          projectCtx,
-		PlanningConstitution:    parseYAMLNode(planningConst),
-		IssueFormatConstitution: parseYAMLNode(issueFormatConstitution),
-		Task:                    substitutePlaceholders(tmpl.Task, placeholders),
-		Constraints:             substitutePlaceholders(tmpl.Constraints, placeholders),
-		OutputFormat:            substitutePlaceholders(tmpl.OutputFormat, placeholders),
+		PlanningConstitution:    ictx.ParseYAMLNode(planningConst),
+		IssueFormatConstitution: ictx.ParseYAMLNode(issueFormatConstitution),
+		Task:                    ictx.SubstitutePlaceholders(tmpl.Task, placeholders),
+		Constraints:             ictx.SubstitutePlaceholders(tmpl.Constraints, placeholders),
+		OutputFormat:            ictx.SubstitutePlaceholders(tmpl.OutputFormat, placeholders),
 		GoldenExample:           o.cfg.Cobbler.GoldenExample,
 		AdditionalContext:       userInput,
 		ValidationErrors:        validationErrors,

--- a/pkg/orchestrator/precycle.go
+++ b/pkg/orchestrator/precycle.go
@@ -5,6 +5,7 @@ package orchestrator
 
 import (
 	an "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/analysis"
+	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
 )
 
 // Type aliases for backward-compatible re-exports.
@@ -21,7 +22,7 @@ func (o *Orchestrator) RunPreCycleAnalysis() {
 			Log:                    logf,
 			Releases:               o.cfg.Project.Releases,
 			ValidateDocSchemas:     o.validateDocSchemas,
-			ValidatePromptTemplate: validatePromptTemplate,
+			ValidatePromptTemplate: ictx.ValidatePromptTemplate,
 		},
 	})
 }

--- a/pkg/orchestrator/prompt.go
+++ b/pkg/orchestrator/prompt.go
@@ -5,7 +5,6 @@ package orchestrator
 
 import (
 	ctx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
-	"gopkg.in/yaml.v3"
 )
 
 // ---------------------------------------------------------------------------
@@ -14,24 +13,3 @@ import (
 
 type MeasurePromptDoc = ctx.MeasurePromptDoc
 type StitchPromptDoc = ctx.StitchPromptDoc
-type promptTemplate = ctx.PromptTemplate
-
-// ---------------------------------------------------------------------------
-// Function delegates.
-// ---------------------------------------------------------------------------
-
-func parsePromptTemplate(yamlContent string) (promptTemplate, error) {
-	return ctx.ParsePromptTemplate(yamlContent)
-}
-
-func validatePromptTemplate(path string) []string {
-	return ctx.ValidatePromptTemplate(path)
-}
-
-func parseYAMLNode(content string) *yaml.Node {
-	return ctx.ParseYAMLNode(content)
-}
-
-func substitutePlaceholders(text string, data map[string]string) string {
-	return ctx.SubstitutePlaceholders(text, data)
-}

--- a/pkg/orchestrator/prompt_files.go
+++ b/pkg/orchestrator/prompt_files.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
 	st "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/stats"
 )
 
@@ -51,17 +52,17 @@ func (o *Orchestrator) resolveContextFileEntries() []contextFileEntry {
 	var entries []contextFileEntry
 
 	// Build exclude set (empty map when ContextExclude is unset).
-	excludeSet := resolveFileSet(o.cfg.Project.ContextExclude)
+	excludeSet := ictx.ResolveFileSet(o.cfg.Project.ContextExclude)
 
 	// Resolve doc files: ContextInclude overrides standard patterns.
 	var docFiles []string
 	var docSource string
 	if strings.TrimSpace(o.cfg.Project.ContextInclude) != "" {
-		docFiles = resolveContextSources(o.cfg.Project.ContextInclude)
-		docFiles = ensureTypedDocs(docFiles)
+		docFiles = ictx.ResolveContextSources(o.cfg.Project.ContextInclude)
+		docFiles = ictx.EnsureTypedDocs(docFiles)
 		docSource = "config"
 	} else {
-		docFiles = resolveStandardFiles()
+		docFiles = ictx.ResolveStandardFiles()
 		docSource = "default"
 	}
 
@@ -78,7 +79,7 @@ func (o *Orchestrator) resolveContextFileEntries() []contextFileEntry {
 		}
 		entries = append(entries, contextFileEntry{
 			Source:   docSource,
-			Category: classifyContextFile(path),
+			Category: ictx.ClassifyContextFile(path),
 			Path:     path,
 			Lines:    safeCountLines(path),
 			Bytes:    int(info.Size()),
@@ -87,7 +88,7 @@ func (o *Orchestrator) resolveContextFileEntries() []contextFileEntry {
 
 	// Extra context sources from configuration.
 	if strings.TrimSpace(o.cfg.Project.ContextSources) != "" {
-		extras := resolveContextSources(o.cfg.Project.ContextSources)
+		extras := ictx.ResolveContextSources(o.cfg.Project.ContextSources)
 		for _, path := range extras {
 			if seen[path] || excludeSet[path] {
 				continue

--- a/pkg/orchestrator/prompt_test.go
+++ b/pkg/orchestrator/prompt_test.go
@@ -9,13 +9,14 @@ import (
 	"strings"
 	"testing"
 
+	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
 	"gopkg.in/yaml.v3"
 )
 
 // --- parsePromptTemplate ---
 
 func TestParsePromptTemplate_MeasureFields(t *testing.T) {
-	tmpl, err := parsePromptTemplate(defaultMeasurePrompt)
+	tmpl, err := ictx.ParsePromptTemplate(defaultMeasurePrompt)
 	if err != nil {
 		t.Fatalf("parsePromptTemplate: %v", err)
 	}
@@ -34,7 +35,7 @@ func TestParsePromptTemplate_MeasureFields(t *testing.T) {
 }
 
 func TestParsePromptTemplate_StitchFields(t *testing.T) {
-	tmpl, err := parsePromptTemplate(defaultStitchPrompt)
+	tmpl, err := ictx.ParsePromptTemplate(defaultStitchPrompt)
 	if err != nil {
 		t.Fatalf("parsePromptTemplate: %v", err)
 	}
@@ -50,7 +51,7 @@ func TestParsePromptTemplate_StitchFields(t *testing.T) {
 }
 
 func TestParsePromptTemplate_InvalidYAML(t *testing.T) {
-	_, err := parsePromptTemplate("not: [valid: yaml")
+	_, err := ictx.ParsePromptTemplate("not: [valid: yaml")
 	if err == nil {
 		t.Error("expected error for invalid YAML")
 	}
@@ -66,7 +67,7 @@ func TestSubstitutePlaceholders(t *testing.T) {
 		"lines_min":   "250",
 		"lines_max":   "350",
 	}
-	got := substitutePlaceholders(text, data)
+	got := ictx.SubstitutePlaceholders(text, data)
 	want := "Output to /tmp/out.yaml, max 5 tasks of 250-350 lines."
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
@@ -76,7 +77,7 @@ func TestSubstitutePlaceholders(t *testing.T) {
 // --- validatePromptTemplate ---
 
 func TestValidatePromptTemplate_MissingFile(t *testing.T) {
-	errs := validatePromptTemplate("/nonexistent/path/prompt.yaml")
+	errs := ictx.ValidatePromptTemplate("/nonexistent/path/prompt.yaml")
 	if errs != nil {
 		t.Errorf("expected nil for missing file, got %v", errs)
 	}
@@ -89,7 +90,7 @@ func TestValidatePromptTemplate_ValidFile(t *testing.T) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("writing file: %v", err)
 	}
-	errs := validatePromptTemplate(path)
+	errs := ictx.ValidatePromptTemplate(path)
 	if errs != nil {
 		t.Errorf("expected nil for valid file, got %v", errs)
 	}
@@ -101,7 +102,7 @@ func TestValidatePromptTemplate_InvalidYAML(t *testing.T) {
 	if err := os.WriteFile(path, []byte("not: [valid: yaml"), 0o644); err != nil {
 		t.Fatalf("writing file: %v", err)
 	}
-	errs := validatePromptTemplate(path)
+	errs := ictx.ValidatePromptTemplate(path)
 	if len(errs) == 0 {
 		t.Error("expected errors for invalid YAML, got none")
 	}
@@ -110,7 +111,7 @@ func TestValidatePromptTemplate_InvalidYAML(t *testing.T) {
 // --- parseYAMLNode ---
 
 func TestParseYAMLNode_ValidYAML(t *testing.T) {
-	node := parseYAMLNode("articles:\n  - id: P1\n    title: Test")
+	node := ictx.ParseYAMLNode("articles:\n  - id: P1\n    title: Test")
 	if node == nil {
 		t.Fatal("expected non-nil node")
 	}
@@ -120,14 +121,14 @@ func TestParseYAMLNode_ValidYAML(t *testing.T) {
 }
 
 func TestParseYAMLNode_Empty(t *testing.T) {
-	node := parseYAMLNode("")
+	node := ictx.ParseYAMLNode("")
 	if node != nil {
 		t.Error("expected nil for empty input")
 	}
 }
 
 func TestParseYAMLNode_Invalid(t *testing.T) {
-	node := parseYAMLNode("not: [valid: yaml")
+	node := ictx.ParseYAMLNode("not: [valid: yaml")
 	if node != nil {
 		t.Error("expected nil for invalid YAML")
 	}
@@ -373,7 +374,7 @@ func TestLoadOODPromptContext_Empty(t *testing.T) {
 	defer os.Chdir(orig)
 	os.MkdirAll("docs/specs/product-requirements", 0o755)
 
-	contracts, protocols := loadOODPromptContext()
+	contracts, protocols := ictx.LoadOODPromptContext()
 	if len(contracts) != 0 {
 		t.Errorf("expected no contracts with no PRD files, got %d", len(contracts))
 	}
@@ -402,7 +403,7 @@ package_contract:
 title: Cmd
 `), 0o644)
 
-	contracts, _ := loadOODPromptContext()
+	contracts, _ := ictx.LoadOODPromptContext()
 	if len(contracts) != 1 {
 		t.Fatalf("expected 1 contract, got %d", len(contracts))
 	}
@@ -435,7 +436,7 @@ shared_protocols:
     pattern: "signal.Notify(...)"
 `), 0o644)
 
-	_, protocols := loadOODPromptContext()
+	_, protocols := ictx.LoadOODPromptContext()
 	if len(protocols) != 1 {
 		t.Fatalf("expected 1 protocol, got %d", len(protocols))
 	}
@@ -459,7 +460,7 @@ package_contract:
   exports: []
 `), 0o644)
 
-	contracts, _ := loadOODPromptContext()
+	contracts, _ := ictx.LoadOODPromptContext()
 	if len(contracts) != 0 {
 		t.Errorf("expected no contracts for empty exports, got %d", len(contracts))
 	}

--- a/pkg/orchestrator/scaffold.go
+++ b/pkg/orchestrator/scaffold.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/build"
+	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
 	"gopkg.in/yaml.v3"
 )
 
@@ -93,8 +94,8 @@ func (o *Orchestrator) Scaffold(targetDir, orchestratorRoot string) error {
 		return fmt.Errorf("creating cobbler directory: %w", err)
 	}
 	contextFiles := map[string]string{
-		"measure_context.yaml": defaultMeasureContext,
-		"stitch_context.yaml":  defaultStitchContext,
+		"measure_context.yaml": ictx.DefaultMeasureContext,
+		"stitch_context.yaml":  ictx.DefaultStitchContext,
 	}
 	for _, name := range slices.Sorted(maps.Keys(contextFiles)) {
 		p := filepath.Join(cobblerDir, name)

--- a/pkg/orchestrator/stats.go
+++ b/pkg/orchestrator/stats.go
@@ -7,6 +7,7 @@
 package orchestrator
 
 import (
+	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
 	st "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/stats"
 )
 
@@ -28,8 +29,8 @@ func (o *Orchestrator) statsDeps() st.StatsDeps {
 	return st.StatsDeps{
 		BinaryDir:            o.cfg.Project.BinaryDir,
 		MagefilesDir:         o.cfg.Project.MagefilesDir,
-		ResolveStandardFiles: resolveStandardFiles,
-		ClassifyContextFile:  classifyContextFile,
+		ResolveStandardFiles: ictx.ResolveStandardFiles,
+		ClassifyContextFile:  ictx.ClassifyContextFile,
 	}
 }
 

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
+	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/generate"
 	gh "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/github"
 	"gopkg.in/yaml.v3"
@@ -426,7 +427,7 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 }
 
 func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
-	tmpl, err := parsePromptTemplate(orDefault(o.cfg.Cobbler.StitchPrompt, defaultStitchPrompt))
+	tmpl, err := ictx.ParsePromptTemplate(orDefault(o.cfg.Cobbler.StitchPrompt, defaultStitchPrompt))
 	if err != nil {
 		return "", fmt.Errorf("stitch prompt YAML: %w", err)
 	}
@@ -436,7 +437,7 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 
 	// Load per-phase context file (prd003 R9.9).
 	stitchCtxPath := filepath.Join(o.cfg.Cobbler.Dir, "stitch_context.yaml")
-	phaseCtx, phaseErr := loadPhaseContext(stitchCtxPath)
+	phaseCtx, phaseErr := ictx.LoadPhaseContext(stitchCtxPath)
 	if phaseErr != nil {
 		return "", fmt.Errorf("loading stitch context: %w", phaseErr)
 	}
@@ -503,14 +504,14 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 		requiredReading := parseRequiredReading(task.Description)
 		var sourcePaths []string
 		for _, entry := range requiredReading {
-			clean := stripParenthetical(entry)
+			clean := ictx.StripParenthetical(entry)
 			if strings.HasSuffix(clean, ".go") {
 				sourcePaths = append(sourcePaths, clean)
 			}
 		}
 		if len(sourcePaths) > 0 {
 			before := len(projectCtx.SourceCode)
-			projectCtx.SourceCode = filterSourceFiles(projectCtx.SourceCode, sourcePaths)
+			projectCtx.SourceCode = ictx.FilterSourceFiles(projectCtx.SourceCode, sourcePaths)
 			logf("buildStitchPrompt: filtered source files %d -> %d (required_reading has %d source paths)",
 				before, len(projectCtx.SourceCode), len(sourcePaths))
 		} else {
@@ -519,7 +520,7 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 		}
 
 		// Context budget enforcement.
-		applyContextBudget(projectCtx, o.cfg.Cobbler.MaxContextBytes, sourcePaths)
+		ictx.ApplyContextBudget(projectCtx, o.cfg.Cobbler.MaxContextBytes, sourcePaths)
 	}
 
 	taskContext := fmt.Sprintf("Task ID: %s\nType: %s\nTitle: %s",
@@ -528,7 +529,7 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 	repoFiles := defaultGitOps.LsFiles(task.WorktreeDir)
 
 	// Load OOD context.
-	oodContracts, oodProtocols := loadOODPromptContext()
+	oodContracts, oodProtocols := ictx.LoadOODPromptContext()
 	if len(oodProtocols) > 0 {
 		logf("buildStitchPrompt: injecting %d shared_protocols", len(oodProtocols))
 	}
@@ -537,7 +538,7 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 	}
 
 	// Load semantic model from PRD (informational context for stitch).
-	semanticModel := loadPRDSemanticModel()
+	semanticModel := ictx.LoadPRDSemanticModel()
 	if semanticModel != nil {
 		logf("buildStitchPrompt: injecting semantic_model from PRD")
 	}
@@ -547,8 +548,8 @@ func (o *Orchestrator) buildStitchPrompt(task stitchTask) (string, error) {
 		RepositoryFiles:       repoFiles,
 		ProjectContext:        projectCtx,
 		Context:               taskContext,
-		ExecutionConstitution: parseYAMLNode(executionConst),
-		GoStyleConstitution:   parseYAMLNode(goStyleConst),
+		ExecutionConstitution: ictx.ParseYAMLNode(executionConst),
+		GoStyleConstitution:   ictx.ParseYAMLNode(goStyleConst),
 		Task:                  tmpl.Task,
 		Constraints:           tmpl.Constraints,
 		Description:           task.Description,


### PR DESCRIPTION
## Summary

Eliminates 28 pass-through wrapper functions, 2 unexported type aliases, 3 constant aliases, and 2 variable aliases from context.go and prompt.go. Keeps init() for dependency injection, all 118 exported type aliases (public API), and two wrappers with ProjectConfig-to-ContextConfig conversion logic.

## Changes

- Removed 25 wrapper functions and constants/variables from context.go (lines 148-296)
- Removed 4 wrapper functions and promptTemplate alias from prompt.go
- Updated 11 files (measure.go, stitch.go, generator.go, scaffold.go, analyze.go, precycle.go, stats.go, prompt_files.go, context_test.go, prompt_test.go, issues_gh_test.go) to use ictx.X() directly
- Kept buildProjectContext and selectNextPendingUseCase (have type conversion logic)
- Kept ConstitutionToMarkdown (exported public API)

## Stats

- go_loc_prod: 18723 → 18580 (−143)
- go_loc_test: 34342 → 34345 (+3, import lines)
- go_loc: 53065 → 52925 (−140 net)

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] Documentation reviewed for consistency

Closes #1695