### PR TITLE
GH-1960: Match bare PRD references in touchpoints for release advance check

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -602,15 +602,21 @@ func (o *Orchestrator) releaseHasReadyRequirements(useCases []RoadmapUseCase) bo
 	}
 
 	// Collect all PRD stems referenced by this release's UC touchpoints.
+	// TouchpointPRDRefRe matches "prdNNN-name R1, R2" (with R-groups).
+	// BarePRDRefRe matches "prdNNN-name" even without R-groups, catching
+	// touchpoints like "(prd096-users)" that omit R-group refs (GH-1960).
 	prdStems := make(map[string]bool)
 	for _, uc := range useCases {
 		touchpoints := loadUCTouchpoints(uc.ID)
 		for _, tp := range touchpoints {
-			// extractTouchpointCitations is in the generate package and
-			// unexported; reuse the same regex pattern to extract PRD stems.
 			matches := generate.TouchpointPRDRefRe.FindAllStringSubmatch(tp, -1)
 			for _, m := range matches {
 				prdStems[m[1]] = true
+			}
+			// Also match bare PRD references without R-groups.
+			bareMatches := generate.BarePRDRefRe.FindAllString(tp, -1)
+			for _, stem := range bareMatches {
+				prdStems[stem] = true
 			}
 		}
 	}

--- a/pkg/orchestrator/generator_test.go
+++ b/pkg/orchestrator/generator_test.go
@@ -1932,6 +1932,53 @@ touchpoints:
 	}
 }
 
+func TestCheckAutoAdvanceRelease_BarePRDRefBlocksAdvance(t *testing.T) {
+	dir := initTestGitRepo(t)
+
+	// Release 00.0: all UCs done, touchpoint cites PRD without R-groups.
+	roadmapContent := `id: rm1
+title: Test Roadmap
+releases:
+  - version: "00.0"
+    name: Release 0
+    status: in_progress
+    use_cases:
+      - id: rel00.0-uc001-users
+        status: done
+        summary: Users utility
+`
+	writeRoadmapFile(t, dir, roadmapContent)
+	cfgPath := filepath.Join(dir, DefaultConfigFile)
+	writeConfigFile(t, cfgPath, []string{"00.0"})
+
+	// UC touchpoint references prd096-users WITHOUT R-group citations.
+	ucDir := filepath.Join(dir, "docs", "specs", "use-cases")
+	os.MkdirAll(ucDir, 0o755)
+	ucContent := `id: rel00.0-uc001-users
+touchpoints:
+  - T1: "cmd/users — users prints logged-in usernames (prd096-users)"
+`
+	os.WriteFile(filepath.Join(ucDir, "rel00.0-uc001-users.yaml"), []byte(ucContent), 0o644)
+
+	// requirements.yaml has ready R-items in prd096-users.
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+	reqContent := `requirements:
+  prd096-users:
+    R1.1:
+      status: ready
+    R2.1:
+      status: ready
+`
+	os.WriteFile(filepath.Join(cobblerDir, "requirements.yaml"), []byte(reqContent), 0o644)
+
+	o := &Orchestrator{cfg: Config{Cobbler: CobblerConfig{Dir: ".cobbler/"}}}
+	advanced, _ := o.checkAutoAdvanceRelease()
+	if advanced {
+		t.Error("should not advance when bare PRD touchpoint has ready requirements (GH-1960)")
+	}
+}
+
 // --- resetImplementedReleases (GH-1021) ---
 
 func TestResetImplementedReleases(t *testing.T) {

--- a/pkg/orchestrator/internal/generate/requirements.go
+++ b/pkg/orchestrator/internal/generate/requirements.go
@@ -358,6 +358,11 @@ type touchpointCitation struct {
 // TouchpointPRDRefRe matches PRD + R-group references in touchpoint text.
 var TouchpointPRDRefRe = regexp.MustCompile(`(prd\d+[-\w]*)\s+(R\d+(?:\s*,\s*R\d+)*)`)
 
+// BarePRDRefRe matches bare PRD stems in touchpoint text, including those
+// without R-group references (e.g., "prd096-users" in parentheses). This
+// catches touchpoints that omit R-group citations (GH-1960).
+var BarePRDRefRe = regexp.MustCompile(`prd\d+[-\w]*`)
+
 // extractTouchpointCitations parses touchpoint strings to extract PRD
 // citations with their requirement groups.
 func extractTouchpointCitations(touchpoints []string) []touchpointCitation {


### PR DESCRIPTION
## Summary

Fixes a regression from GH-1952 where `releaseHasReadyRequirements` only matched PRD references with R-group citations (`prd025 R1, R2`), missing bare references like `(prd096-users)`. Releases with bare PRD touchpoints defaulted to "all implemented" and were skipped by the measure agent.

## Changes

- Added `BarePRDRefRe` regex in `generate` package matching `prd\d+[-\w]*` without requiring R-groups
- `releaseHasReadyRequirements` now uses both regexes to collect PRD stems
- Added test verifying bare PRD touchpoints block auto-advance when requirements are ready

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/ -count=1`)
- [x] New test verifies bare PRD ref blocks advance

Closes #1960