### PR TITLE
GH-1805: Handle rate limits separately from task failures

### DIFF
--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -236,6 +236,13 @@ type CobblerConfig struct {
 	// Set to 0 to disable the guard.
 	MaxConsecutiveZeroLOCCycles int `yaml:"max_consecutive_zero_loc_cycles"`
 
+	// RateLimitBackoffSeconds is the number of seconds to wait before
+	// retrying a task that failed due to API rate limits. When a task's
+	// rate limit wait time exceeds half its total duration, the orchestrator
+	// uses this backoff instead of the short failure backoff. Default 60.
+	// Set to 0 to use the default (GH-1805).
+	RateLimitBackoffSeconds int `yaml:"rate_limit_backoff_seconds"`
+
 	// HistoryDir is the directory for saving measure artifacts (prompt,
 	// issues YAML, stream-json log) per iteration. Default "history".
 	HistoryDir string `yaml:"history_dir"`

--- a/pkg/orchestrator/internal/claude/claude.go
+++ b/pkg/orchestrator/internal/claude/claude.go
@@ -64,6 +64,7 @@ type ClaudeResult struct {
 	DurationAPIMs       int    // SDK mode only; API-side latency in milliseconds
 	SessionID           string // SDK mode only; Claude session identifier
 	RawOutput           []byte
+	RateLimitWaitS      int // seconds spent waiting on rate limits (GH-1805)
 }
 
 // LocSnapshot holds a point-in-time LOC count.
@@ -116,9 +117,10 @@ type HistoryStats struct {
 	Tokens        HistoryTokens `yaml:"tokens"`
 	CostUSD       float64      `yaml:"cost_usd"`
 	NumTurns      int          `yaml:"num_turns,omitempty"`
-	DurationAPIMs int          `yaml:"duration_api_ms,omitempty"`
-	SessionID     string       `yaml:"session_id,omitempty"`
-	LOCBefore     LocSnapshot  `yaml:"loc_before"`
+	DurationAPIMs    int          `yaml:"duration_api_ms,omitempty"`
+	RateLimitWaitS   int          `yaml:"rate_limit_wait_s,omitempty"`
+	SessionID        string       `yaml:"session_id,omitempty"`
+	LOCBefore        LocSnapshot  `yaml:"loc_before"`
 	LOCAfter      LocSnapshot  `yaml:"loc_after"`
 	Diff          HistoryDiff  `yaml:"diff"`
 }
@@ -524,12 +526,15 @@ func SaveHistoryLog(dir, ts, phase string, rawOutput []byte) {
 // ProgressWriter wraps a bytes.Buffer, logging concise one-line summaries
 // of Claude stream-json events via Log(). All bytes pass through unchanged.
 type ProgressWriter struct {
-	Buf       *bytes.Buffer
-	Start     time.Time
-	LastEvent time.Time
-	Partial   []byte
-	Turn      int
-	GotFirst  bool
+	Buf              *bytes.Buffer
+	Start            time.Time
+	LastEvent        time.Time
+	Partial          []byte
+	Turn             int
+	GotFirst         bool
+	InRateLimit      bool      // true while waiting on a rate_limit_event (GH-1805)
+	RateLimitStart   time.Time // when the current rate limit wait began
+	RateLimitWaitS   int       // cumulative seconds spent waiting on rate limits
 }
 
 // NewProgressWriter creates a ProgressWriter writing to dst.
@@ -590,6 +595,13 @@ func (pw *ProgressWriter) LogLine(line []byte) {
 	total := now.Sub(pw.Start).Round(time.Second)
 	pw.LastEvent = now
 
+	// Accumulate rate limit wait time when a non-rate-limit event arrives
+	// after a rate limit period (GH-1805).
+	if pw.InRateLimit && msg.Type != "rate_limit_event" {
+		pw.RateLimitWaitS += int(now.Sub(pw.RateLimitStart).Seconds())
+		pw.InRateLimit = false
+	}
+
 	switch msg.Type {
 	case "assistant":
 		pw.Turn++
@@ -618,6 +630,11 @@ func (pw *ProgressWriter) LogLine(line []byte) {
 		Log("claude: [%s +%s] tools done, waiting for LLM", total, step)
 	case "rate_limit_event":
 		Log("claude: [%s] rate_limit", total)
+		if !pw.InRateLimit {
+			pw.InRateLimit = true
+			pw.RateLimitStart = now
+		}
+		return // don't clear InRateLimit on rate_limit events
 	case "system":
 		Log("claude: [%s] ready", total)
 	case "result":

--- a/pkg/orchestrator/internal/claude/claude_test.go
+++ b/pkg/orchestrator/internal/claude/claude_test.go
@@ -587,3 +587,83 @@ func TestEnsureCredentials_ExtractFails(t *testing.T) {
 		t.Fatal("expected error when extraction fails and file doesn't exist")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// ProgressWriter rate limit tracking (GH-1805)
+// ---------------------------------------------------------------------------
+
+func TestProgressWriter_RateLimitWaitS_NoRateLimit(t *testing.T) {
+	t.Parallel()
+	pw := NewProgressWriter(&bytes.Buffer{}, time.Now())
+
+	// Feed assistant and result events — no rate limit.
+	pw.LogLine([]byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"hi"}]}}`))
+	pw.LogLine([]byte(`{"type":"result","total_cost_usd":0.01,"usage":{"input_tokens":10,"output_tokens":5}}`))
+
+	if pw.RateLimitWaitS != 0 {
+		t.Errorf("RateLimitWaitS = %d, want 0", pw.RateLimitWaitS)
+	}
+	if pw.InRateLimit {
+		t.Error("InRateLimit should be false")
+	}
+}
+
+func TestProgressWriter_RateLimitWaitS_SingleRateLimit(t *testing.T) {
+	t.Parallel()
+	start := time.Now()
+	pw := NewProgressWriter(&bytes.Buffer{}, start)
+
+	// Simulate a rate limit event.
+	pw.LogLine([]byte(`{"type":"rate_limit_event"}`))
+	if !pw.InRateLimit {
+		t.Fatal("InRateLimit should be true after rate_limit_event")
+	}
+
+	// Manually advance the rate limit start to simulate 10 seconds of waiting.
+	pw.RateLimitStart = time.Now().Add(-10 * time.Second)
+
+	// Next non-rate-limit event should close the rate limit window.
+	pw.LogLine([]byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"back"}]}}`))
+	if pw.InRateLimit {
+		t.Error("InRateLimit should be false after assistant event")
+	}
+	if pw.RateLimitWaitS < 9 {
+		t.Errorf("RateLimitWaitS = %d, want >= 9", pw.RateLimitWaitS)
+	}
+}
+
+func TestProgressWriter_RateLimitWaitS_MultipleRateLimits(t *testing.T) {
+	t.Parallel()
+	pw := NewProgressWriter(&bytes.Buffer{}, time.Now())
+
+	// First rate limit window: 5 seconds.
+	pw.LogLine([]byte(`{"type":"rate_limit_event"}`))
+	pw.RateLimitStart = time.Now().Add(-5 * time.Second)
+	pw.LogLine([]byte(`{"type":"assistant","message":{"content":[{"type":"text","text":"a"}]}}`))
+	first := pw.RateLimitWaitS
+
+	// Second rate limit window: 8 seconds.
+	pw.LogLine([]byte(`{"type":"rate_limit_event"}`))
+	pw.RateLimitStart = time.Now().Add(-8 * time.Second)
+	pw.LogLine([]byte(`{"type":"result","total_cost_usd":0.01,"usage":{"input_tokens":1,"output_tokens":1}}`))
+
+	if pw.RateLimitWaitS < first+7 {
+		t.Errorf("RateLimitWaitS = %d, want >= %d (cumulative)", pw.RateLimitWaitS, first+7)
+	}
+}
+
+func TestProgressWriter_ConsecutiveRateLimitEvents(t *testing.T) {
+	t.Parallel()
+	pw := NewProgressWriter(&bytes.Buffer{}, time.Now())
+
+	// Multiple consecutive rate_limit_event messages should not reset
+	// the start time — only the first one starts the window.
+	pw.LogLine([]byte(`{"type":"rate_limit_event"}`))
+	firstStart := pw.RateLimitStart
+	time.Sleep(1 * time.Millisecond) // ensure clock advances
+	pw.LogLine([]byte(`{"type":"rate_limit_event"}`))
+
+	if !pw.RateLimitStart.Equal(firstStart) {
+		t.Error("consecutive rate_limit_events should not update RateLimitStart")
+	}
+}

--- a/pkg/orchestrator/internal/claude/runner.go
+++ b/pkg/orchestrator/internal/claude/runner.go
@@ -131,6 +131,7 @@ func (r *execRunner) run(ctx context.Context, prompt, workDir string, silence bo
 	result := ParseClaudeTokens(rawOutput)
 	if pw != nil {
 		result.NumTurns = pw.Turn
+		result.RateLimitWaitS = pw.RateLimitWaitS
 	}
 	result.RawOutput = make([]byte, len(rawOutput))
 	copy(result.RawOutput, rawOutput)

--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -22,18 +22,19 @@ import (
 // GeneratorIssueStats holds per-issue stats derived from history files.
 type GeneratorIssueStats struct {
 	gh.CobblerIssue
-	Status        string  // "done", "failed", "in-progress", "pending"
-	CostUSD       float64
-	DurationS     int
-	DurationAPIMs int // Claude API execution time in ms (SDK mode, GH-1708)
-	NumTurns      int
-	LocDeltaProd int
-	LocDeltaTest int
-	NumReqs      int // number of requirements in the task description
-	InputTokens  int // total input tokens from history stats
-	OutputTokens int // total output tokens from history stats
-	PRDs         []string
-	Release      string // roadmap release version, e.g. "01.0"
+	Status         string  // "done", "failed", "in-progress", "pending"
+	CostUSD        float64
+	DurationS      int
+	DurationAPIMs  int // Claude API execution time in ms (SDK mode, GH-1708)
+	RateLimitWaitS int // seconds spent waiting on API rate limits (GH-1805)
+	NumTurns       int
+	LocDeltaProd   int
+	LocDeltaTest   int
+	NumReqs        int // number of requirements in the task description
+	InputTokens    int // total input tokens from history stats
+	OutputTokens   int // total output tokens from history stats
+	PRDs           []string
+	Release        string // roadmap release version, e.g. "01.0"
 }
 
 // GeneratorStatsDeps holds dependencies for generator stats collection.
@@ -115,17 +116,18 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 
 	// Build aggregated stitch stats and task metadata from history entries.
 	type stitchAgg struct {
-		Title         string
-		CostUSD       float64
-		DurationS     int
-		DurationAPIMs int // Claude API execution time (SDK mode only, GH-1708)
-		NumTurns      int
-		InputTokens   int
-		OutputTokens  int
-		LocDeltaProd  int
-		LocDeltaTest  int
-		LastStatus    string // last history entry status: "success" or "failed"
-		StartedAt     string // earliest StartedAt for chronological ordering
+		Title          string
+		CostUSD        float64
+		DurationS      int
+		DurationAPIMs  int // Claude API execution time (SDK mode only, GH-1708)
+		RateLimitWaitS int // cumulative rate limit wait seconds (GH-1805)
+		NumTurns       int
+		InputTokens    int
+		OutputTokens   int
+		LocDeltaProd   int
+		LocDeltaTest   int
+		LastStatus     string // last history entry status: "success" or "failed"
+		StartedAt      string // earliest StartedAt for chronological ordering
 	}
 	stitchByTask := make(map[string]*stitchAgg)
 	var taskOrder []string // insertion order for deterministic iteration
@@ -163,6 +165,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 				agg.DurationS = hs.DurationS
 			}
 			agg.DurationAPIMs += hs.DurationAPIMs
+			agg.RateLimitWaitS += hs.RateLimitWaitS
 			agg.NumTurns += hs.NumTurns
 			agg.InputTokens += hs.Tokens.Input
 			agg.OutputTokens += hs.Tokens.Output
@@ -223,7 +226,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	// Build rows from history-derived task list.
 	rows := make([]GeneratorIssueStats, 0, len(stitchByTask))
 	var totalStitchCost float64
-	var totalStitchDurS, totalStitchAPIMs int
+	var totalStitchDurS, totalStitchAPIMs, totalRateLimitWaitS int
 	var totalTurns, totalLocProd, totalLocTest, totalReqs int
 	var totalInputTokens, totalOutputTokens int
 	var nDone, nFailed, nSkipped, nInProgress, nPending int
@@ -241,14 +244,15 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 				Number: num,
 				Title:  agg.Title,
 			},
-			CostUSD:       agg.CostUSD,
-			DurationS:     agg.DurationS,
-			DurationAPIMs: agg.DurationAPIMs,
-			NumTurns:      agg.NumTurns,
-			InputTokens:  agg.InputTokens,
-			OutputTokens: agg.OutputTokens,
-			LocDeltaProd: agg.LocDeltaProd,
-			LocDeltaTest: agg.LocDeltaTest,
+			CostUSD:        agg.CostUSD,
+			DurationS:      agg.DurationS,
+			DurationAPIMs:  agg.DurationAPIMs,
+			RateLimitWaitS: agg.RateLimitWaitS,
+			NumTurns:       agg.NumTurns,
+			InputTokens:    agg.InputTokens,
+			OutputTokens:   agg.OutputTokens,
+			LocDeltaProd:   agg.LocDeltaProd,
+			LocDeltaTest:   agg.LocDeltaTest,
 		}
 
 		// Derive status from history; override with GitHub data when available.
