### PR TITLE
GH-1961: Flag bare PRD touchpoints in mage analyze

### DIFF
--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -359,6 +359,7 @@ completeness_checklists:
     - id matches filename without extension
     - flow steps are numbered (F1, F2, ...), end-to-end, map to real components
     - touchpoints are numbered (T1, T2, ...) and list interfaces, components, protocols
+    - touchpoints that cite PRDs must include R-group references (e.g., "prd030-md5sum R1, R2, R3"); bare PRD citations without R-groups break codereadiness computation
     - success_criteria are structured objects with id, criterion, and traces to PRD AC IDs
     - test_suite references a corresponding test suite ID
     - Test suite YAML exists and traces back to this use case

--- a/pkg/orchestrator/constitutions/design.yaml
+++ b/pkg/orchestrator/constitutions/design.yaml
@@ -359,6 +359,7 @@ completeness_checklists:
     - id matches filename without extension
     - flow steps are numbered (F1, F2, ...), end-to-end, map to real components
     - touchpoints are numbered (T1, T2, ...) and list interfaces, components, protocols
+    - touchpoints that cite PRDs must include R-group references (e.g., "prd030-md5sum R1, R2, R3"); bare PRD citations without R-groups break codereadiness computation
     - success_criteria are structured objects with id, criterion, and traces to PRD AC IDs
     - test_suite references a corresponding test suite ID
     - Test suite YAML exists and traces back to this use case

--- a/pkg/orchestrator/internal/analysis/analyze.go
+++ b/pkg/orchestrator/internal/analysis/analyze.go
@@ -38,6 +38,7 @@ type AnalyzeResult struct {
 	UnreachableUCs                 []string // UCs whose touchpoint PRDs have no R-items (warning)
 	FailedRequirements             []string // R-items marked complete_with_failures (warning)
 	MissingWeights                 []string // R-items without explicit weight annotation (warning, GH-1946)
+	BareTouchpoints                []string // Touchpoints citing PRDs without R-group references (warning, GH-1961)
 }
 
 // AnalyzeCounts holds the artifact counts discovered during analysis.
@@ -309,6 +310,17 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 		}
 	}
 	deps.Log("analyze: broken citations found %d", len(result.BrokenCitations))
