### PR TITLE
GH-1882: Add MinMeasureIssues to prevent empty measure results in tests

### DIFF
--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -216,6 +216,14 @@ type CobblerConfig struct {
 	// no retries are attempted. A value of 2-3 is recommended.
 	MaxMeasureRetries int `yaml:"max_measure_retries"`
 
+	// MinMeasureIssues is the minimum number of tasks that measure must
+	// propose when unresolved requirements exist. When set, an additional
+	// prompt constraint tells Claude that returning [] is not acceptable.
+	// Default 0 (disabled — Claude may return [] when it judges the spec
+	// complete). Useful for test configurations where the LLM occasionally
+	// misinterprets a specs-only project as already implemented (GH-1882).
+	MinMeasureIssues int `yaml:"min_measure_issues"`
+
 	// MaxRequirementsPerTask is the maximum number of requirements a single
 	// proposed task may contain. When exceeded the task is rejected and the
 	// measure agent is re-prompted to split it. When 0 (default), the limit

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -530,6 +530,18 @@ func (o *Orchestrator) buildMeasurePrompt(userInput, existingIssues string, limi
 	activeRelease := filterImplementedRelease(o.cfg.Project.Release)
 	doc.Constraints += measureReleasesConstraint(activeReleases, activeRelease)
 
+	// When MinMeasureIssues is set and unresolved requirements exist, add
+	// a constraint that overrides the "return [] when complete" instruction.
+	// This prevents the LLM from non-deterministically returning empty
+	// results for projects with high documentation-to-code ratios (GH-1882).
+	if minIssues := o.cfg.Cobbler.MinMeasureIssues; minIssues > 0 && o.hasUnresolvedRequirements() {
+		doc.Constraints += fmt.Sprintf("\n- MANDATORY: You MUST propose at least %d task(s). "+
+			"The requirements.yaml file shows unresolved R-items with status \"ready\". "+
+			"Returning an empty list [] is NOT acceptable when ready requirements exist. "+
+			"Analyze the ready R-items and propose implementation tasks for them.", minIssues)
+		logf("buildMeasurePrompt: min_measure_issues=%d constraint injected", minIssues)
+	}
+
 	out, err := yaml.Marshal(&doc)
 	if err != nil {
 		return "", fmt.Errorf("marshaling measure prompt: %w", err)

--- a/tests/rel01.0/uc002/lifecycle_claude_test.go
+++ b/tests/rel01.0/uc002/lifecycle_claude_test.go
@@ -31,6 +31,7 @@ func TestRel01_UC002_RunOneCycle(t *testing.T) {
 
 	testutil.WriteConfigOverride(t, dir, func(cfg *orchestrator.Config) {
 		cfg.Cobbler.MaxMeasureIssues = 1
+		cfg.Cobbler.MinMeasureIssues = 1 // prevent empty [] from LLM non-determinism (GH-1882)
 		cfg.Generation.Cycles = 1
 	})
 

--- a/tests/rel01.0/uc003/measure_claude_test.go
+++ b/tests/rel01.0/uc003/measure_claude_test.go
@@ -31,6 +31,7 @@ func TestRel01_UC003_MeasureCreatesIssues(t *testing.T) {
 
 	testutil.WriteConfigOverride(t, dir, func(cfg *orchestrator.Config) {
 		cfg.Cobbler.MaxMeasureIssues = 1
+		cfg.Cobbler.MinMeasureIssues = 1 // prevent empty [] from LLM non-determinism (GH-1882)
 	})
 
 	if err := testutil.RunMage(t, dir, "reset"); err != nil {
@@ -87,6 +88,7 @@ func TestRel01_UC003_MeasureRecordsInvocation(t *testing.T) {
 
 	testutil.WriteConfigOverride(t, dir, func(cfg *orchestrator.Config) {
 		cfg.Cobbler.MaxMeasureIssues = 1
+		cfg.Cobbler.MinMeasureIssues = 1 // prevent empty [] from LLM non-determinism (GH-1882)
 	})
 
 	if err := testutil.RunMage(t, dir, "reset"); err != nil {


### PR DESCRIPTION
## Summary

Adds a `MinMeasureIssues` config field that injects a mandatory prompt constraint when unresolved requirements exist, preventing Claude from non-deterministically returning `[]` for projects with high documentation-to-code ratios. The affected e2e tests now set `MinMeasureIssues: 1` to eliminate the 30-50% flake rate.

## Changes

- Added `MinMeasureIssues` config field to `CobblerConfig` (default 0 = disabled, no production behavior change)
- In `buildMeasurePrompt`: when `MinMeasureIssues > 0` and `hasUnresolvedRequirements()`, append a MANDATORY constraint overriding the "return [] when complete" instruction
- UC002 `RunOneCycle` and UC003 `MeasureCreatesIssues`/`MeasureRecordsInvocation` tests set `MinMeasureIssues: 1`

## Stats

```
config.go:                  +8
measure.go:                 +11
uc002/lifecycle_claude_test.go: +1
uc003/measure_claude_test.go:   +2
Total:                      +23/-0
```

## Test plan

- [x] All 12 unit test packages pass
- [x] Test code compiles with `-tags usecase,claude`
- [ ] Run `mage test:usecase` 5 times to verify flake rate is eliminated (requires Claude API access)

Closes #1882