### PR TITLE
GH-1703: Fix measure agent ignoring code_complete status and releases list

### DIFF
--- a/pkg/orchestrator/internal/generate/measure.go
+++ b/pkg/orchestrator/internal/generate/measure.go
@@ -426,10 +426,12 @@ type RoadmapRelease struct {
 }
 
 // UCStatusDone returns true when the status string indicates a completed
-// use case or release ("implemented", "done", or "closed").
+// use case or release. Recognized statuses: "implemented", "done", "closed",
+// "code_complete", "released" (GH-1703).
 func UCStatusDone(status string) bool {
 	s := strings.ToLower(status)
-	return s == "implemented" || s == "done" || s == "closed"
+	return s == "implemented" || s == "done" || s == "closed" ||
+		s == "code_complete" || s == "released"
 }
 
 // FilterImplementedReleases returns a copy of releases with any entry whose
@@ -485,4 +487,37 @@ func FilterImplementedRelease(release string) string {
 		}
 	}
 	return release
+}
+
+// reRelease matches release patterns like "rel01.0" or "rel02.1" in text.
+var reRelease = regexp.MustCompile(`rel(\d{2}\.\d)`)
+
+// ExtractReleaseFromText returns the release version (e.g. "05.5") from text
+// containing a pattern like "rel05.5". Returns "" if no release is found.
+func ExtractReleaseFromText(text string) string {
+	m := reRelease.FindStringSubmatch(text)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+// IsOutOfScopeRelease returns true if the proposed task references a release
+// that is not in the active releases list (GH-1703). When activeReleases is
+// empty, no filtering is applied. The release is extracted from the task's
+// title and description using the "relNN.N" pattern.
+func IsOutOfScopeRelease(title, description string, activeReleases []string) bool {
+	if len(activeReleases) == 0 {
+		return false
+	}
+	rel := ExtractReleaseFromText(title + " " + description)
+	if rel == "" {
+		return false // cannot determine release — allow it
+	}
+	for _, r := range activeReleases {
+		if r == rel {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -14,6 +14,7 @@ import (
 	an "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/analysis"
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
 	ictx "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/context"
+	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/generate"
 	gh "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/github"
 	"gopkg.in/yaml.v3"
 )
@@ -625,6 +626,23 @@ func (o *Orchestrator) importIssuesImpl(yamlFile, repo, generation string, skipE
 		existingTitles[norm] = issue.Index
 	}
 	issues = filtered
+
+	// Hard-filter proposals for out-of-scope releases (GH-1703).
+	// The prompt constraint instructs Claude to stay in scope, but this
+	// filter rejects any proposals that slip through anyway.
+	activeReleases := filterImplementedReleases(o.cfg.Project.Releases)
+	if len(activeReleases) > 0 {
+		var scoped []proposedIssue
+		for _, issue := range issues {
+			if generate.IsOutOfScopeRelease(issue.Title, issue.Description, activeReleases) {
+				rel := generate.ExtractReleaseFromText(issue.Title + " " + issue.Description)
+				logf("importIssues: rejecting out-of-scope task %q (release %s not in %v)", issue.Title, rel, activeReleases)
+				continue
+			}
+			scoped = append(scoped, issue)
+		}
+		issues = scoped
+	}
 
 	// Create all issues on GitHub as separate stitch tasks (GH-1367).
 	// The measure placeholder remains a distinct [measure] issue.


### PR DESCRIPTION
## Summary

Fixes the measure agent proposing stitch tasks for releases marked code_complete or released in road-map.yaml, and for releases removed from the releases list in configuration.yaml.

## Changes

- internal/generate/measure.go: Add code_complete and released to UCStatusDone, add ExtractReleaseFromText and IsOutOfScopeRelease functions
- measure.go: Add hard filter in importIssuesImpl that rejects proposed tasks referencing out-of-scope releases

## Test plan

- [x] mage analyze passes
- [x] All tests pass
- [x] Documentation reviewed for consistency

Closes #1703