### PR TITLE
GH-1797: Fix UC002 RunOneCycle reading gen branch from main dir

### DIFF
--- a/tests/rel01.0/uc002/lifecycle_claude_test.go
+++ b/tests/rel01.0/uc002/lifecycle_claude_test.go
@@ -37,10 +37,8 @@ func TestRel01_UC002_RunOneCycle(t *testing.T) {
 	if err := testutil.RunMage(t, dir, "reset"); err != nil {
 		t.Fatalf("reset: %v", err)
 	}
-	if err := testutil.RunMage(t, dir, "generator:start"); err != nil {
-		t.Fatalf("generator:start: %v", err)
-	}
-	genBranch := testutil.GitBranch(t, dir)
+	wtDir := testutil.GeneratorStart(t, dir)
+	genBranch := testutil.GitBranch(t, wtDir)
 
 	if err := testutil.RunMageTimeout(t, dir, claudeTimeout, "generator:run"); err != nil {
 		t.Fatalf("generator:run: %v", err)


### PR DESCRIPTION
## Summary

Fixes TestRel01_UC002_RunOneCycle which always failed because it read the generation branch name from the original test directory (which stays on main) instead of the worktree created by generator:start.

## Changes

- Use testutil.GeneratorStart (returns worktree path) instead of raw RunMage + GitBranch
- Read generation branch from the worktree directory

Closes #1797