### PR TITLE
GH-1699: Auto-skip stitch tasks after repeated timeouts

### DIFF
--- a/pkg/orchestrator/cobbler.go
+++ b/pkg/orchestrator/cobbler.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
+	gh "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/github"
 )
 
 // ---------------------------------------------------------------------------
@@ -141,6 +142,33 @@ func (o *Orchestrator) hasOpenIssues() (bool, error) {
 			return len(issues), err
 		},
 	})
+}
+
+// hasOnlySkippedIssues returns true when there are open cobbler issues but
+// every one of them carries the cobbler-skipped label (GH-1699). This lets
+// the generator stop cleanly instead of looping on tasks that cannot succeed.
+func (o *Orchestrator) hasOnlySkippedIssues() (bool, error) {
+	repo, err := ghTrackerWithCfg(o.cfg).DetectGitHubRepo(".")
+	if err != nil {
+		return false, err
+	}
+	generation, err := defaultGitOps.CurrentBranch(".")
+	if err != nil {
+		return false, err
+	}
+	issues, err := defaultGhTracker.ListOpenCobblerIssues(repo, generation)
+	if err != nil {
+		return false, err
+	}
+	if len(issues) == 0 {
+		return false, nil // no open issues at all
+	}
+	for _, iss := range issues {
+		if !gh.HasLabel(iss, gh.LabelSkipped) {
+			return false, nil // at least one non-skipped issue
+		}
+	}
+	return true, nil
 }
 
 // HistoryClean removes the history subdirectory.

--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -480,6 +480,13 @@ func (o *Orchestrator) RunCycles(label string) error {
 			logf("generator %s: cycle %d — auto-advanced release %s", label, cycle, ver)
 		}
 
