### PR TITLE
GH-1948: Include per-requirement completion status in measure prompt

### DIFF
--- a/pkg/orchestrator/analyze.go
+++ b/pkg/orchestrator/analyze.go
@@ -141,5 +141,5 @@ func computeCodeStatus(roadmap *RoadmapDoc, scan map[string]int) CodeStatusRepor
 			UseCases: ucs,
 		})
 	}
-	return an.ComputeCodeStatus(&internalRoadmap, scan)
+	return an.ComputeCodeStatus(&internalRoadmap, scan, nil)
 }

--- a/pkg/orchestrator/internal/analysis/codestatus.go
+++ b/pkg/orchestrator/internal/analysis/codestatus.go
@@ -99,9 +99,102 @@ func ScanTestDirectories(testsRoot string) map[string]int {
 	return result
 }
 
-// ComputeCodeStatus builds the code status report from the roadmap and
-// a test directory scan.
-func ComputeCodeStatus(roadmap *RoadmapDoc, testDirScan map[string]int) CodeStatusReport {
+// isRequirementComplete returns true if the status represents a completed
+// or skipped R-item.
+func isRequirementComplete(status string) bool {
+	return status == "complete" || status == "complete_with_failures" || status == "skip"
+}
+
+// findPRDRequirements looks up the requirement map for a PRD stem, trying
+// exact match first, then dash-delimited prefix match (e.g. "prd001" matches
+// "prd001-core" but not "prd0011-other").
+func findPRDRequirements(reqs map[string]map[string]RequirementState, stem string) map[string]RequirementState {
+	if r, ok := reqs[stem]; ok {
+		return r
+	}
+	var bestKey string
+	var bestReqs map[string]RequirementState
+	for key, r := range reqs {
+		if strings.HasPrefix(key, stem+"-") {
+			if bestKey == "" || len(key) > len(bestKey) {
+				bestKey = key
+				bestReqs = r
+			}
+		}
+	}
+	return bestReqs
+}
+
+// ComputeReqCompletion loads .cobbler/requirements.yaml and use case files,
+// then determines which use cases have all their cited R-items complete.
+// Returns a map from UC prefix (e.g. "rel01.0-uc001") to completion status.
+// Returns nil when requirements.yaml is missing or empty (GH-1948).
+func ComputeReqCompletion(cobblerDir string) map[string]bool {
+	reqFile := loadYAML[RequirementsFile](filepath.Join(cobblerDir, "requirements.yaml"))
+	if reqFile == nil || len(reqFile.Requirements) == 0 {
+		return nil
+	}
+
+	ucFiles, err := filepath.Glob("docs/specs/use-cases/rel*.yaml")
+	if err != nil || len(ucFiles) == 0 {
+		return nil
+	}
+
+	result := make(map[string]bool)
+	for _, path := range ucFiles {
+		uc, err := LoadUseCase(path)
+		if err != nil || len(uc.Touchpoints) == 0 {
+			continue
+		}
+		prefix := UCPrefixFromID(uc.ID)
+		if prefix == "" {
+			continue
+		}
+
+		citations := ExtractCitationsFromTouchpoints(uc.Touchpoints)
+		if len(citations) == 0 {
+			continue
+		}
+
+		allComplete := true
+		for _, cite := range citations {
+			prdReqs := findPRDRequirements(reqFile.Requirements, cite.PRDID)
+			if prdReqs == nil {
+				allComplete = false
+				break
+			}
+			for _, group := range cite.Groups {
+				groupPrefix := group + "."
+				found := false
+				for key, st := range prdReqs {
+					if strings.HasPrefix(key, groupPrefix) {
+						found = true
+						if !isRequirementComplete(st.Status) {
+							allComplete = false
+							break
+						}
+					}
+				}
+				if !found || !allComplete {
+					allComplete = false
+					break
+				}
+			}
+			if !allComplete {
+				break
+			}
+		}
+		result[prefix] = allComplete
+	}
+	return result
+}
+
+// ComputeCodeStatus builds the code status report from the roadmap,
+// a test directory scan, and optional per-UC requirements completion.
+// When reqComplete is non-nil, a use case is considered implemented if
+// it has test files OR all its cited R-items are complete in
+// requirements.yaml (GH-1948).
+func ComputeCodeStatus(roadmap *RoadmapDoc, testDirScan map[string]int, reqComplete map[string]bool) CodeStatusReport {
 	var report CodeStatusReport
 
 	for _, release := range roadmap.Releases {
@@ -126,6 +219,9 @@ func ComputeCodeStatus(roadmap *RoadmapDoc, testDirScan map[string]int) CodeStat
 				codeStatus = "implemented"
 				implemented++
 				testDir = TestDirForUC(uc.ID)
+			} else if reqComplete[prefix] {
+				codeStatus = "implemented"
+				implemented++
 			}
 
 			relStatus.UseCases = append(relStatus.UseCases, UCCodeStatus{
@@ -184,7 +280,7 @@ func PrintCodeStatus() error {
 
 	testScan := ScanTestDirectories("tests")
 
-	report := ComputeCodeStatus(roadmap, testScan)
+	report := ComputeCodeStatus(roadmap, testScan, nil)
 	report.Gaps = DetectSpecCodeGaps(&report)
 
 	PrintCodeStatusReport(&report)

--- a/pkg/orchestrator/internal/analysis/codestatus_test.go
+++ b/pkg/orchestrator/internal/analysis/codestatus_test.go
@@ -152,7 +152,7 @@ func TestComputeCodeStatus_AllImplemented(t *testing.T) {
 		"rel01.0-uc001": 1,
 		"rel01.0-uc002": 3,
 	}
-	report := ComputeCodeStatus(roadmap, scan)
+	report := ComputeCodeStatus(roadmap, scan, nil)
 
 	if len(report.Releases) != 1 {
 		t.Fatalf("got %d releases, want 1", len(report.Releases))
@@ -183,7 +183,7 @@ func TestComputeCodeStatus_Partial(t *testing.T) {
 	scan := map[string]int{
 		"rel01.0-uc001": 1,
 	}
-	report := ComputeCodeStatus(roadmap, scan)
+	report := ComputeCodeStatus(roadmap, scan, nil)
 
 	if report.Releases[0].CodeReadiness != "partial" {
 		t.Errorf("CodeReadiness: got %q, want %q", report.Releases[0].CodeReadiness, "partial")
@@ -205,7 +205,7 @@ func TestComputeCodeStatus_None(t *testing.T) {
 		}},
 	}
 	scan := map[string]int{}
-	report := ComputeCodeStatus(roadmap, scan)
+	report := ComputeCodeStatus(roadmap, scan, nil)
 
 	if report.Releases[0].CodeReadiness != "none" {
 		t.Errorf("CodeReadiness: got %q, want %q", report.Releases[0].CodeReadiness, "none")
@@ -222,7 +222,7 @@ func TestComputeCodeStatus_SkipsEmptyReleases(t *testing.T) {
 		},
 	}
 	scan := map[string]int{"rel01.0-uc001": 1}
-	report := ComputeCodeStatus(roadmap, scan)
+	report := ComputeCodeStatus(roadmap, scan, nil)
 
 	if len(report.Releases) != 1 {
 		t.Errorf("got %d releases, want 1 (empty release should be skipped)", len(report.Releases))
@@ -241,7 +241,7 @@ func TestComputeCodeStatus_MultipleReleases(t *testing.T) {
 		},
 	}
 	scan := map[string]int{"rel01.0-uc001": 2}
-	report := ComputeCodeStatus(roadmap, scan)
+	report := ComputeCodeStatus(roadmap, scan, nil)
 
 	if len(report.Releases) != 2 {
 		t.Fatalf("got %d releases, want 2", len(report.Releases))
@@ -488,6 +488,363 @@ func TestPrintCodeStatus_WithGap(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "gap") {
 		t.Errorf("error should mention 'gap', got: %v", err)
+	}
+}
+
+// --- ComputeCodeStatus with reqComplete (GH-1948) ---
+
+func TestComputeCodeStatus_ReqCompleteMarksImplemented(t *testing.T) {
+	roadmap := &RoadmapDoc{
+		Releases: []RoadmapRelease{{
+			Version: "01.0",
+			Name:    "Core",
+			Status:  "done",
+			UseCases: []RoadmapUseCase{
+				{ID: "rel01.0-uc001-init", Status: "done"},
+				{ID: "rel01.0-uc002-lifecycle", Status: "done"},
+			},
+		}},
+	}
+	scan := map[string]int{} // no test files
+	reqComplete := map[string]bool{
+		"rel01.0-uc001": true,
+		"rel01.0-uc002": true,
+	}
+	report := ComputeCodeStatus(roadmap, scan, reqComplete)
+
+	if report.Releases[0].CodeReadiness != "all implemented" {
+		t.Errorf("CodeReadiness: got %q, want %q", report.Releases[0].CodeReadiness, "all implemented")
+	}
+	for i, uc := range report.Releases[0].UseCases {
+		if uc.CodeStatus != "implemented" {
+			t.Errorf("UC[%d] CodeStatus: got %q, want %q", i, uc.CodeStatus, "implemented")
+		}
+		if uc.TestFiles != 0 {
+			t.Errorf("UC[%d] TestFiles: got %d, want 0 (implemented via reqs, not tests)", i, uc.TestFiles)
+		}
+	}
+}
+
+func TestComputeCodeStatus_ReqCompletePartial(t *testing.T) {
+	roadmap := &RoadmapDoc{
+		Releases: []RoadmapRelease{{
+			Version: "01.0",
+			Name:    "Core",
+			Status:  "done",
+			UseCases: []RoadmapUseCase{
+				{ID: "rel01.0-uc001-init", Status: "done"},
+				{ID: "rel01.0-uc002-lifecycle", Status: "done"},
+			},
+		}},
+	}
+	scan := map[string]int{}
+	reqComplete := map[string]bool{
+		"rel01.0-uc001": true,
+		"rel01.0-uc002": false, // not all reqs complete
+	}
+	report := ComputeCodeStatus(roadmap, scan, reqComplete)
+
+	if report.Releases[0].CodeReadiness != "partial" {
+		t.Errorf("CodeReadiness: got %q, want %q", report.Releases[0].CodeReadiness, "partial")
+	}
+}
+
+func TestComputeCodeStatus_TestFilesTakePrecedence(t *testing.T) {
+	roadmap := &RoadmapDoc{
+		Releases: []RoadmapRelease{{
+			Version: "01.0",
+			Name:    "Core",
+			Status:  "done",
+			UseCases: []RoadmapUseCase{
+				{ID: "rel01.0-uc001-init", Status: "done"},
+			},
+		}},
+	}
+	scan := map[string]int{"rel01.0-uc001": 3}
+	reqComplete := map[string]bool{"rel01.0-uc001": true}
+	report := ComputeCodeStatus(roadmap, scan, reqComplete)
+
+	uc := report.Releases[0].UseCases[0]
+	if uc.CodeStatus != "implemented" {
+		t.Errorf("CodeStatus: got %q, want %q", uc.CodeStatus, "implemented")
+	}
+	if uc.TestFiles != 3 {
+		t.Errorf("TestFiles: got %d, want 3 (test files should be counted when present)", uc.TestFiles)
+	}
+	if uc.TestDir == "" {
+		t.Error("TestDir should be set when test files exist")
+	}
+}
+
+func TestComputeCodeStatus_NilReqCompleteBackwardCompat(t *testing.T) {
+	roadmap := &RoadmapDoc{
+		Releases: []RoadmapRelease{{
+			Version: "01.0",
+			Name:    "Core",
+			Status:  "done",
+			UseCases: []RoadmapUseCase{
+				{ID: "rel01.0-uc001-init", Status: "done"},
+			},
+		}},
+	}
+	scan := map[string]int{}
+	report := ComputeCodeStatus(roadmap, scan, nil)
+
+	if report.Releases[0].UseCases[0].CodeStatus != "not started" {
+		t.Errorf("CodeStatus: got %q, want %q (nil reqComplete should not change behavior)",
+			report.Releases[0].UseCases[0].CodeStatus, "not started")
+	}
+}
+
+// --- ComputeReqCompletion (GH-1948) ---
+
+func TestComputeReqCompletion_AllComplete(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+	os.MkdirAll("docs/specs/use-cases", 0o755)
+
+	os.WriteFile(filepath.Join(cobblerDir, "requirements.yaml"), []byte(`requirements:
+  prd001-core:
+    R1.1:
+      status: complete
+    R1.2:
+      status: complete
+`), 0o644)
+
+	os.WriteFile("docs/specs/use-cases/rel01.0-uc001-init.yaml", []byte(`id: rel01.0-uc001-init
+title: Init
+touchpoints:
+  - T1: prd001-core R1
+`), 0o644)
+
+	result := ComputeReqCompletion(cobblerDir)
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !result["rel01.0-uc001"] {
+		t.Error("rel01.0-uc001 should be complete")
+	}
+}
+
+func TestComputeReqCompletion_PartiallyComplete(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+	os.MkdirAll("docs/specs/use-cases", 0o755)
+
+	os.WriteFile(filepath.Join(cobblerDir, "requirements.yaml"), []byte(`requirements:
+  prd001-core:
+    R1.1:
+      status: complete
+    R1.2:
+      status: ready
+`), 0o644)
+
+	os.WriteFile("docs/specs/use-cases/rel01.0-uc001-init.yaml", []byte(`id: rel01.0-uc001-init
+title: Init
+touchpoints:
+  - T1: prd001-core R1
+`), 0o644)
+
+	result := ComputeReqCompletion(cobblerDir)
+	if result["rel01.0-uc001"] {
+		t.Error("rel01.0-uc001 should NOT be complete (R1.2 is ready)")
+	}
+}
+
+func TestComputeReqCompletion_NoRequirementsFile(t *testing.T) {
+	dir := t.TempDir()
+	result := ComputeReqCompletion(dir)
+	if result != nil {
+		t.Errorf("expected nil, got %v", result)
+	}
+}
+
+func TestComputeReqCompletion_SkipStatusCountsAsComplete(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+	os.MkdirAll("docs/specs/use-cases", 0o755)
+
+	os.WriteFile(filepath.Join(cobblerDir, "requirements.yaml"), []byte(`requirements:
+  prd001-core:
+    R1.1:
+      status: complete
+    R1.2:
+      status: skip
+`), 0o644)
+
+	os.WriteFile("docs/specs/use-cases/rel01.0-uc001-init.yaml", []byte(`id: rel01.0-uc001-init
+title: Init
+touchpoints:
+  - T1: prd001-core R1
+`), 0o644)
+
+	result := ComputeReqCompletion(cobblerDir)
+	if !result["rel01.0-uc001"] {
+		t.Error("rel01.0-uc001 should be complete (skip counts as complete)")
+	}
+}
+
+func TestComputeReqCompletion_CompleteWithFailuresCountsAsComplete(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+	os.MkdirAll("docs/specs/use-cases", 0o755)
+
+	os.WriteFile(filepath.Join(cobblerDir, "requirements.yaml"), []byte(`requirements:
+  prd001-core:
+    R1.1:
+      status: complete_with_failures
+`), 0o644)
+
+	os.WriteFile("docs/specs/use-cases/rel01.0-uc001-init.yaml", []byte(`id: rel01.0-uc001-init
+title: Init
+touchpoints:
+  - T1: prd001-core R1
+`), 0o644)
+
+	result := ComputeReqCompletion(cobblerDir)
+	if !result["rel01.0-uc001"] {
+		t.Error("rel01.0-uc001 should be complete (complete_with_failures counts)")
+	}
+}
+
+func TestComputeReqCompletion_MissingPRDInReqs(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+	os.MkdirAll("docs/specs/use-cases", 0o755)
+
+	os.WriteFile(filepath.Join(cobblerDir, "requirements.yaml"), []byte(`requirements:
+  prd099-other:
+    R1.1:
+      status: complete
+`), 0o644)
+
+	os.WriteFile("docs/specs/use-cases/rel01.0-uc001-init.yaml", []byte(`id: rel01.0-uc001-init
+title: Init
+touchpoints:
+  - T1: prd001-core R1
+`), 0o644)
+
+	result := ComputeReqCompletion(cobblerDir)
+	if result["rel01.0-uc001"] {
+		t.Error("rel01.0-uc001 should NOT be complete (prd001-core not in requirements)")
+	}
+}
+
+func TestComputeReqCompletion_PrefixMatch(t *testing.T) {
+	dir := t.TempDir()
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(origDir) })
+
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+	os.MkdirAll("docs/specs/use-cases", 0o755)
+
+	// requirements.yaml has full stem "prd001-core", touchpoint cites "prd001"
+	os.WriteFile(filepath.Join(cobblerDir, "requirements.yaml"), []byte(`requirements:
+  prd001-core:
+    R1.1:
+      status: complete
+`), 0o644)
+
+	os.WriteFile("docs/specs/use-cases/rel01.0-uc001-init.yaml", []byte(`id: rel01.0-uc001-init
+title: Init
+touchpoints:
+  - T1: prd001 R1
+`), 0o644)
+
+	result := ComputeReqCompletion(cobblerDir)
+	if !result["rel01.0-uc001"] {
+		t.Error("rel01.0-uc001 should be complete (prd001 prefix matches prd001-core)")
+	}
+}
+
+// --- isRequirementComplete ---
+
+func TestIsRequirementComplete(t *testing.T) {
+	cases := []struct {
+		status string
+		want   bool
+	}{
+		{"complete", true},
+		{"complete_with_failures", true},
+		{"skip", true},
+		{"ready", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		if got := isRequirementComplete(tc.status); got != tc.want {
+			t.Errorf("isRequirementComplete(%q) = %v, want %v", tc.status, got, tc.want)
+		}
+	}
+}
+
+// --- findPRDRequirements ---
+
+func TestFindPRDRequirements_ExactMatch(t *testing.T) {
+	reqs := map[string]map[string]RequirementState{
+		"prd001-core": {"R1.1": {Status: "complete"}},
+	}
+	got := findPRDRequirements(reqs, "prd001-core")
+	if got == nil || got["R1.1"].Status != "complete" {
+		t.Errorf("expected exact match for prd001-core")
+	}
+}
+
+func TestFindPRDRequirements_PrefixMatch(t *testing.T) {
+	reqs := map[string]map[string]RequirementState{
+		"prd001-core": {"R1.1": {Status: "ready"}},
+	}
+	got := findPRDRequirements(reqs, "prd001")
+	if got == nil || got["R1.1"].Status != "ready" {
+		t.Errorf("expected prefix match prd001 -> prd001-core")
+	}
+}
+
+func TestFindPRDRequirements_NoMatch(t *testing.T) {
+	reqs := map[string]map[string]RequirementState{
+		"prd001-core": {"R1.1": {Status: "ready"}},
+	}
+	got := findPRDRequirements(reqs, "prd999")
+	if got != nil {
+		t.Errorf("expected nil for non-matching stem, got %v", got)
+	}
+}
+
+func TestFindPRDRequirements_LongestPrefixWins(t *testing.T) {
+	reqs := map[string]map[string]RequirementState{
+		"prd001-core":     {"R1.1": {Status: "ready"}},
+		"prd001-core-ext": {"R1.1": {Status: "complete"}},
+	}
+	got := findPRDRequirements(reqs, "prd001-core")
+	// Exact match should win over prefix
+	if got == nil || got["R1.1"].Status != "ready" {
+		t.Errorf("exact match should take precedence")
 	}
 }
 

--- a/pkg/orchestrator/internal/analysis/precycle.go
+++ b/pkg/orchestrator/internal/analysis/precycle.go
@@ -107,7 +107,8 @@ func RunPreCycleAnalysis(deps PreCycleDeps) {
 	roadmap := loadYAML[RoadmapDoc]("docs/road-map.yaml")
 	if roadmap != nil {
 		testScan := ScanTestDirectories("tests")
-		report := ComputeCodeStatus(roadmap, testScan)
+		reqComplete := ComputeReqCompletion(deps.CobblerDir)
+		report := ComputeCodeStatus(roadmap, testScan, reqComplete)
 		report.Gaps = DetectSpecCodeGaps(&report)
 		doc.CodeStatus = &report
 	} else {

--- a/pkg/orchestrator/internal/analysis/types.go
+++ b/pkg/orchestrator/internal/analysis/types.go
@@ -115,6 +115,17 @@ type ArchDependencyRule struct {
 	Description string `yaml:"description"`
 }
 
+// RequirementState holds the status of a single R-item from
+// .cobbler/requirements.yaml.
+type RequirementState struct {
+	Status string `yaml:"status"`
+}
+
+// RequirementsFile is the top-level structure of .cobbler/requirements.yaml.
+type RequirementsFile struct {
+	Requirements map[string]map[string]RequirementState `yaml:"requirements"`
+}
+
 // loadYAML reads a YAML file and unmarshals it into T.
 // Returns nil if the file does not exist or cannot be parsed.
 func loadYAML[T any](path string) *T {


### PR DESCRIPTION
## Summary

The measure prompt's code status section showed all use cases as "not started" even when their R-items were marked complete in requirements.yaml. This caused the measure agent to re-propose already-completed work during generation runs, producing zero-LOC stitch tasks and triggering auto-stop.

`ComputeCodeStatus()` now considers requirements.yaml completion status alongside test file presence when determining use case implementation status.

## Changes

- Added `RequirementState` and `RequirementsFile` types to the analysis package
- Added `ComputeReqCompletion()` to load requirements.yaml and use case touchpoints, returning a per-UC completion map
- Modified `ComputeCodeStatus()` to accept the completion map: a use case is "implemented" if it has test files OR all its cited R-items are complete
- Updated `RunPreCycleAnalysis()` to compute and pass requirements completion
- Added 15 new tests covering requirements-aware paths, prefix matching, skip/complete_with_failures statuses, and backward compatibility

## Stats

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| go_loc_prod | 19,361 | 19,315 | -46 |
| go_loc_test | 35,136 | 35,493 | +357 |

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)
- [x] New tests cover: reqComplete marking implemented, partial completion, nil backward compat, test files taking precedence, skip/complete_with_failures statuses, prefix matching, missing PRD

Closes #1948