### PR TITLE
GH-1953: Strip [stitch] prefix from measure-proposed titles

### DIFF
--- a/pkg/orchestrator/internal/github/issues.go
+++ b/pkg/orchestrator/internal/github/issues.go
@@ -598,7 +598,7 @@ func (t *GitHubTracker) FinalizeMeasurePlaceholder(repo string, number int, gene
 // issue URL (https://github.com/owner/repo/issues/123) on success.
 func (t *GitHubTracker) CreateCobblerIssue(repo, generation string, issue ProposedIssue) (int, error) {
 	body := FormatIssueFrontMatter(generation, issue.Index, issue.Dependency) + issue.Description
-	title := "[measure] " + issue.Title
+	title := "[measure] " + NormalizeIssueTitle(issue.Title)
 
 	genLabel := GenLabel(generation)
 	out, err := exec.Command(t.GhBin, "issue", "create",

--- a/pkg/orchestrator/internal/github/issues_test.go
+++ b/pkg/orchestrator/internal/github/issues_test.go
@@ -821,6 +821,8 @@ func TestNormalizeIssueTitle(t *testing.T) {
 		{"extra whitespace", "  [measure]  prd001: Implement Foo  ", "prd001: Implement Foo"},
 		{"empty string", "", ""},
 		{"prefix only", "[measure] ", "[measure]"},
+		{"double stitch", "[stitch] [stitch] prd001: Implement Foo", "[stitch] prd001: Implement Foo"},
+		{"stitch in proposed title", "[stitch] prd001: Implement Foo", "prd001: Implement Foo"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

Normalizes proposed issue titles in `CreateCobblerIssue` before adding the `[measure]` prefix. When Claude includes `[stitch]` in its proposed title, the existing `NormalizeIssueTitle()` function strips it, preventing the `[stitch] [stitch]` doubling observed in 40% of tasks in run 38.

## Changes

- Call `NormalizeIssueTitle(issue.Title)` before prefixing in `CreateCobblerIssue`
- Added test cases for double-prefix and stitch-in-proposed-title scenarios

## Test plan

- [x] All github package tests pass
- [x] New test cases verify double-prefix stripping

Closes #1953