### PR TITLE
GH-1950: Remove secrets configuration from scaffolded configuration.yaml

### DIFF
--- a/docs/specs/product-requirements/prd001-orchestrator-core.yaml
+++ b/docs/specs/product-requirements/prd001-orchestrator-core.yaml
@@ -31,8 +31,8 @@ requirements:
       - R1.8: CobblerConfig must include IssuesRepo (string) for the GitHub repository (owner/repo) used as the issue tracker; auto-detected from module_path when empty
       - R1.9: CobblerConfig must include Dir (string, default ".cobbler/") for the scratch directory
       - R1.10: ProjectConfig must include MagefilesDir (string, default "magefiles") for the directory skipped during Go file deletion
-      - R1.11: ClaudeConfig must include SecretsDir (string, default ".secrets") for token files
-      - R1.12: ClaudeConfig must include DefaultTokenFile (string, default "claude.json") for the credential filename
+      - R1.11: ClaudeConfig must include SecretsDir (string, default ".secrets", omitempty) for token files; omitted from scaffolded configuration.yaml
+      - R1.12: ClaudeConfig must include DefaultTokenFile (string, default "claude.json", omitempty) for the credential filename; omitted from scaffolded configuration.yaml
       - R1.13: ProjectConfig must include SeedFiles (map[string]string) mapping destination paths to template source file paths
       - R1.14: CobblerConfig must include MeasurePrompt (string) as a file path to a custom measure prompt template; LoadConfig reads the referenced file and replaces the path with its content
       - R1.15: CobblerConfig must include StitchPrompt (string) as a file path to a custom stitch prompt template; LoadConfig reads the referenced file and replaces the path with its content
@@ -43,7 +43,7 @@ requirements:
       - R1.20: GenerationConfig must include Cycles (int) for the number of measure+stitch cycles per run; 0 means run until all issues are closed
       - R1.21: CobblerConfig must include UserPrompt (string) for additional context in the measure prompt
       - R1.22: GenerationConfig must include Branch (string) for explicit branch selection
-      - R1.23: ClaudeConfig must include TokenFile (string) for a credential file override in SecretsDir
+      - R1.23: ClaudeConfig must include TokenFile (string, omitempty) for a credential file override in SecretsDir; omitted from scaffolded configuration.yaml
       - R1.24: All Config fields must have YAML struct tags using snake_case names
       - R1.25: CobblerConfig must include EstimatedLinesMin (int, default 250) for the minimum estimated lines per task, passed to the measure prompt as LinesMin
       - R1.26: CobblerConfig must include EstimatedLinesMax (int, default 350) for the maximum estimated lines per task, passed to the measure prompt as LinesMax

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -376,14 +376,17 @@ type ClaudeConfig struct {
 	SilenceAgent *bool `yaml:"silence_agent"`
 
 	// SecretsDir is the directory containing token files (default ".secrets").
-	SecretsDir string `yaml:"secrets_dir"`
+	// Omitted from scaffolded configuration.yaml; resolved internally.
+	SecretsDir string `yaml:"secrets_dir,omitempty"`
 
 	// DefaultTokenFile is the default credential filename (default "claude.json").
-	DefaultTokenFile string `yaml:"default_token_file"`
+	// Omitted from scaffolded configuration.yaml; resolved internally.
+	DefaultTokenFile string `yaml:"default_token_file,omitempty"`
 
 	// TokenFile overrides the credential filename in SecretsDir.
 	// If empty, DefaultTokenFile is used.
-	TokenFile string `yaml:"token_file"`
+	// Omitted from scaffolded configuration.yaml; resolved internally.
+	TokenFile string `yaml:"token_file,omitempty"`
 
 	// MaxTimeSec is the maximum duration in seconds for a single Claude
 	// invocation (default 300, i.e. 5 minutes). If the time expires, the

--- a/pkg/orchestrator/scaffold.go
+++ b/pkg/orchestrator/scaffold.go
@@ -148,6 +148,14 @@ func (o *Orchestrator) Scaffold(targetDir, orchestratorRoot string) error {
 		logf("scaffold: created seed template %s -> %s", seedPath, tmplPath)
 	}
 
+	// Clear secrets fields so they are not written to the scaffolded
+	// configuration.yaml. These are internal defaults resolved by
+	// applyDefaults at load time; exposing them in committed config
+	// leaks credential-storage implementation details.
+	cfg.Claude.SecretsDir = ""
+	cfg.Claude.DefaultTokenFile = ""
+	cfg.Claude.TokenFile = ""
+
 	cfgPath := filepath.Join(targetDir, DefaultConfigFile)
 	if _, err := os.Stat(cfgPath); os.IsNotExist(err) {
 		logf("scaffold: writing %s", cfgPath)

--- a/pkg/orchestrator/scaffold_test.go
+++ b/pkg/orchestrator/scaffold_test.go
@@ -281,6 +281,44 @@ func TestWriteScaffoldConfig_WritesValidYAML(t *testing.T) {
 	}
 }
 
+func TestWriteScaffoldConfig_OmitsSecretsFields(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "configuration.yaml")
+	cfg := DefaultConfig()
+	// Clear secrets fields the same way Scaffold does.
+	cfg.Claude.SecretsDir = ""
+	cfg.Claude.DefaultTokenFile = ""
+	cfg.Claude.TokenFile = ""
+
+	if err := writeScaffoldConfig(path, cfg); err != nil {
+		t.Fatalf("writeScaffoldConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading written config: %v", err)
+	}
+	content := string(data)
+
+	for _, field := range []string{"secrets_dir", "default_token_file", "token_file"} {
+		if strings.Contains(content, field) {
+			t.Errorf("scaffolded config contains %q, want it omitted", field)
+		}
+	}
+
+	// Verify the config still loads correctly with defaults applied.
+	var parsed Config
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("config not valid YAML: %v", err)
+	}
+	parsed.applyDefaults()
+	if parsed.Claude.SecretsDir != ".secrets" {
+		t.Errorf("SecretsDir after applyDefaults = %q, want %q", parsed.Claude.SecretsDir, ".secrets")
+	}
+	if parsed.Claude.DefaultTokenFile != "claude.json" {
+		t.Errorf("DefaultTokenFile after applyDefaults = %q, want %q", parsed.Claude.DefaultTokenFile, "claude.json")
+	}
+}
+
 // --- copyFile ---
 
 func TestCopyFile_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

Scaffolded `configuration.yaml` no longer includes `secrets_dir`, `default_token_file`, or `token_file` fields. These credential-storage implementation details are now resolved internally by `applyDefaults()` at config load time, removing them from committed configuration files while preserving backward compatibility.

## Changes

- Added `omitempty` to `SecretsDir`, `DefaultTokenFile`, `TokenFile` YAML struct tags in `ClaudeConfig`
- Clear secrets fields in `Scaffold()` before writing `configuration.yaml`
- Added `TestWriteScaffoldConfig_OmitsSecretsFields` test
- Updated PRD requirements R1.11, R1.12, R1.23 to document omitempty behavior

## Stats

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| go_loc_prod | 19,469 | 19,326 | -143 |
| go_loc_test | 35,493 | 35,531 | +38 |
| spec_words (prd) | 9,408 | 9,423 | +15 |

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] New test verifies secrets fields absent from scaffolded config
- [x] New test verifies `applyDefaults()` still resolves defaults after loading config without secrets fields

Closes #1950