### PR TITLE
GH-1952: Block auto-advance when release has ready requirements

### DIFF
--- a/docs/specs/product-requirements/prd003-cobbler-workflows.yaml
+++ b/docs/specs/product-requirements/prd003-cobbler-workflows.yaml
@@ -108,6 +108,7 @@ requirements:
       - R7.4: Reserved (GitHub Issues are created remotely; no local commit required)
       - R7.5: When Config.Cobbler.MaxRequirementsPerTask is greater than zero, measure must count the number of requirement items in each proposed issue's description and reject issues that exceed the limit; rejected issues must trigger a re-prompt (up to Config.Cobbler.MaxMeasureRetries attempts) instructing Claude to split them into smaller tasks
       - R7.6: When Config.Cobbler.MaxRequirementsPerTask is greater than zero and Config.Cobbler.MaxWeightPerTask is zero, applyDefaults must set MaxWeightPerTask equal to MaxRequirementsPerTask so that weight-based validation is always active when count-based batching is configured (GH-1951)
+      - R7.7: checkAutoAdvanceRelease must not advance a release when any requirement from PRDs referenced by the release's UC touchpoints is still ready in requirements.yaml, even if all UCs have a done status; this prevents orphaned ready requirements in uncited R-groups from becoming invisible to the measure agent (GH-1952)
 
   R8:
     title: Pre-flight Checks
@@ -255,6 +256,7 @@ acceptance_criteria:
       - R7.4
       - R7.5
       - R7.6
+      - R7.7
   - id: AC7
     criterion: Reserved (pre-flight podman checks removed — podman support dropped)
     traces:

--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -559,7 +559,16 @@ func (o *Orchestrator) checkAutoAdvanceRelease() (bool, string) {
 		}
 	}
 
