### PR TITLE
Fix worktree path for requirements.yaml in Claude test helpers

### DIFF
--- a/tests/rel01.0/internal/testutil/testutil.go
+++ b/tests/rel01.0/internal/testutil/testutil.go
@@ -929,9 +929,14 @@ func HasUnresolvedRequirements(t testing.TB, dir string) bool {
 // issue. If measure returns zero issues despite unresolved requirements, it
 // retries once (Claude non-determinism). Returns the issue count. Fatals if
 // both attempts return zero (GH-1798).
+//
+// The precondition check reads requirements.yaml from the generation worktree
+// (where generator:start writes it), not from dir (which stays on main).
 func MeasureAndExpectIssues(t testing.TB, dir string, timeout time.Duration) int {
 	t.Helper()
-	if !HasUnresolvedRequirements(t, dir) {
+	// Requirements.yaml lives in the generation worktree, not in dir.
+	wtDir := FindGenerationWorktree(t, dir)
+	if !HasUnresolvedRequirements(t, wtDir) {
 		t.Fatal("MeasureAndExpectIssues: precondition failed — no unresolved requirements in requirements.yaml")
 	}
 	for attempt := 1; attempt <= 2; attempt++ {

--- a/tests/rel01.0/uc003/measure_claude_test.go
+++ b/tests/rel01.0/uc003/measure_claude_test.go
@@ -61,10 +61,11 @@ func TestRel01_UC003_MeasureReturnsZeroForImplementedSpec(t *testing.T) {
 	if err := testutil.RunMage(t, dir, "reset"); err != nil {
 		t.Fatalf("reset: %v", err)
 	}
-	_ = testutil.GeneratorStart(t, dir)
+	wtDir := testutil.GeneratorStart(t, dir)
 
 	// Mark all requirements complete — deterministic precondition.
-	testutil.MarkAllRequirementsComplete(t, dir)
+	// Requirements.yaml lives in the generation worktree.
+	testutil.MarkAllRequirementsComplete(t, wtDir)
 
 	if err := testutil.RunMageTimeout(t, dir, claudeTimeout, "cobbler:measure"); err != nil {
 		t.Fatalf("cobbler:measure: %v", err)


### PR DESCRIPTION
## Summary

Fixes MeasureAndExpectIssues and MarkAllRequirementsComplete to read requirements.yaml from the generation worktree instead of the main repo dir.

## Changes

- testutil: MeasureAndExpectIssues uses FindGenerationWorktree for precondition check
- UC003 MeasureReturnsZero: passes worktree path to MarkAllRequirementsComplete