+		// If the only remaining open issues are skipped, stop the generation
+		// immediately rather than wasting cycles (GH-1699).
+		if onlySkipped, skippedErr := o.hasOnlySkippedIssues(); skippedErr == nil && onlySkipped {
+			logf("generator %s: cycle %d — only skipped tasks remain, stopping", label, cycle)
+			break
+		}
+
 		// Skip measure if open issues remain — stitch should drain them first (GH-1352).
 		if openBefore, err := o.hasOpenIssues(); err == nil && openBefore {
 			logf("generator %s: cycle %d — skipping measure, open issues remain", label, cycle)

--- a/pkg/orchestrator/internal/github/issues.go
+++ b/pkg/orchestrator/internal/github/issues.go
@@ -156,6 +156,7 @@ type ContextIssue struct {
 const (
 	LabelReady      = "cobbler-ready"
 	LabelInProgress = "cobbler-in-progress"
+	LabelSkipped    = "cobbler-skipped"
 )
 
 // GenLabelPrefix is the prefix for generation-scoped labels.
@@ -426,6 +427,7 @@ func (t *GitHubTracker) EnsureCobblerLabels(repo string) error {
 	}{
 		{LabelReady, "0075ca", "Cobbler task ready to be picked by stitch"},
 		{LabelInProgress, "e4e669", "Cobbler task currently being worked on"},
+		{LabelSkipped, "d93f0b", "Cobbler task skipped after exceeding retry limit"},
 	}
 
 	for _, l := range labels {
@@ -778,9 +780,10 @@ func (t *GitHubTracker) PickReadyIssue(repo, generation string) (CobblerIssue, e
 	}
 
 	// Filter to ready issues and sort by number ascending.
+	// Exclude skipped issues (GH-1699) — they exceeded their retry limit.
 	var ready []CobblerIssue
 	for _, iss := range issues {
-		if HasLabel(iss, LabelReady) && !HasLabel(iss, LabelInProgress) {
+		if HasLabel(iss, LabelReady) && !HasLabel(iss, LabelInProgress) && !HasLabel(iss, LabelSkipped) {
 			ready = append(ready, iss)
 		}
 	}

--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -223,7 +223,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	var totalStitchDurS int
 	var totalTurns, totalLocProd, totalLocTest, totalReqs int
 	var totalInputTokens, totalOutputTokens int
-	var nDone, nFailed, nInProgress, nPending int
+	var nDone, nFailed, nSkipped, nInProgress, nPending int
 	prdStatus := make(map[string]string) // prd name → highest-priority status
 	prdReleaseMap := BuildPRDReleaseMap()
 	seen := make(map[string]bool) // track task IDs already added
@@ -267,6 +267,8 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 				s.Status = "done"
 			case ghIss.State == "closed":
 				s.Status = "failed"
+			case gh.HasLabel(ghIss, gh.LabelSkipped):
+				s.Status = "skipped"
 			case gh.HasLabel(ghIss, gh.LabelInProgress):
 				s.Status = "in-progress"
 			case ghIss.State == "open":
@@ -279,6 +281,8 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 			nDone++
 		case "failed":
 			nFailed++
+		case "skipped":
+			nSkipped++
 		case "in-progress":
 			nInProgress++
 		default:
@@ -338,6 +342,9 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		case ghIss.State == "closed":
 			s.Status = "failed"
 			nFailed++
+		case gh.HasLabel(ghIss, gh.LabelSkipped):
+			s.Status = "skipped"
+			nSkipped++
 		case gh.HasLabel(ghIss, gh.LabelInProgress):
 			s.Status = "in-progress"
 			nInProgress++
@@ -394,6 +401,9 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	fmt.Printf("Tasks: %d done, %d in-progress, %d pending", nDone, nInProgress, nPending)
 	if nFailed > 0 {
 		fmt.Printf(", %d failed", nFailed)
+	}
+	if nSkipped > 0 {
+		fmt.Printf(", %d skipped", nSkipped)
 	}
 	fmt.Println()
 	fmt.Printf("Total cost: $%.2f", totalCost)

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -153,10 +153,12 @@ func (o *Orchestrator) RunStitchN(limit int) (int, error) {
 				count := failedTaskCounts[task.ID]
 				logf("task %s was reset after %s (failure %d/%d)", task.ID, time.Since(taskStart).Round(time.Second), count, maxFailures)
 
-				// Close the task as permanently failed once the limit is reached.
+				// Skip the task once it exceeds the retry limit (GH-1699).
+				// Label it cobbler-skipped so pickReadyIssue excludes it, and
+				// continue to the next task instead of halting the generation.
 				if maxFailures > 0 && count >= maxFailures {
-					logf("task %s reached max failures (%d), closing as permanently failed", task.ID, maxFailures)
-					o.closeTaskAsFailed(task, count)
+					logf("task %s reached max failures (%d), marking as skipped", task.ID, maxFailures)
+					o.skipTask(task, count)
 				}
 
 				// Back off before the next iteration to reduce API pressure.
@@ -674,14 +676,25 @@ func (o *Orchestrator) resetTask(task stitchTask, reason string) {
 // closeTaskAsFailed closes a task as permanently failed after exceeding the
 // maximum failure count. Posts a comment and closes the issue so measure can
 // create a replacement if needed (GH-1562).
-func (o *Orchestrator) closeTaskAsFailed(task stitchTask, failureCount int) {
+// skipTask labels a task as cobbler-skipped after it exceeds the retry limit
+// (GH-1699). The task remains open but is excluded from future pickReadyIssue
+// calls. The generation continues with the next available task.
+func (o *Orchestrator) skipTask(task stitchTask, failureCount int) {
 	comment := fmt.Sprintf(
-		"Stitch abandoned after %d consecutive failures. Closing as permanently failed (GH-1562).",
+		"Stitch skipped after %d consecutive failures. Task labeled cobbler-skipped and excluded from future picks (GH-1699).",
 		failureCount,
 	)
 	defaultGhTracker.CommentCobblerIssue(task.Repo, task.GhNumber, comment)
-	if err := defaultGhTracker.CloseCobblerIssue(task.Repo, task.GhNumber, task.Generation); err != nil {
-		logf("closeTaskAsFailed: warning closing #%d: %v", task.GhNumber, err)
+
+	// Remove in-progress and ready labels, add skipped label.
+	if err := defaultGhTracker.RemoveIssueLabel(task.Repo, task.GhNumber, gh.LabelInProgress); err != nil {
+		logf("skipTask: remove in-progress label from #%d: %v", task.GhNumber, err)
+	}
+	if err := defaultGhTracker.RemoveIssueLabel(task.Repo, task.GhNumber, gh.LabelReady); err != nil {
+		logf("skipTask: remove ready label from #%d: %v", task.GhNumber, err)
+	}
+	if err := defaultGhTracker.AddIssueLabel(task.Repo, task.GhNumber, gh.LabelSkipped); err != nil {
+		logf("skipTask: add skipped label to #%d: %v", task.GhNumber, err)
 	}
 }
 

--- a/pkg/orchestrator/stitch_test.go
+++ b/pkg/orchestrator/stitch_test.go
@@ -102,9 +102,9 @@ func TestFailedTaskCounts_IncrementsOnRepeatedFailure(t *testing.T) {
 	}
 }
 
-// TestCloseTaskAsFailed_PostsCommentAndCloses verifies that closeTaskAsFailed
-// does not panic with a fake repo (GitHub errors are logged, not fatal).
-func TestCloseTaskAsFailed_NoOp(t *testing.T) {
+// TestSkipTask_PostsCommentAndLabels verifies that skipTask does not panic
+// with a fake repo (GitHub errors are logged, not fatal).
+func TestSkipTask_NoOp(t *testing.T) {
 	t.Parallel()
 	o := New(Config{})
 	task := stitchTask{
@@ -114,7 +114,7 @@ func TestCloseTaskAsFailed_NoOp(t *testing.T) {
 		Repo:       "fake/repo",
 		Generation: "test-gen",
 	}
-	o.closeTaskAsFailed(task, 3) // must not panic
+	o.skipTask(task, 3) // must not panic
 }
 
 // TestStitchSleep_DefaultIsTimeSleep verifies the default stitchSleep is


### PR DESCRIPTION
## Summary

When a stitch task exceeds its retry limit, it is now labeled `cobbler-skipped` and excluded from future picks instead of being closed and halting the generation. The generator stops cleanly when only skipped tasks remain, and `stats:generator` reports skipped tasks separately.

## Changes

- `stitch.go`: Replace `closeTaskAsFailed` with `skipTask` — labels task `cobbler-skipped`, removes `ready`/`in-progress` labels, continues to next task
- `internal/github/issues.go`: Add `LabelSkipped` constant, exclude skipped issues from `PickReadyIssue`, register label in `EnsureCobblerLabels`
- `generator.go`: Stop generation immediately when only skipped tasks remain (no wasted zero-LOC cycles)
- `cobbler.go`: Add `hasOnlySkippedIssues` method to detect skipped-only state
- `internal/stats/generator_stats.go`: Derive "skipped" status from `cobbler-skipped` label, show skipped count in stats output
- `stitch_test.go`: Update test for renamed method

## Stats

- go_loc_prod: 18532 → 18593 (+61, new feature code)
- go_loc_test: 34351 → 34351 (unchanged)
- go_loc: 52883 → 52944 (+61 net)

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)
- [x] Documentation reviewed for consistency

Closes #1699