@@ -296,6 +300,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		totalStitchCost += s.CostUSD
 		totalStitchDurS += s.DurationS
 		totalStitchAPIMs += s.DurationAPIMs
+		totalRateLimitWaitS += s.RateLimitWaitS
 		totalTurns += s.NumTurns
 		totalLocProd += s.LocDeltaProd
 		totalLocTest += s.LocDeltaTest
@@ -416,7 +421,11 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	if totalMeasureCost > 0 {
 		fmt.Printf(" (stitch $%.2f + measure $%.2f)", totalStitchCost, totalMeasureCost)
 	}
-	fmt.Printf(", %d turns\n", totalTurns)
+	fmt.Printf(", %d turns", totalTurns)
+	if totalRateLimitWaitS > 0 {
+		fmt.Printf(", %s rate-limited", FormatDuration(totalRateLimitWaitS))
+	}
+	fmt.Println()
 	fmt.Printf("LOC created: %+d prod, %+d test\n", totalLocProd, totalLocTest)
 	fmt.Printf("Requirements: %d total in tasks\n", totalReqs)
 	combinedIn := totalInputTokens + totalMeasureIn
@@ -482,6 +491,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		Reqs      string
 		Cost      string
 		Dur       string
+		RateLimit string // rate limit wait time (GH-1805)
 		Turns     string
 		TokIn     string
 		TokOut    string
