### PR TITLE
GH-1884: Add Started column to stats:generator table

### DIFF
--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"text/tabwriter"
+	"time"
 
 	cl "github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/claude"
 	"github.com/mesh-intelligence/cobbler-scaffold/pkg/orchestrator/internal/generate"
@@ -487,6 +488,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	type tableRow struct {
 		ID        string
 		Status    string
+		Started   string // display-formatted StartedAt timestamp (GH-1884)
 		Rel       string
 		Reqs      string
 		Cost      string
@@ -501,6 +503,16 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		Title     string
 		SortTime  string // StartedAt for chronological ordering
 		IsMeasure bool   // true for measure rows, used for post-sort enrichment
+	}
+	formatStarted := func(rfc3339 string) string {
+		if rfc3339 == "" {
+			return "-"
+		}
+		t, err := time.Parse(time.RFC3339, rfc3339)
+		if err != nil {
+			return "-"
+		}
+		return t.Local().Format("Jan 02 15:04")
 	}
 	var tableRows []tableRow
 
@@ -559,6 +571,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		if agg, ok := stitchByTask[taskID]; ok {
 			tr.SortTime = agg.StartedAt
 		}
+		tr.Started = formatStarted(tr.SortTime)
 		tableRows = append(tableRows, tr)
 	}
 
@@ -574,6 +587,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		tr := tableRow{
 			ID:        mid,
 			Status:    "done",
+			Started:   formatStarted(m.StartedAt),
 			Rel:       "-",
 			Reqs:      "-",
 			RateLimit: "-",
@@ -612,6 +626,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		tr := tableRow{
 			ID:        strconv.Itoa(iss.Number),
 			Status:    "in-progress",
+			Started:   "-",
 			Rel:       "-",
 			Reqs:      "-",
 			Prod:      "-",
@@ -682,10 +697,10 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "#\tStatus\tRel\tReqs\tCost\tDuration\tRateLimit\tTurns\tTokIn\tTokOut\tProd\tTest\tParent\tTitle")
+	fmt.Fprintln(w, "#\tStatus\tStarted\tRel\tReqs\tCost\tDuration\tRateLimit\tTurns\tTokIn\tTokOut\tProd\tTest\tParent\tTitle")
 	for _, tr := range tableRows {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			tr.ID, tr.Status, tr.Rel, tr.Reqs, tr.Cost, tr.Dur, tr.RateLimit, tr.Turns, tr.TokIn, tr.TokOut, tr.Prod, tr.Test, tr.Parent, tr.Title)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			tr.ID, tr.Status, tr.Started, tr.Rel, tr.Reqs, tr.Cost, tr.Dur, tr.RateLimit, tr.Turns, tr.TokIn, tr.TokOut, tr.Prod, tr.Test, tr.Parent, tr.Title)
 	}
 	if err := w.Flush(); err != nil {
 		return err

--- a/pkg/orchestrator/internal/stats/generator_stats_test.go
+++ b/pkg/orchestrator/internal/stats/generator_stats_test.go
@@ -806,6 +806,73 @@ loc_after:
 	}
 }
 
+func TestPrintGeneratorStats_StartedColumn(t *testing.T) {
+	// Uses os.Chdir — do NOT use t.Parallel()
+	dir := t.TempDir()
+
+	histDir := filepath.Join(dir, "history")
+	os.MkdirAll(histDir, 0o755)
+
+	stitch1 := `caller: stitch
+task_id: "300"
+task_title: "[stitch] prd001 R1 with timestamp"
+status: success
+started_at: "2026-03-22T14:30:00Z"
+duration: "5m 0s"
+duration_s: 300
+tokens:
+  input: 100000
+  output: 5000
+  cache_creation: 0
+  cache_read: 0
+cost_usd: 1.00
+num_turns: 10
+loc_before:
+  production: 500
+  test: 200
+loc_after:
+  production: 550
+  test: 220
+`
+	os.WriteFile(filepath.Join(histDir, "2026-03-22-14-30-00-stitch-stats.yaml"), []byte(stitch1), 0o644)
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	deps := GeneratorStatsDeps{
+		Log:                    func(format string, args ...any) {},
+		ListGenerationBranches: func() []string { return []string{"generation-main"} },
+		GenerationBranch:       "generation-main",
+		CurrentBranch:          "generation-main",
+		HistoryDir:             histDir,
+	}
+
+	err := PrintGeneratorStats(deps)
+	w.Close()
+	captured, _ := io.ReadAll(r)
+	os.Stdout = oldStdout
+	output := string(captured)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Table header should include Started column.
+	if !strings.Contains(output, "Started") {
+		t.Errorf("expected 'Started' column header in output:\n%s", output)
+	}
+
+	// Task 300 should show a formatted start time (Mar 22).
+	if !strings.Contains(output, "Mar 22") {
+		t.Errorf("expected 'Mar 22' in Started column for task 300:\n%s", output)
+	}
+}
+
 func TestPrintGeneratorStats_RateLimitColumn(t *testing.T) {
 	// Uses os.Chdir — do NOT use t.Parallel()
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary

Adds a Started column to the `mage stats:generator` table showing when each stitch or measure task began. The timestamp data was already tracked for chronological sorting but not displayed. Formatted as `"Jan 02 15:04"` in local timezone.

## Changes

- Added `Started` display field to `tableRow` struct
- Added `formatStarted` helper (RFC3339 → `"Jan 02 15:04"`)
- Populated Started for stitch, measure, and active measure rows
- Added `Started` column to table header and row format (after Status, before Rel)
- New test: `TestPrintGeneratorStats_StartedColumn`

## Stats

```
generator_stats.go:     +17/-3
generator_stats_test.go: +68/-0
Total:                   +85/-3
```

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`, 12 packages)
- [x] New test verifies Started column header and formatted date

Closes #1884