### PR TITLE
GH-1798: Make Claude e2e tests resilient to LLM non-determinism

### DIFF
--- a/tests/rel01.0/internal/testutil/testutil.go
+++ b/tests/rel01.0/internal/testutil/testutil.go
@@ -848,3 +848,104 @@ func CopyFile(src, dst string) error {
 	_, err = io.Copy(out, in)
 	return err
 }
+
+// MarkAllRequirementsComplete reads .cobbler/requirements.yaml (generating it
+// first via generator:start if absent) and overwrites every R-item status to
+// "complete". This creates a deterministic precondition for tests that expect
+// measure to return zero tasks (GH-1798).
+func MarkAllRequirementsComplete(t testing.TB, dir string) {
+	t.Helper()
+	reqFile := filepath.Join(dir, ".cobbler", "requirements.yaml")
+
+	data, err := os.ReadFile(reqFile)
+	if err != nil {
+		t.Fatalf("MarkAllRequirementsComplete: read %s: %v", reqFile, err)
+	}
+
+	type reqState struct {
+		Status string `yaml:"status"`
+		Issue  int    `yaml:"issue,omitempty"`
+	}
+	type reqFile_ struct {
+		Requirements map[string]map[string]reqState `yaml:"requirements"`
+	}
+	var rf reqFile_
+	if err := yaml.Unmarshal(data, &rf); err != nil {
+		t.Fatalf("MarkAllRequirementsComplete: parse: %v", err)
+	}
+	for prd, items := range rf.Requirements {
+		for id, st := range items {
+			st.Status = "complete"
+			items[id] = st
+		}
+		rf.Requirements[prd] = items
+	}
+	out, err := yaml.Marshal(&rf)
+	if err != nil {
+		t.Fatalf("MarkAllRequirementsComplete: marshal: %v", err)
+	}
+	if err := os.WriteFile(reqFile, out, 0o644); err != nil {
+		t.Fatalf("MarkAllRequirementsComplete: write: %v", err)
+	}
+	// Commit so measure sees the change.
+	cmd := exec.Command("git", "add", "-A")
+	cmd.Dir = dir
+	cmd.Run()
+	cmd = exec.Command("git", "commit", "-m", "Mark all requirements complete for test")
+	cmd.Dir = dir
+	cmd.Run()
+}
+
+// HasUnresolvedRequirements returns true if .cobbler/requirements.yaml contains
+// any R-item with status "ready". Returns false if the file does not exist.
+func HasUnresolvedRequirements(t testing.TB, dir string) bool {
+	t.Helper()
+	reqFile := filepath.Join(dir, ".cobbler", "requirements.yaml")
+	data, err := os.ReadFile(reqFile)
+	if err != nil {
+		return false
+	}
+	type reqState struct {
+		Status string `yaml:"status"`
+	}
+	type reqFile_ struct {
+		Requirements map[string]map[string]reqState `yaml:"requirements"`
+	}
+	var rf reqFile_
+	if err := yaml.Unmarshal(data, &rf); err != nil {
+		return false
+	}
+	for _, items := range rf.Requirements {
+		for _, st := range items {
+			if st.Status == "ready" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// MeasureAndExpectIssues runs cobbler:measure and waits for at least one ready
+// issue. If measure returns zero issues despite unresolved requirements, it
+// retries once (Claude non-determinism). Returns the issue count. Fatals if
+// both attempts return zero (GH-1798).
+func MeasureAndExpectIssues(t testing.TB, dir string, timeout time.Duration) int {
+	t.Helper()
+	if !HasUnresolvedRequirements(t, dir) {
+		t.Fatal("MeasureAndExpectIssues: precondition failed — no unresolved requirements in requirements.yaml")
+	}
+	for attempt := 1; attempt <= 2; attempt++ {
+		if err := RunMageTimeout(t, dir, ClaudeTestTimeout, "cobbler:measure"); err != nil {
+			t.Fatalf("cobbler:measure (attempt %d): %v", attempt, err)
+		}
+		n := WaitForReadyIssues(t, dir, 1, timeout)
+		if n > 0 {
+			return n
+		}
+		if attempt == 1 {
+			t.Logf("MeasureAndExpectIssues: Claude returned empty list despite unresolved requirements, retrying (attempt 2)")
+		}
+	}
+	t.Fatal("MeasureAndExpectIssues: Claude returned empty list on both attempts despite unresolved requirements")
+	return 0
+}

--- a/tests/rel01.0/uc003/measure_claude_test.go
+++ b/tests/rel01.0/uc003/measure_claude_test.go
@@ -10,9 +10,6 @@
 package uc003_test
 
 import (
-	"os"
-	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -23,8 +20,10 @@ import (
 // claudeTimeout is the per-invocation limit for mage targets that call Claude.
 var claudeTimeout = testutil.ClaudeTestTimeout
 
-// MeasureCreatesIssues runs a single measure invocation with
-// MaxMeasureIssues=1 and verifies at least one issue is created.
+// MeasureCreatesIssues verifies that measure proposes tasks when unresolved
+// requirements exist. Uses MeasureAndExpectIssues which checks the
+// precondition (hasUnresolvedRequirements) and retries once on empty
+// Claude response (GH-1798).
 // Requires Claude: invokes cobbler:measure which calls Claude via podman.
 func TestRel01_UC003_MeasureCreatesIssues(t *testing.T) {
 	dir := testutil.SetupRepo(t, snapshotDir)
@@ -37,75 +36,21 @@ func TestRel01_UC003_MeasureCreatesIssues(t *testing.T) {
 	if err := testutil.RunMage(t, dir, "reset"); err != nil {
 		t.Fatalf("reset: %v", err)
 	}
-	if err := testutil.RunMage(t, dir, "init"); err != nil {
-		t.Fatalf("init: %v", err)
-	}
-	if err := testutil.RunMageTimeout(t, dir, claudeTimeout, "cobbler:measure"); err != nil {
-		t.Fatalf("cobbler:measure: %v", err)
-	}
+	_ = testutil.GeneratorStart(t, dir)
 
-	n := testutil.WaitForReadyIssues(t, dir, 1, 60*time.Second)
-	if n == 0 {
-		t.Error("expected at least 1 ready issue after cobbler:measure, got 0")
-	}
+	n := testutil.MeasureAndExpectIssues(t, dir, 60*time.Second)
 	t.Logf("cobbler:measure created %d issue(s)", n)
 }
 
-// seedHelloWorldSource writes the minimal Go source files that satisfy
-// prd001 (hello world binary) into dir and commits them. The sdd-hello-world
-// snapshot only contains specs; without seeding, measure correctly proposes
-// implementing the binary.
-func seedHelloWorldSource(t *testing.T, dir string) {
-	t.Helper()
-	cmdDir := filepath.Join(dir, "cmd", "sdd-hello-world")
-	if err := os.MkdirAll(cmdDir, 0o755); err != nil {
-		t.Fatalf("seedHelloWorldSource: mkdir: %v", err)
-	}
-	mainGo := `package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("Hello, World!")
-}
-`
-	versionGo := `package main
-
-// Version is the current release version.
-const Version = "0.0.1"
-`
-	if err := os.WriteFile(filepath.Join(cmdDir, "main.go"), []byte(mainGo), 0o644); err != nil {
-		t.Fatalf("seedHelloWorldSource: write main.go: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(cmdDir, "version.go"), []byte(versionGo), 0o644); err != nil {
-		t.Fatalf("seedHelloWorldSource: write version.go: %v", err)
-	}
-	for _, args := range [][]string{
-		{"git", "add", "-A"},
-		{"git", "commit", "-m", "Seed hello world source for spec-complete test"},
-	} {
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Dir = dir
-		if out, err := cmd.CombinedOutput(); err != nil {
-			t.Fatalf("seedHelloWorldSource: %v: %s", err, out)
-		}
-	}
-}
-
-// MeasureReturnsZeroForImplementedSpec runs cobbler:measure against a
-// codebase with Go sources that satisfy prd001. The measure agent should
-// return an empty task list and create zero issues. This validates the
-// spec-complete detection introduced in GH-889: the measure prompt now
-// explicitly permits returning [] when no meaningful work remains.
+// MeasureReturnsZeroForImplementedSpec marks all requirements as complete
+// in requirements.yaml, then runs cobbler:measure and verifies zero tasks
+// are proposed. This is a deterministic test: the orchestrator knows all
+// R-items are complete, and both the prompt constraint and the validation
+// layer reject proposals for completed requirements (GH-1798).
 // Requires Claude: invokes cobbler:measure which calls Claude via podman.
 func TestRel01_UC003_MeasureReturnsZeroForImplementedSpec(t *testing.T) {
 	dir := testutil.SetupRepo(t, snapshotDir)
 	testutil.SetupClaude(t, dir)
-
-	// Seed the Go source files that satisfy the spec. The sdd-hello-world
-	// snapshot is specs-only (generator:stop strips sources), so without
-	// this seeding measure correctly proposes implementing the binary.
-	seedHelloWorldSource(t, dir)
 
 	// Allow up to 3 issues so that if measure incorrectly proposes work it
 	// shows up in the assertion, rather than being artificially limited to 0.
@@ -113,18 +58,21 @@ func TestRel01_UC003_MeasureReturnsZeroForImplementedSpec(t *testing.T) {
 		cfg.Cobbler.MaxMeasureIssues = 3
 	})
 
-	// init is a no-op but follows the test convention; do NOT reset so the
-	// full codebase is visible to the measure agent.
-	if err := testutil.RunMage(t, dir, "init"); err != nil {
-		t.Fatalf("init: %v", err)
+	if err := testutil.RunMage(t, dir, "reset"); err != nil {
+		t.Fatalf("reset: %v", err)
 	}
+	_ = testutil.GeneratorStart(t, dir)
+
+	// Mark all requirements complete — deterministic precondition.
+	testutil.MarkAllRequirementsComplete(t, dir)
+
 	if err := testutil.RunMageTimeout(t, dir, claudeTimeout, "cobbler:measure"); err != nil {
 		t.Fatalf("cobbler:measure: %v", err)
 	}
 
 	n := testutil.CountReadyIssues(t, dir)
 	if n != 0 {
-		t.Errorf("expected 0 ready issues after measure on fully-implemented codebase, got %d", n)
+		t.Errorf("expected 0 ready issues after measure with all requirements complete, got %d", n)
 	}
 	t.Logf("cobbler:measure created %d issue(s) (want 0)", n)
 }

--- a/tests/rel01.0/uc004/stitch_claude_test.go
+++ b/tests/rel01.0/uc004/stitch_claude_test.go
@@ -22,7 +22,8 @@ var claudeTimeout = testutil.ClaudeTestTimeout
 
 // StitchExecutesTask runs 1 measure (MaxMeasureIssues=1) then 1 stitch
 // (MaxStitchIssuesPerCycle=1) and verifies the task was processed.
-// Requires Claude: invokes cobbler:measure and cobbler:stitch which call Claude via podman.
+// Precondition: hasUnresolvedRequirements via MeasureAndExpectIssues (GH-1798).
+// Requires Claude: invokes cobbler:measure and cobbler:stitch.
 func TestRel01_UC004_StitchExecutesTask(t *testing.T) {
 	dir := testutil.SetupRepo(t, snapshotDir)
 	testutil.SetupClaude(t, dir)
@@ -39,12 +40,7 @@ func TestRel01_UC004_StitchExecutesTask(t *testing.T) {
 
 	headBefore := testutil.GitHead(t, dir)
 
-	if err := testutil.RunMageTimeout(t, dir, claudeTimeout, "cobbler:measure"); err != nil {
-		t.Fatalf("cobbler:measure: %v", err)
-	}
-	if n := testutil.WaitForReadyIssues(t, dir, 1, 60*time.Second); n == 0 {
-		t.Fatal("expected at least 1 ready issue after measure, got 0")
-	}
+	testutil.MeasureAndExpectIssues(t, dir, 60*time.Second)
 
 	if err := testutil.RunMageTimeout(t, dir, claudeTimeout, "cobbler:stitch"); err != nil {
 		t.Fatalf("cobbler:stitch: %v", err)
@@ -58,7 +54,8 @@ func TestRel01_UC004_StitchExecutesTask(t *testing.T) {
 
 // StitchRecordsInvocation runs measure+stitch and verifies that the stitch
 // history contains an InvocationRecord with diff stats and LOC data.
-// Requires Claude: invokes cobbler:measure and cobbler:stitch which call Claude via podman.
+// Precondition: hasUnresolvedRequirements via MeasureAndExpectIssues (GH-1798).
+// Requires Claude: invokes cobbler:measure and cobbler:stitch.
 func TestRel01_UC004_StitchRecordsInvocation(t *testing.T) {
 	dir := testutil.SetupRepo(t, snapshotDir)
 	testutil.SetupClaude(t, dir)
@@ -72,9 +69,9 @@ func TestRel01_UC004_StitchRecordsInvocation(t *testing.T) {
 		t.Fatalf("reset: %v", err)
 	}
 	_ = testutil.GeneratorStart(t, dir)
-	if err := testutil.RunMageTimeout(t, dir, claudeTimeout, "cobbler:measure"); err != nil {
-		t.Fatalf("cobbler:measure: %v", err)
-	}
+
+	testutil.MeasureAndExpectIssues(t, dir, 60*time.Second)
+
 	if err := testutil.RunMageTimeout(t, dir, claudeTimeout, "cobbler:stitch"); err != nil {
 		t.Fatalf("cobbler:stitch: %v", err)
 	}
@@ -114,8 +111,8 @@ func TestRel01_UC004_StitchRecordsInvocation(t *testing.T) {
 // implements the single proposed task and closes its issue, the second
 // measure should detect that the implementation satisfies the requirement
 // and return an empty task list rather than spinning with follow-up tasks.
-// This validates the multi-cycle termination behaviour introduced in GH-889.
-// Requires Claude: invokes cobbler:measure and cobbler:stitch which call Claude via podman.
+// Precondition: hasUnresolvedRequirements via MeasureAndExpectIssues (GH-1798).
+// Requires Claude: invokes cobbler:measure and cobbler:stitch.
 func TestRel01_UC004_SecondMeasureProducesNoNewTasks(t *testing.T) {
 	dir := testutil.SetupRepo(t, snapshotDir)
 	testutil.SetupClaude(t, dir)
@@ -130,13 +127,8 @@ func TestRel01_UC004_SecondMeasureProducesNoNewTasks(t *testing.T) {
 	}
 	_ = testutil.GeneratorStart(t, dir)
 
-	// First measure: propose one task.
-	if err := testutil.RunMageTimeout(t, dir, claudeTimeout, "cobbler:measure"); err != nil {
-		t.Fatalf("first cobbler:measure: %v", err)
-	}
-	if n := testutil.WaitForReadyIssues(t, dir, 1, 60*time.Second); n == 0 {
-		t.Fatal("expected at least 1 ready issue after first measure, got 0")
-	}
+	// First measure: propose one task (with precondition check and retry).
+	testutil.MeasureAndExpectIssues(t, dir, 60*time.Second)
 
 	// Stitch: implement the proposed task and close its issue.
 	if err := testutil.RunMageTimeout(t, dir, claudeTimeout, "cobbler:stitch"); err != nil {


### PR DESCRIPTION
## Summary

Restructures Claude e2e tests (UC003, UC004) around deterministic orchestrator preconditions instead of depending on Claude's non-deterministic output. Tests that expect tasks verify hasUnresolvedRequirements first and retry once. Tests that expect no tasks mark all requirements complete in requirements.yaml.

## Changes

- testutil: add MarkAllRequirementsComplete, HasUnresolvedRequirements, MeasureAndExpectIssues helpers
- UC003 MeasureCreatesIssues: use MeasureAndExpectIssues (precondition + retry)
- UC003 MeasureReturnsZero: mark requirements complete, remove seedHelloWorldSource dependency
- UC004 StitchExecutesTask/RecordsInvocation/SecondMeasure: use MeasureAndExpectIssues

## Test plan

- [x] `go vet -tags 'usecase claude' ./tests/rel01.0/...` passes
- [x] Unit tests pass
- [ ] `mage test:usecase` validates the restructured tests

Closes #1798