@@ -511,6 +521,10 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		tr.Dur = "-"
 		if r.DurationS > 0 {
 			tr.Dur = FormatDuration(r.DurationS)
+		}
+		tr.RateLimit = "-"
+		if r.RateLimitWaitS > 0 {
+			tr.RateLimit = FormatDuration(r.RateLimitWaitS)
 		}
 		tr.Turns = "-"
 		if r.NumTurns > 0 {
@@ -562,6 +576,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 			Status:    "done",
 			Rel:       "-",
 			Reqs:      "-",
+			RateLimit: "-",
 			Prod:      "-",
 			Test:      "-",
 			Parent:    "-",
@@ -603,6 +618,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 			Test:      "-",
 			Cost:      "-",
 			Dur:       "-",
+			RateLimit: "-",
 			Turns:     "-",
 			TokIn:     "-",
 			TokOut:    "-",
@@ -666,10 +682,10 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "#\tStatus\tRel\tReqs\tCost\tDuration\tTurns\tTokIn\tTokOut\tProd\tTest\tParent\tTitle")
+	fmt.Fprintln(w, "#\tStatus\tRel\tReqs\tCost\tDuration\tRateLimit\tTurns\tTokIn\tTokOut\tProd\tTest\tParent\tTitle")
 	for _, tr := range tableRows {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			tr.ID, tr.Status, tr.Rel, tr.Reqs, tr.Cost, tr.Dur, tr.Turns, tr.TokIn, tr.TokOut, tr.Prod, tr.Test, tr.Parent, tr.Title)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			tr.ID, tr.Status, tr.Rel, tr.Reqs, tr.Cost, tr.Dur, tr.RateLimit, tr.Turns, tr.TokIn, tr.TokOut, tr.Prod, tr.Test, tr.Parent, tr.Title)
 	}
 	if err := w.Flush(); err != nil {
 		return err

--- a/pkg/orchestrator/internal/stats/generator_stats_test.go
+++ b/pkg/orchestrator/internal/stats/generator_stats_test.go
@@ -806,6 +806,103 @@ loc_after:
 	}
 }
 