-	// All UCs done — auto-advance this release.
+	// All UCs are done, but check that all PRD requirements from this
+	// release are also complete. UC touchpoints may not cite every R-group
+	// in a PRD, leaving orphaned ready requirements that become invisible
+	// once the release is filtered from the measure prompt (GH-1952).
+	if o.releaseHasReadyRequirements(target.UseCases) {
+		logf("checkAutoAdvanceRelease: release %s has all UCs done but ready requirements remain, not advancing", target.Version)
+		return false, ""
+	}
+
+	// All UCs done and all requirements complete — auto-advance.
 	logf("checkAutoAdvanceRelease: release %s has all use cases done, advancing", target.Version)
 	if err := o.ReleaseUpdate(target.Version); err != nil {
 		logf("checkAutoAdvanceRelease: ReleaseUpdate(%s) failed: %v", target.Version, err)
@@ -579,6 +588,48 @@ func (o *Orchestrator) checkAutoAdvanceRelease() (bool, string) {
 	}
 
 	return true, target.Version
+}
+
+// releaseHasReadyRequirements returns true if any requirement from PRDs
+// referenced by the release's use case touchpoints is still "ready" in
+// requirements.yaml. This checks ALL requirements in each referenced PRD,
+// not just the R-groups cited by touchpoints, to catch orphaned R-items
+// that no UC touchpoint covers (GH-1952).
+func (o *Orchestrator) releaseHasReadyRequirements(useCases []RoadmapUseCase) bool {
+	states := generate.LoadRequirementStates(o.cfg.Cobbler.Dir)
+	if states == nil {
+		return false
+	}
+
+	// Collect all PRD stems referenced by this release's UC touchpoints.
+	prdStems := make(map[string]bool)
+	for _, uc := range useCases {
+		touchpoints := loadUCTouchpoints(uc.ID)
+		for _, tp := range touchpoints {
+			// extractTouchpointCitations is in the generate package and
+			// unexported; reuse the same regex pattern to extract PRD stems.
+			matches := generate.TouchpointPRDRefRe.FindAllStringSubmatch(tp, -1)
+			for _, m := range matches {
+				prdStems[m[1]] = true
+			}
+		}
+	}
+
+	// Check if any requirement in those PRDs is still ready.
+	for stem := range prdStems {
+		for prdKey, prdReqs := range states {
+			if prdKey != stem && !strings.HasPrefix(prdKey, stem+"-") {
+				continue
+			}
+			for id, st := range prdReqs {
+				if st.Status == "ready" {
+					logf("releaseHasReadyRequirements: %s %s is still ready", prdKey, id)
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // validateAndMarkUCs finds the first non-implemented release in road-map.yaml

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -1878,6 +1878,60 @@ releases:
 	}
 }
 
+func TestCheckAutoAdvanceRelease_ReadyRequirementsBlockAdvance(t *testing.T) {
+	dir := initTestGitRepo(t)
+
+	// Release 00.0: all UCs done, but a PRD requirement is still ready.
+	roadmapContent := `id: rm1
+title: Test Roadmap
+releases:
+  - version: "00.0"
+    name: Release 0
+    status: in_progress
+    use_cases:
+      - id: rel00.0-uc001-format
+        status: done
+        summary: Format output
+`
+	writeRoadmapFile(t, dir, roadmapContent)
+	cfgPath := filepath.Join(dir, DefaultConfigFile)
+	writeConfigFile(t, cfgPath, []string{"00.0"})
+
+	// Create a UC file with touchpoints referencing prd025.
+	ucDir := filepath.Join(dir, "docs", "specs", "use-cases")
+	os.MkdirAll(ucDir, 0o755)
+	ucContent := `id: rel00.0-uc001-format
+touchpoints:
+  - T1: "Format output prd025 R1, R2"
+`
+	os.WriteFile(filepath.Join(ucDir, "rel00.0-uc001-format.yaml"), []byte(ucContent), 0o644)
+
+	// Create requirements.yaml with a ready R-item in prd025 (R4 group,
+	// not cited by the UC touchpoint which only cites R1 and R2).
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+	reqContent := `requirements:
+  prd025-unexpand:
+    R1.1:
+      status: complete
+      issue: 100
+    R2.1:
+      status: complete
+      issue: 101
+    R4.3:
+      status: ready
+    R4.4:
+      status: ready
+`
+	os.WriteFile(filepath.Join(cobblerDir, "requirements.yaml"), []byte(reqContent), 0o644)
+
+	o := &Orchestrator{cfg: Config{Cobbler: CobblerConfig{Dir: ".cobbler/"}}}
+	advanced, _ := o.checkAutoAdvanceRelease()
+	if advanced {
+		t.Error("should not advance when PRD requirements are still ready")
+	}
+}
+
 // --- resetImplementedReleases (GH-1021) ---
 
 func TestResetImplementedReleases(t *testing.T) {

--- a/pkg/orchestrator/internal/generate/requirements.go
+++ b/pkg/orchestrator/internal/generate/requirements.go
@@ -355,8 +355,8 @@ type touchpointCitation struct {
 	groups []string // e.g. ["R1", "R2"]
 }
 
-// touchpointPRDRefRe matches PRD + R-group references in touchpoint text.
-var touchpointPRDRefRe = regexp.MustCompile(`(prd\d+[-\w]*)\s+(R\d+(?:\s*,\s*R\d+)*)`)
+// TouchpointPRDRefRe matches PRD + R-group references in touchpoint text.
+var TouchpointPRDRefRe = regexp.MustCompile(`(prd\d+[-\w]*)\s+(R\d+(?:\s*,\s*R\d+)*)`)
 
 // extractTouchpointCitations parses touchpoint strings to extract PRD
 // citations with their requirement groups.
@@ -364,7 +364,7 @@ func extractTouchpointCitations(touchpoints []string) []touchpointCitation {
 	var citations []touchpointCitation
 	seen := make(map[string]map[string]bool) // prdID → set of groups
 	for _, tp := range touchpoints {
-		matches := touchpointPRDRefRe.FindAllStringSubmatch(tp, -1)
+		matches := TouchpointPRDRefRe.FindAllStringSubmatch(tp, -1)
 		for _, m := range matches {
 			prdID := m[1]
 			groupStr := m[2]


### PR DESCRIPTION
## Summary

Prevents `checkAutoAdvanceRelease` from advancing a release when PRD requirements from that release's use cases are still `ready` in requirements.yaml. UC touchpoints may not cite every R-group in a PRD, leaving orphaned ready requirements that become invisible to the measure agent once the release is filtered from scope. The new `releaseHasReadyRequirements` gate catches these stragglers.

## Changes

- Added `releaseHasReadyRequirements()` helper in `generator.go` that loads requirements.yaml and checks all PRDs referenced by the release's UC touchpoints for any `ready` items
- Gate in `checkAutoAdvanceRelease()` blocks advance when ready requirements remain
- Exported `TouchpointPRDRefRe` regex from `generate` package for reuse
- Added `TestCheckAutoAdvanceRelease_ReadyRequirementsBlockAdvance` test
- Added PRD requirement R7.7 in prd003

## Stats

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| go_loc_prod | 19,491 | 19,388 | -103 |
| go_loc_test | 35,565 | 35,619 | +54 |
| spec_words (prd) | 9,457 | 9,507 | +50 |

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] Generate package tests pass (renamed regex variable)
- [x] New test verifies ready requirements block auto-advance

Closes #1952