+
+	// Check 6b: Bare touchpoints (PRD cited without R-group references, GH-1961).
+	// This breaks codereadiness computation and requirement traceability.
+	for ucID, tps := range ucTouchpoints {
+		for _, cite := range ExtractCitationsFromTouchpoints(tps) {
+			if len(cite.Groups) == 0 {
+				result.BareTouchpoints = append(result.BareTouchpoints,
+					fmt.Sprintf("%s: cites %s without R-group references", ucID, cite.PRDID))
+			}
+		}
+	}
 
 	// Check 9: PRDs spanning multiple releases
 	for prdID, releases := range prdToReleases {
@@ -584,6 +596,7 @@ func (r AnalyzeResult) PrintReport(prdCount, ucCount, tsCount, smCount int) erro
 	PrintSection("Unreachable UCs (touchpoint PRDs have no R-items — warning)", r.UnreachableUCs)
 	PrintSection("Failed requirements (R-items complete with test failures — warning)", r.FailedRequirements)
 	PrintSection("Missing weights (R-items without explicit weight annotation — warning)", r.MissingWeights)
+	PrintSection("Bare touchpoints (PRD cited without R-group references — warning)", r.BareTouchpoints)
 
 	if !hasIssues {
 		fmt.Printf("\n✅ All consistency checks passed\n")

--- a/pkg/orchestrator/internal/analysis/analyze_test.go
+++ b/pkg/orchestrator/internal/analysis/analyze_test.go
@@ -1793,3 +1793,76 @@ func TestCollectAnalyzeResult_UnreachableUC_MissingPRD(t *testing.T) {
 		t.Fatalf("expected 1 unreachable UC, got %d: %v", len(result.UnreachableUCs), result.UnreachableUCs)
 	}
 }
+
+// --- Check 6b: Bare touchpoints (GH-1961) ---
+
+func TestCollectAnalyzeResult_BareTouchpoint_FlagsMissingRGroups(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	os.MkdirAll("docs/specs/product-requirements", 0o755)
+	os.MkdirAll("docs/specs/use-cases", 0o755)
+	os.MkdirAll("docs/specs/test-suites", 0o755)
+	os.MkdirAll("docs/constitutions", 0o755)
+	os.MkdirAll("pkg/orchestrator/constitutions", 0o755)
+
+	// PRD with R-items.
+	prd := "id: prd096-users\ntitle: Users\nrequirements:\n  R1:\n    title: Core\n    items:\n      - R1.1: Must print users\n"
+	os.WriteFile("docs/specs/product-requirements/prd096-users.yaml", []byte(prd), 0o644)
+
+	// UC that cites PRD WITHOUT R-group references.
+	uc := "id: rel01.0-uc001-users\ntitle: Users\ntouchpoints:\n  - T1: \"cmd/users — prints logged-in usernames (prd096-users)\"\n"
+	os.WriteFile("docs/specs/use-cases/rel01.0-uc001-users.yaml", []byte(uc), 0o644)
+
+	roadmap := "id: rm\ntitle: R\nreleases:\n  - version: \"01.0\"\n    name: R1\n    status: pending\n    use_cases:\n      - id: rel01.0-uc001-users\n        summary: Users\n"
+	os.WriteFile("docs/road-map.yaml", []byte(roadmap), 0o644)
+	os.WriteFile("docs/specs/test-suites/test-rel01.0.yaml",
+		[]byte("id: test-rel01.0\ntitle: T\ntraces:\n  - rel01.0-uc001-users\n"), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BareTouchpoints) != 1 {
+		t.Fatalf("expected 1 bare touchpoint, got %d: %v", len(result.BareTouchpoints), result.BareTouchpoints)
+	}
+	if !strings.Contains(result.BareTouchpoints[0], "prd096-users") {
+		t.Errorf("expected bare touchpoint to mention prd096-users, got %q", result.BareTouchpoints[0])
+	}
+}
+
+func TestCollectAnalyzeResult_BareTouchpoint_NotFlaggedWithRGroups(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+
+	os.MkdirAll("docs/specs/product-requirements", 0o755)
+	os.MkdirAll("docs/specs/use-cases", 0o755)
+	os.MkdirAll("docs/specs/test-suites", 0o755)
+	os.MkdirAll("docs/constitutions", 0o755)
+	os.MkdirAll("pkg/orchestrator/constitutions", 0o755)
+
+	prd := "id: prd096-users\ntitle: Users\nrequirements:\n  R1:\n    title: Core\n    items:\n      - R1.1: Must print users\n"
+	os.WriteFile("docs/specs/product-requirements/prd096-users.yaml", []byte(prd), 0o644)
+
+	// UC that cites PRD WITH R-group references — no warning expected.
+	uc := "id: rel01.0-uc001-users\ntitle: Users\ntouchpoints:\n  - T1: \"cmd/users — prints usernames (prd096-users R1)\"\n"
+	os.WriteFile("docs/specs/use-cases/rel01.0-uc001-users.yaml", []byte(uc), 0o644)
+
+	roadmap := "id: rm\ntitle: R\nreleases:\n  - version: \"01.0\"\n    name: R1\n    status: pending\n    use_cases:\n      - id: rel01.0-uc001-users\n        summary: Users\n"
+	os.WriteFile("docs/road-map.yaml", []byte(roadmap), 0o644)
+	os.WriteFile("docs/specs/test-suites/test-rel01.0.yaml",
+		[]byte("id: test-rel01.0\ntitle: T\ntraces:\n  - rel01.0-uc001-users\n"), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BareTouchpoints) != 0 {
+		t.Errorf("expected 0 bare touchpoints when R-groups present, got %d: %v",
+			len(result.BareTouchpoints), result.BareTouchpoints)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a warning in `mage analyze` when use case touchpoints cite PRDs without R-group references. Bare citations like `(prd096-users)` break codereadiness computation (GH-1960) and weaken requirement traceability. Also updates the design constitution to require R-group references in touchpoints.

## Changes

- Added `BareTouchpoints` field to `AnalyzeResult` and Check 6b in `CollectAnalyzeResult`
- Print as warning: "Bare touchpoints (PRD cited without R-group references)"
- Updated design constitution use-case completeness checklist
- Synced embedded constitution copy
- Added 2 tests: flagged when R-groups missing, not flagged when present

## Test plan

- [x] `mage analyze` passes
- [x] All analysis package tests pass
- [x] New test verifies bare touchpoint detection
- [x] New test verifies proper citations are not flagged

Closes #1961