### PR TITLE
GH-1906: Fix e2e requirement tracking test for generation worktree

### DIFF
--- a/tests/e2e/requirements_tracking_test.go
+++ b/tests/e2e/requirements_tracking_test.go
@@ -62,8 +62,10 @@ func TestRequirementTracking_GeneratorStartProducesRequirements(t *testing.T) {
 		t.Fatalf("GeneratorStart: %v", err)
 	}
 
-	// Read and verify the generated requirements.yaml.
-	reqPath := filepath.Join(dir, ".cobbler", "requirements.yaml")
+	// Read requirements.yaml from CWD (the generation worktree after
+	// GeneratorStart, not the original repo dir) (GH-1608, GH-1906).
+	cwd, _ := os.Getwd()
+	reqPath := filepath.Join(cwd, ".cobbler", "requirements.yaml")
 	data, err := os.ReadFile(reqPath)
 	if err != nil {
 		t.Fatalf("reading requirements.yaml: %v", err)


### PR DESCRIPTION
## Summary

Fixes TestRequirementTracking_GeneratorStartProducesRequirements to read requirements.yaml from CWD (the generation worktree) instead of the original repo dir. Pre-existing issue since GH-1608 worktree changes.

## Test plan

- [x] e2e test passes
- [x] All 7 rel01.0 use-case suites pass

Closes #1906