+func TestPrintGeneratorStats_RateLimitColumn(t *testing.T) {
+	// Uses os.Chdir — do NOT use t.Parallel()
+	dir := t.TempDir()
+
+	histDir := filepath.Join(dir, "history")
+	os.MkdirAll(histDir, 0o755)
+
+	// Task with rate limit wait time.
+	stitch1 := `caller: stitch
+task_id: "200"
+task_title: "[stitch] prd001 R1 rate limited task"
+status: success
+started_at: "2026-03-20T12:00:00Z"
+duration: "15m 0s"
+duration_s: 900
+rate_limit_wait_s: 780
+tokens:
+  input: 100000
+  output: 5000
+  cache_creation: 0
+  cache_read: 0
+cost_usd: 1.00
+num_turns: 10
+loc_before:
+  production: 500
+  test: 200
+loc_after:
+  production: 550
+  test: 220
+`
+	// Task without rate limit.
+	stitch2 := `caller: stitch
+task_id: "201"
+task_title: "[stitch] prd001 R2 normal task"
+status: success
+started_at: "2026-03-20T13:00:00Z"
+duration: "3m 0s"
+duration_s: 180
+tokens:
+  input: 80000
+  output: 3000
+  cache_creation: 0
+  cache_read: 0
+cost_usd: 0.50
+num_turns: 5
+loc_before:
+  production: 550
+  test: 220
+loc_after:
+  production: 600
+  test: 250
+`
+	os.WriteFile(filepath.Join(histDir, "2026-03-20-12-00-00-stitch-stats.yaml"), []byte(stitch1), 0o644)
+	os.WriteFile(filepath.Join(histDir, "2026-03-20-13-00-00-stitch-stats.yaml"), []byte(stitch2), 0o644)
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	deps := GeneratorStatsDeps{
+		Log:                    func(format string, args ...any) {},
+		ListGenerationBranches: func() []string { return []string{"generation-main"} },
+		GenerationBranch:       "generation-main",
+		CurrentBranch:          "generation-main",
+		HistoryDir:             histDir,
+	}
+
+	err := PrintGeneratorStats(deps)
+	w.Close()
+	captured, _ := io.ReadAll(r)
+	os.Stdout = oldStdout
+	output := string(captured)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Table header should include RateLimit column.
+	if !strings.Contains(output, "RateLimit") {
+		t.Errorf("expected 'RateLimit' column header in output:\n%s", output)
+	}
+
+	// Task 200 should show a rate limit duration (13m0s = 780s).
+	if !strings.Contains(output, "13m0s") {
+		t.Errorf("expected rate limit duration '13m0s' for task 200 in output:\n%s", output)
+	}
+
+	// Summary header should mention rate-limited time.
+	if !strings.Contains(output, "rate-limited") {
+		t.Errorf("expected 'rate-limited' in summary header:\n%s", output)
+	}
+}
+
 func TestPrintGeneratorStats_PrefersHistoryOverComments(t *testing.T) {
 	// Uses os.Chdir — do NOT use t.Parallel()
 	dir := t.TempDir()

--- a/pkg/orchestrator/stitch.go
+++ b/pkg/orchestrator/stitch.go
@@ -21,6 +21,28 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+// rateLimitResetError wraps errTaskReset with rate limit context so the
+// stitch loop can distinguish rate-limit-dominated failures from genuine
+// task failures (GH-1805).
+type rateLimitResetError struct {
+	RateLimitWaitS int
+	TotalDurationS int
+}
+
+func (e *rateLimitResetError) Error() string {
+	return errTaskReset.Error()
+}
+
+func (e *rateLimitResetError) Unwrap() error {
+	return errTaskReset
+}
+
+// isRateLimitDominated returns true when rate limit waits consumed more
+// than half of the total task duration.
+func (e *rateLimitResetError) isRateLimitDominated() bool {
+	return e.TotalDurationS > 0 && e.RateLimitWaitS > e.TotalDurationS/2
+}
+
 //go:embed prompts/stitch.yaml
 var defaultStitchPrompt string
 
@@ -149,20 +171,43 @@ func (o *Orchestrator) RunStitchN(limit int) (int, error) {
 		logf("executing task %d: id=%s title=%q", totalTasks+1, task.ID, task.Title)
 		if err := o.doOneTask(task, baseBranch, repoRoot); err != nil {
 			if errors.Is(err, errTaskReset) {
-				failedTaskCounts[task.ID]++
-				count := failedTaskCounts[task.ID]
-				logf("task %s was reset after %s (failure %d/%d)", task.ID, time.Since(taskStart).Round(time.Second), count, maxFailures)
+				// Check whether this failure was dominated by rate limit
+				// waits. If so, don't count it toward the failure limit
+				// and use a longer backoff (GH-1805).
+				var rlErr *rateLimitResetError
+				rateLimited := errors.As(err, &rlErr) && rlErr.isRateLimitDominated()
 
-				// Skip the task once it exceeds the retry limit (GH-1699).
-				// Label it cobbler-skipped so pickReadyIssue excludes it, and
-				// continue to the next task instead of halting the generation.
-				if maxFailures > 0 && count >= maxFailures {
-					logf("task %s reached max failures (%d), marking as skipped", task.ID, maxFailures)
-					o.skipTask(task, count)
+				if rateLimited {
+					logf("task %s was reset after %s (rate-limited %ds/%ds, not counted as failure)",
+						task.ID, time.Since(taskStart).Round(time.Second),
+						rlErr.RateLimitWaitS, rlErr.TotalDurationS)
+				} else {
+					failedTaskCounts[task.ID]++
+					count := failedTaskCounts[task.ID]
+					logf("task %s was reset after %s (failure %d/%d)", task.ID, time.Since(taskStart).Round(time.Second), count, maxFailures)
+
+					// Skip the task once it exceeds the retry limit (GH-1699).
+					// Label it cobbler-skipped so pickReadyIssue excludes it, and
+					// continue to the next task instead of halting the generation.
+					if maxFailures > 0 && count >= maxFailures {
+						logf("task %s reached max failures (%d), marking as skipped", task.ID, maxFailures)
+						o.skipTask(task, count)
+					}
 				}
 
-				// Back off before the next iteration to reduce API pressure.
-				backoff := time.Duration(count) * 2 * time.Second
+				// Back off before the next iteration. Use a longer backoff
+				// when rate-limited to allow the API window to reset (GH-1805).
+				var backoff time.Duration
+				if rateLimited {
+					rlBackoff := o.cfg.Cobbler.RateLimitBackoffSeconds
+					if rlBackoff <= 0 {
+						rlBackoff = 60
+					}
+					backoff = time.Duration(rlBackoff) * time.Second
+				} else {
+					count := failedTaskCounts[task.ID]
+					backoff = time.Duration(count) * 2 * time.Second
+				}
 				logf("task %s: backing off %s before next task", task.ID, backoff)
 				stitchSleep(backoff)
 				continue
@@ -258,21 +303,28 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	o.saveHistoryLog(historyTS, "stitch", tokens.RawOutput)
 
 	if claudeErr != nil {
-		logf("doOneTask: Claude failed for %s after %s: %v", task.ID, time.Since(claudeStart).Round(time.Second), claudeErr)
+		durS := int(time.Since(taskStart).Seconds())
+		rlWaitS := tokens.RateLimitWaitS
+		logf("doOneTask: Claude failed for %s after %s (rate_limit_wait=%ds): %v",
+			task.ID, time.Since(claudeStart).Round(time.Second), rlWaitS, claudeErr)
 		o.saveHistoryStats(historyTS, "stitch", claude.HistoryStats{
-			Caller:    "stitch",
-			TaskID:    task.ID,
-			TaskTitle: task.Title,
-			Status:    "failed",
-			Error:     fmt.Sprintf("claude failure: %v", claudeErr),
-			StartedAt: claudeStart.UTC().Format(time.RFC3339),
-			Duration:  time.Since(taskStart).Round(time.Second).String(),
-			DurationS: int(time.Since(taskStart).Seconds()),
-			Tokens:    claude.HistoryTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
-			CostUSD:   tokens.CostUSD,
-			LOCBefore: locBefore,
+			Caller:         "stitch",
+			TaskID:         task.ID,
+			TaskTitle:      task.Title,
+			Status:         "failed",
+			Error:          fmt.Sprintf("claude failure: %v", claudeErr),
+			StartedAt:      claudeStart.UTC().Format(time.RFC3339),
+			Duration:       time.Since(taskStart).Round(time.Second).String(),
+			DurationS:      durS,
+			RateLimitWaitS: rlWaitS,
+			Tokens:         claude.HistoryTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
+			CostUSD:        tokens.CostUSD,
+			LOCBefore:      locBefore,
 		})
 		o.failTask(task, "Claude failure", taskStart)
+		if rlWaitS > 0 {
+			return &rateLimitResetError{RateLimitWaitS: rlWaitS, TotalDurationS: durS}
+		}
 		return errTaskReset
 	}
 	logf("doOneTask: Claude completed for %s in %s", task.ID, time.Since(claudeStart).Round(time.Second))
@@ -375,20 +427,21 @@ func (o *Orchestrator) doOneTask(task stitchTask, baseBranch, repoRoot string) e
 	// Save stitch stats.
 	taskDuration := time.Since(taskStart)
 	o.saveHistoryStats(historyTS, "stitch", claude.HistoryStats{
-		Caller:        "stitch",
-		TaskID:        task.ID,
-		TaskTitle:     task.Title,
-		Status:        "success",
-		StartedAt:     claudeStart.UTC().Format(time.RFC3339),
-		Duration:      taskDuration.Round(time.Second).String(),
-		DurationS:     int(taskDuration.Seconds()),
-		Tokens:        claude.HistoryTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
-		CostUSD:       tokens.CostUSD,
-		NumTurns:      tokens.NumTurns,
-		DurationAPIMs: tokens.DurationAPIMs,
-		SessionID:     tokens.SessionID,
-		LOCBefore:     locBefore,
-		LOCAfter:      locAfter,
+		Caller:         "stitch",
+		TaskID:         task.ID,
+		TaskTitle:      task.Title,
+		Status:         "success",
+		StartedAt:      claudeStart.UTC().Format(time.RFC3339),
+		Duration:       taskDuration.Round(time.Second).String(),
+		DurationS:      int(taskDuration.Seconds()),
+		RateLimitWaitS: tokens.RateLimitWaitS,
+		Tokens:         claude.HistoryTokens{Input: tokens.InputTokens, Output: tokens.OutputTokens, CacheCreation: tokens.CacheCreationTokens, CacheRead: tokens.CacheReadTokens},
+		CostUSD:        tokens.CostUSD,
+		NumTurns:       tokens.NumTurns,
+		DurationAPIMs:  tokens.DurationAPIMs,
+		SessionID:      tokens.SessionID,
+		LOCBefore:      locBefore,
+		LOCAfter:       locAfter,
 		Diff:          claude.HistoryDiff{Files: diff.FilesChanged, Insertions: diff.Insertions, Deletions: diff.Deletions},
 	})
 

--- a/pkg/orchestrator/stitch_test.go
+++ b/pkg/orchestrator/stitch_test.go
@@ -4,6 +4,7 @@
 package orchestrator
 
 import (
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1234,4 +1235,79 @@ func TestSweepCompletedTasks_NoCobblerDir(t *testing.T) {
 	// and sweep returns immediately.
 	o := New(Config{Cobbler: CobblerConfig{Dir: "/nonexistent/dir/xyz"}})
 	o.sweepCompletedTasks("fake/repo", "test-gen") // must not panic
+}
+
+// ---------------------------------------------------------------------------
+// Rate limit error handling (GH-1805)
+// ---------------------------------------------------------------------------
+
+func TestRateLimitResetError_UnwrapsToErrTaskReset(t *testing.T) {
+	t.Parallel()
+	err := &rateLimitResetError{RateLimitWaitS: 60, TotalDurationS: 100}
+	if !errors.Is(err, errTaskReset) {
+		t.Error("rateLimitResetError should unwrap to errTaskReset")
+	}
+}
+
+func TestRateLimitResetError_IsRateLimitDominated(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		rl, dur int
+		want    bool
+	}{
+		{"majority rate limited", 600, 900, true},
+		{"exactly half", 450, 900, false},
+		{"just over half", 451, 900, true},
+		{"minority rate limited", 100, 900, false},
+		{"no rate limit", 0, 900, false},
+		{"zero duration", 10, 0, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &rateLimitResetError{RateLimitWaitS: tt.rl, TotalDurationS: tt.dur}
+			if got := e.isRateLimitDominated(); got != tt.want {
+				t.Errorf("isRateLimitDominated(%d/%d) = %v, want %v", tt.rl, tt.dur, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRateLimitResetError_SkipsFailureCounter(t *testing.T) {
+	t.Parallel()
+	// Simulates the RunStitchN logic: a rate-limit-dominated failure
+	// should NOT increment failedTaskCounts.
+	failedTaskCounts := map[string]int{}
+	taskID := "rl-test-42"
+
+	err := &rateLimitResetError{RateLimitWaitS: 700, TotalDurationS: 900}
+	var rlErr *rateLimitResetError
+	rateLimited := errors.As(err, &rlErr) && rlErr.isRateLimitDominated()
+
+	if !rateLimited {
+		failedTaskCounts[taskID]++
+	}
+
+	if failedTaskCounts[taskID] != 0 {
+		t.Errorf("rate-limited failure should not increment counter, got %d", failedTaskCounts[taskID])
+	}
+}
+
+func TestRateLimitResetError_CountsNonDominatedFailure(t *testing.T) {
+	t.Parallel()
+	// A failure with some rate limiting but not dominant should still count.
+	failedTaskCounts := map[string]int{}
+	taskID := "rl-test-43"
+
+	err := &rateLimitResetError{RateLimitWaitS: 100, TotalDurationS: 900}
+	var rlErr *rateLimitResetError
+	rateLimited := errors.As(err, &rlErr) && rlErr.isRateLimitDominated()
+
+	if !rateLimited {
+		failedTaskCounts[taskID]++
+	}
+
+	if failedTaskCounts[taskID] != 1 {
+		t.Errorf("non-dominated failure should increment counter, got %d", failedTaskCounts[taskID])
+	}
 }


### PR DESCRIPTION
## Summary

Rate limit waits now tracked separately from active Claude processing time. Tasks that fail due to rate limits are retried without incrementing the failure counter, preventing the 3-consecutive-zero-LOC auto-stop from triggering on rate-limit-caused failures. A new RateLimit column in `stats:generator` shows per-task rate limit wait time.

## Changes

- Track rate limit wait time in ProgressWriter and ClaudeResult (CLI mode)
- Add `rateLimitResetError` type that wraps `errTaskReset` with rate limit context
- Skip failure counter increment when rate limit waits exceed 50% of task duration
- Use configurable backoff (default 60s) after rate-limited failures instead of 2s
- Add `RateLimitBackoffSeconds` config field and `RateLimitWaitS` to HistoryStats
- Add RateLimit column to `stats:generator` table and total to summary header
- 12 new test cases across claude, stitch, and stats packages

## Stats

```
go_loc_prod: 18997 → 18937 (-60)
go_loc_test: 34293 → 34546 (+253)
go_loc:      53290 → 53483 (+193)
```

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)
- [x] New tests cover ProgressWriter tracking, error type behavior, failure counter logic, stats column

Closes #1805