### PR TITLE
GH-1951: Derive max_weight_per_task from max_requirements_per_task

### DIFF
--- a/docs/specs/product-requirements/prd003-cobbler-workflows.yaml
+++ b/docs/specs/product-requirements/prd003-cobbler-workflows.yaml
@@ -107,6 +107,7 @@ requirements:
       - R7.3: importIssues must order issues by dependency index so dependent issues are created after their prerequisites
       - R7.4: Reserved (GitHub Issues are created remotely; no local commit required)
       - R7.5: When Config.Cobbler.MaxRequirementsPerTask is greater than zero, measure must count the number of requirement items in each proposed issue's description and reject issues that exceed the limit; rejected issues must trigger a re-prompt (up to Config.Cobbler.MaxMeasureRetries attempts) instructing Claude to split them into smaller tasks
+      - R7.6: When Config.Cobbler.MaxRequirementsPerTask is greater than zero and Config.Cobbler.MaxWeightPerTask is zero, applyDefaults must set MaxWeightPerTask equal to MaxRequirementsPerTask so that weight-based validation is always active when count-based batching is configured (GH-1951)
 
   R8:
     title: Pre-flight Checks
@@ -253,6 +254,7 @@ acceptance_criteria:
       - R7.3
       - R7.4
       - R7.5
+      - R7.6
   - id: AC7
     criterion: Reserved (pre-flight podman checks removed — podman support dropped)
     traces:

--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -233,9 +233,12 @@ type CobblerConfig struct {
 	// MaxWeightPerTask is the maximum total weight a single proposed task
 	// may carry. When set, the measure agent batches requirements by total
 	// weight (from PRD weight annotations) instead of count. Requirements
-	// without explicit weights default to weight 1. When 0 (default), the
-	// limit is disabled and MaxRequirementsPerTask governs batching.
-	// When both are set, MaxWeightPerTask takes precedence (GH-1832).
+	// without explicit weights default to weight 1. When 0 and
+	// MaxRequirementsPerTask > 0, applyDefaults derives MaxWeightPerTask
+	// from MaxRequirementsPerTask so that weight-based validation is always
+	// active when count-based batching is configured (GH-1951).
+	// When both are explicitly set, MaxWeightPerTask takes precedence
+	// (GH-1832).
 	MaxWeightPerTask int `yaml:"max_weight_per_task"`
 
 	// MaxTaskFailures is the maximum number of times a task may fail within
@@ -567,6 +570,14 @@ func (c *Config) applyDefaults() {
 	}
 	if c.Claude.MaxTimeSec == 0 {
 		c.Claude.MaxTimeSec = 300
+	}
+	// When count-based batching is configured but weight-based is not,
+	// derive a weight budget equal to the count limit. Since the default
+	// weight per requirement is 1, this preserves count-based behavior
+	// for uniformly-weighted tasks while catching tasks whose total
+	// weight exceeds the budget (GH-1951).
+	if c.Cobbler.MaxRequirementsPerTask > 0 && c.Cobbler.MaxWeightPerTask == 0 {
+		c.Cobbler.MaxWeightPerTask = c.Cobbler.MaxRequirementsPerTask
 	}
 }
 

--- a/pkg/orchestrator/config_test.go
+++ b/pkg/orchestrator/config_test.go
@@ -120,6 +120,40 @@ func TestLoadConfig_AppliesDefaults(t *testing.T) {
 	}
 }
 
+func TestApplyDefaults_DerivesMaxWeightFromMaxRequirements(t *testing.T) {
+	// When MaxRequirementsPerTask is set but MaxWeightPerTask is not,
+	// applyDefaults derives MaxWeightPerTask from MaxRequirementsPerTask.
+	cfg := Config{Cobbler: CobblerConfig{MaxRequirementsPerTask: 6}}
+	cfg.applyDefaults()
+	if cfg.Cobbler.MaxWeightPerTask != 6 {
+		t.Errorf("MaxWeightPerTask = %d, want 6 (derived from MaxRequirementsPerTask)",
+			cfg.Cobbler.MaxWeightPerTask)
+	}
+}
+
+func TestApplyDefaults_ExplicitMaxWeightPreserved(t *testing.T) {
+	// When both are explicitly set, the explicit MaxWeightPerTask is kept.
+	cfg := Config{Cobbler: CobblerConfig{
+		MaxRequirementsPerTask: 6,
+		MaxWeightPerTask:       10,
+	}}
+	cfg.applyDefaults()
+	if cfg.Cobbler.MaxWeightPerTask != 10 {
+		t.Errorf("MaxWeightPerTask = %d, want 10 (explicit value preserved)",
+			cfg.Cobbler.MaxWeightPerTask)
+	}
+}
+
+func TestApplyDefaults_NoMaxRequirements_NoMaxWeight(t *testing.T) {
+	// When neither is set, MaxWeightPerTask stays 0 (disabled).
+	cfg := Config{}
+	cfg.applyDefaults()
+	if cfg.Cobbler.MaxWeightPerTask != 0 {
+		t.Errorf("MaxWeightPerTask = %d, want 0 (both disabled)",
+			cfg.Cobbler.MaxWeightPerTask)
+	}
+}
+
 func TestLoadConfig_ConstitutionFileOverride(t *testing.T) {
 	dir := t.TempDir()
 	planningPath := filepath.Join(dir, "planning.yaml")


### PR DESCRIPTION
## Summary

When count-based batching is configured but weight-based is not, `applyDefaults()` now derives `max_weight_per_task` from `max_requirements_per_task`. This ensures weight-based validation is always active, catching tasks whose total requirement weight exceeds the budget even when within the count limit. Tasks like the ones in generation run 38 (6 requirements, total weight 12, budget 6) would now be rejected and re-prompted.

## Changes

- `applyDefaults()` sets `MaxWeightPerTask = MaxRequirementsPerTask` when only count is configured
- Updated `MaxWeightPerTask` doc comment to document derived default behavior
- Added 3 tests: derivation, explicit override preserved, and disabled case
- Added PRD requirement R7.6 in prd003-cobbler-workflows.yaml

## Stats

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| go_loc_prod | 19,480 | 19,337 | -143 |
| go_loc_test | 35,531 | 35,565 | +34 |
| spec_words (prd) | 9,423 | 9,457 | +34 |

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] New test verifies weight derived from count when unset
- [x] New test verifies explicit weight preserved when both set
- [x] New test verifies both disabled when neither set

Closes #1951