### PR TITLE
GH-1968: Add interface constitution + mage analysis checks for PRD interface relations

### DIFF
--- a/docs/constitutions/interface.yaml
+++ b/docs/constitutions/interface.yaml
@@ -1,0 +1,103 @@
+# Interface Constitution
+#
+# This constitution governs the definition, naming, and traceability of
+# interfaces in the architecture and PRDs. It is scaffolded into consuming
+# projects so Claude knows how to write well-formed interface specifications
+# and how PRDs reference interfaces.
+
+articles:
+  - id: I1
+    title: Interfaces live in ARCHITECTURE.yaml
+    rule: |
+      Every interface is declared in the interfaces section of
+      ARCHITECTURE.yaml. An interface groups related data structures and
+      operations under a name that components reference. Interfaces are not
+      declared in PRDs; PRDs reference interfaces defined in the architecture.
+
+  - id: I2
+    title: Required interface fields
+    rule: |
+      Every interface entry must have a name and a summary. The name is a
+      short, unique identifier (e.g., "Orchestrator and Config", "Prompt
+      Templates"). The summary describes what the interface provides in one
+      to three sentences. Optional fields are data_structures (list of type
+      names with brief descriptions) and operations (list of method or
+      function signatures).
+
+  - id: I3
+    title: Naming conventions
+    rule: |
+      Interface names use title case with spaces (e.g., "Generation
+      Lifecycle", "Issue Tracker"). Names must be unique within
+      ARCHITECTURE.yaml. Abbreviations are permitted when the abbreviation
+      is standard in the domain (e.g., "OOD" for object-oriented design),
+      but must be explained in the summary on first use.
+
+  - id: I4
+    title: PRD interface references
+    rule: |
+      PRDs may declare interface relationships using two optional fields:
+      implemented_by and used_by. Both are lists of interface names that
+      must resolve to entries in ARCHITECTURE.yaml's interfaces section.
+
+      implemented_by declares that the PRD's requirements define the
+      implementation of the named interface. The PRD's package_contract
+      exports correspond to the interface's operations.
+
+      used_by declares that the PRD's implementation consumes the named
+      interface. The PRD depends on the interface being available but does
+      not define it.
+
+      A single PRD may appear in both lists for different interfaces. An
+      interface may be implemented by one PRD and used by many.
+
+  - id: I5
+    title: Port and adapter semantics
+    rule: |
+      Interfaces follow the ports and adapters pattern. The interface
+      declaration in ARCHITECTURE.yaml is the port: it defines the
+      contract without specifying implementation. PRDs that list the
+      interface in implemented_by are adapters: they provide a concrete
+      implementation of the port.
+
+      This separation means changing an adapter (rewriting a PRD's
+      implementation) does not change the port (the interface definition).
+      Consumers that reference the interface via used_by depend on the
+      port, not the adapter. Analysis enforces that every referenced
+      interface name resolves to a declared port.
+
+  - id: I6
+    title: Interface traceability
+    rule: |
+      The traceability chain for interfaces runs: ARCHITECTURE.yaml
+      (declares the interface) -> PRD implemented_by (provides the
+      implementation) -> PRD used_by (consumes the interface). Analysis
+      validates both directions: every name in implemented_by and used_by
+      must match an interface name in ARCHITECTURE.yaml. Broken references
+      fail the analysis check.
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Six principles govern interface specifications: interfaces live in
+      ARCHITECTURE.yaml (I1), required fields are name and summary (I2),
+      names use title case and must be unique (I3), PRDs reference
+      interfaces via implemented_by and used_by (I4), interfaces follow
+      ports and adapters semantics (I5), and traceability runs from
+      architecture through PRDs (I6).
+  - tag: structure
+    title: Interface Structure
+    content: |
+      An interface entry in ARCHITECTURE.yaml is a YAML mapping with four
+      fields: name (required), summary (required), data_structures
+      (optional list), and operations (optional list). PRDs reference
+      interfaces by name using implemented_by and used_by string lists.
+  - tag: validation
+    title: Analysis Validation
+    content: |
+      The mage analyze target validates interface references. Every entry
+      in a PRD's implemented_by and used_by lists must match the name
+      field of an interface in ARCHITECTURE.yaml. Unresolved references
+      are reported as errors. Missing or empty interface lists are not
+      errors; the fields are optional.

--- a/pkg/orchestrator/analyze.go
+++ b/pkg/orchestrator/analyze.go
@@ -73,6 +73,7 @@ func (o *Orchestrator) validateDocSchemas() []string {
 	errs = append(errs, validateYAMLStrict[ExecutionDoc]("docs/constitutions/execution.yaml")...)
 	errs = append(errs, validateYAMLStrict[GoStyleDoc]("docs/constitutions/go-style.yaml")...)
 	errs = append(errs, validateYAMLStrict[PlanningDoc]("docs/constitutions/planning.yaml")...)
+	errs = append(errs, validateYAMLStrict[InterfaceDoc]("docs/constitutions/interface.yaml")...)
 	errs = append(errs, validateYAMLStrict[SemanticModelDoc]("docs/constitutions/semantic-model.yaml")...)
 	errs = append(errs, validateYAMLStrict[TestingDoc]("docs/constitutions/testing.yaml")...)
 
@@ -80,6 +81,7 @@ func (o *Orchestrator) validateDocSchemas() []string {
 	errs = append(errs, validateYAMLStrict[DesignDoc]("pkg/orchestrator/constitutions/design.yaml")...)
 	errs = append(errs, validateYAMLStrict[ExecutionDoc]("pkg/orchestrator/constitutions/execution.yaml")...)
 	errs = append(errs, validateYAMLStrict[GoStyleDoc]("pkg/orchestrator/constitutions/go-style.yaml")...)
+	errs = append(errs, validateYAMLStrict[InterfaceDoc]("pkg/orchestrator/constitutions/interface.yaml")...)
 	errs = append(errs, validateYAMLStrict[IssueFormatDoc]("pkg/orchestrator/constitutions/issue-format.yaml")...)
 	errs = append(errs, validateYAMLStrict[PlanningDoc]("pkg/orchestrator/constitutions/planning.yaml")...)
 	errs = append(errs, validateYAMLStrict[TestingDoc]("pkg/orchestrator/constitutions/testing.yaml")...)

--- a/pkg/orchestrator/constitutions/interface.yaml
+++ b/pkg/orchestrator/constitutions/interface.yaml
@@ -1,0 +1,103 @@
+# Interface Constitution
+#
+# This constitution governs the definition, naming, and traceability of
+# interfaces in the architecture and PRDs. It is scaffolded into consuming
+# projects so Claude knows how to write well-formed interface specifications
+# and how PRDs reference interfaces.
+
+articles:
+  - id: I1
+    title: Interfaces live in ARCHITECTURE.yaml
+    rule: |
+      Every interface is declared in the interfaces section of
+      ARCHITECTURE.yaml. An interface groups related data structures and
+      operations under a name that components reference. Interfaces are not
+      declared in PRDs; PRDs reference interfaces defined in the architecture.
+
+  - id: I2
+    title: Required interface fields
+    rule: |
+      Every interface entry must have a name and a summary. The name is a
+      short, unique identifier (e.g., "Orchestrator and Config", "Prompt
+      Templates"). The summary describes what the interface provides in one
+      to three sentences. Optional fields are data_structures (list of type
+      names with brief descriptions) and operations (list of method or
+      function signatures).
+
+  - id: I3
+    title: Naming conventions
+    rule: |
+      Interface names use title case with spaces (e.g., "Generation
+      Lifecycle", "Issue Tracker"). Names must be unique within
+      ARCHITECTURE.yaml. Abbreviations are permitted when the abbreviation
+      is standard in the domain (e.g., "OOD" for object-oriented design),
+      but must be explained in the summary on first use.
+
+  - id: I4
+    title: PRD interface references
+    rule: |
+      PRDs may declare interface relationships using two optional fields:
+      implemented_by and used_by. Both are lists of interface names that
+      must resolve to entries in ARCHITECTURE.yaml's interfaces section.
+
+      implemented_by declares that the PRD's requirements define the
+      implementation of the named interface. The PRD's package_contract
+      exports correspond to the interface's operations.
+
+      used_by declares that the PRD's implementation consumes the named
+      interface. The PRD depends on the interface being available but does
+      not define it.
+
+      A single PRD may appear in both lists for different interfaces. An
+      interface may be implemented by one PRD and used by many.
+
+  - id: I5
+    title: Port and adapter semantics
+    rule: |
+      Interfaces follow the ports and adapters pattern. The interface
+      declaration in ARCHITECTURE.yaml is the port: it defines the
+      contract without specifying implementation. PRDs that list the
+      interface in implemented_by are adapters: they provide a concrete
+      implementation of the port.
+
+      This separation means changing an adapter (rewriting a PRD's
+      implementation) does not change the port (the interface definition).
+      Consumers that reference the interface via used_by depend on the
+      port, not the adapter. Analysis enforces that every referenced
+      interface name resolves to a declared port.
+
+  - id: I6
+    title: Interface traceability
+    rule: |
+      The traceability chain for interfaces runs: ARCHITECTURE.yaml
+      (declares the interface) -> PRD implemented_by (provides the
+      implementation) -> PRD used_by (consumes the interface). Analysis
+      validates both directions: every name in implemented_by and used_by
+      must match an interface name in ARCHITECTURE.yaml. Broken references
+      fail the analysis check.
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Six principles govern interface specifications: interfaces live in
+      ARCHITECTURE.yaml (I1), required fields are name and summary (I2),
+      names use title case and must be unique (I3), PRDs reference
+      interfaces via implemented_by and used_by (I4), interfaces follow
+      ports and adapters semantics (I5), and traceability runs from
+      architecture through PRDs (I6).
+  - tag: structure
+    title: Interface Structure
+    content: |
+      An interface entry in ARCHITECTURE.yaml is a YAML mapping with four
+      fields: name (required), summary (required), data_structures
+      (optional list), and operations (optional list). PRDs reference
+      interfaces by name using implemented_by and used_by string lists.
+  - tag: validation
+    title: Analysis Validation
+    content: |
+      The mage analyze target validates interface references. Every entry
+      in a PRD's implemented_by and used_by lists must match the name
+      field of an interface in ARCHITECTURE.yaml. Unresolved references
+      are reported as errors. Missing or empty interface lists are not
+      errors; the fields are optional.

--- a/pkg/orchestrator/context.go
+++ b/pkg/orchestrator/context.go
@@ -133,6 +133,9 @@ type TestingDoc = ctx.TestingDoc
 // Semantic model types.
 type SemanticModelDoc = ctx.SemanticModelDoc
 
+// Interface constitution types.
+type InterfaceDoc = ctx.InterfaceDoc
+
 // Issue format types.
 type IssueFormatDoc = ctx.IssueFormatDoc
 type IssueFormatSchema = ctx.IssueFormatSchema

--- a/pkg/orchestrator/internal/analysis/analyze.go
+++ b/pkg/orchestrator/internal/analysis/analyze.go
@@ -40,6 +40,7 @@ type AnalyzeResult struct {
 	MissingWeights                 []string // R-items without explicit weight annotation (warning, GH-1946)
 	BareTouchpoints                []string // Touchpoints citing PRDs without R-group references (warning, GH-1961)
 	UCIDPrefixMismatch             []string // Use case ID prefix doesn't match assigned release in roadmap (GH-1964)
+	BrokenInterfaceRefs            []string // implemented_by/used_by references non-existent architecture interface (GH-1968)
 }
 
 // AnalyzeCounts holds the artifact counts discovered during analysis.
@@ -77,6 +78,7 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 	prdStructRefs := make(map[string][]PRDStructRef)     // PRD ID -> struct_refs entries
 	prdACs := make(map[string][]AcceptanceCriterion)     // PRD ID -> acceptance criteria
 	prdRItems := make(map[string][]string)               // PRD ID -> all R-item IDs (R1.1, R1.2, etc.)
+	prdInterfaceRefs := make(map[string][]string)        // PRD ID -> all interface names from implemented_by + used_by
 	for _, path := range prdFiles {
 		id := ExtractID(path)
 		if id != "" {
@@ -123,6 +125,12 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 			}
 			if len(prd.StructRefs) > 0 {
 				prdStructRefs[id] = prd.StructRefs
+			}
+			var ifaceRefs []string
+			ifaceRefs = append(ifaceRefs, prd.ImplementedBy...)
+			ifaceRefs = append(ifaceRefs, prd.UsedBy...)
+			if len(ifaceRefs) > 0 {
+				prdInterfaceRefs[id] = ifaceRefs
 			}
 		}
 	}
@@ -436,6 +444,25 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 	sort.Strings(result.ComponentDepViolations)
 	deps.Log("analyze: component_dep violations found %d", len(result.ComponentDepViolations))
 
+	// Check 20: interface references — implemented_by/used_by must resolve to
+	// an interface name in ARCHITECTURE.yaml (GH-1968).
+	if archDoc != nil && len(prdInterfaceRefs) > 0 {
+		archIfaceNames := make(map[string]bool)
+		for _, iface := range archDoc.Interfaces {
+			archIfaceNames[iface.Name] = true
+		}
+		for prdID, refs := range prdInterfaceRefs {
+			for _, ref := range refs {
+				if !archIfaceNames[ref] {
+					result.BrokenInterfaceRefs = append(result.BrokenInterfaceRefs,
+						fmt.Sprintf("%s: interface %q not found in ARCHITECTURE.yaml", prdID, ref))
+				}
+			}
+		}
+	}
+	sort.Strings(result.BrokenInterfaceRefs)
+	deps.Log("analyze: broken interface refs found %d", len(result.BrokenInterfaceRefs))
+
 	// Check 15: R-item coverage by acceptance criteria.
 	// Every R-item in a PRD should appear in at least one AC's traces list.
 	for prdID, rItems := range prdRItems {
@@ -603,6 +630,7 @@ func (r AnalyzeResult) PrintReport(prdCount, ucCount, tsCount, smCount int) erro
 	hasIssues = PrintSection("component_dependencies gaps (depends_on entries missing from component_dependencies)", r.ComponentDepViolations) || hasIssues
 	hasIssues = PrintSection("Semantic model errors (SM1 sections, SM3 traceability, SM7 naming)", r.SemanticModelErrors) || hasIssues
 	hasIssues = PrintSection("Use case ID prefix mismatch (ID prefix does not match assigned release in roadmap)", r.UCIDPrefixMismatch) || hasIssues
+	hasIssues = PrintSection("Broken interface refs (implemented_by/used_by references non-existent architecture interface)", r.BrokenInterfaceRefs) || hasIssues
 	hasIssues = PrintSection("Uncovered R-items (R-item not traced by any acceptance criterion)", r.UncoveredRItems) || hasIssues
 	PrintSection("Uncovered ACs (AC not covered by any test case — warning)", r.UncoveredACs)
 	PrintSection("Untraced success criteria (S-item with no AC trace — warning)", r.UntracedSuccessCriteria)

--- a/pkg/orchestrator/internal/analysis/analyze_test.go
+++ b/pkg/orchestrator/internal/analysis/analyze_test.go
@@ -1978,3 +1978,150 @@ func TestCollectAnalyzeResult_UCIDPrefixMismatch_Multiple(t *testing.T) {
 			len(result.UCIDPrefixMismatch), result.UCIDPrefixMismatch)
 	}
 }
+
+// --- Check 20: interface reference validation (GH-1968) ---
+
+func TestCollectAnalyzeResult_BrokenInterfaceRef_Missing(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	os.WriteFile("docs/ARCHITECTURE.yaml", []byte(`id: arch
+title: Arch
+interfaces:
+  - name: Orchestrator and Config
+    summary: Entry point
+`), 0o644)
+	os.WriteFile("docs/specs/product-requirements/prd001-core.yaml", []byte(`id: prd001-core
+title: Core
+implemented_by:
+  - Nonexistent Interface
+`), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BrokenInterfaceRefs) != 1 {
+		t.Fatalf("expected 1 broken interface ref, got %d: %v",
+			len(result.BrokenInterfaceRefs), result.BrokenInterfaceRefs)
+	}
+	if !strings.Contains(result.BrokenInterfaceRefs[0], "Nonexistent Interface") {
+		t.Errorf("violation should mention Nonexistent Interface, got %q", result.BrokenInterfaceRefs[0])
+	}
+}
+
+func TestCollectAnalyzeResult_BrokenInterfaceRef_UsedByMissing(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	os.WriteFile("docs/ARCHITECTURE.yaml", []byte(`id: arch
+title: Arch
+interfaces:
+  - name: Prompt Templates
+    summary: Templates
+`), 0o644)
+	os.WriteFile("docs/specs/product-requirements/prd001-core.yaml", []byte(`id: prd001-core
+title: Core
+used_by:
+  - Missing Interface
+`), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BrokenInterfaceRefs) != 1 {
+		t.Fatalf("expected 1 broken interface ref, got %d: %v",
+			len(result.BrokenInterfaceRefs), result.BrokenInterfaceRefs)
+	}
+	if !strings.Contains(result.BrokenInterfaceRefs[0], "Missing Interface") {
+		t.Errorf("violation should mention Missing Interface, got %q", result.BrokenInterfaceRefs[0])
+	}
+}
+
+func TestCollectAnalyzeResult_InterfaceRef_Valid(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	os.WriteFile("docs/ARCHITECTURE.yaml", []byte(`id: arch
+title: Arch
+interfaces:
+  - name: Orchestrator and Config
+    summary: Entry point
+  - name: Prompt Templates
+    summary: Templates
+`), 0o644)
+	os.WriteFile("docs/specs/product-requirements/prd001-core.yaml", []byte(`id: prd001-core
+title: Core
+implemented_by:
+  - Orchestrator and Config
+used_by:
+  - Prompt Templates
+`), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BrokenInterfaceRefs) != 0 {
+		t.Errorf("expected no broken interface refs, got %v", result.BrokenInterfaceRefs)
+	}
+}
+
+func TestCollectAnalyzeResult_InterfaceRef_NoArchDoc(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	// No ARCHITECTURE.yaml — interface refs should not cause errors
+	os.WriteFile("docs/specs/product-requirements/prd001-core.yaml", []byte(`id: prd001-core
+title: Core
+implemented_by:
+  - Some Interface
+`), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BrokenInterfaceRefs) != 0 {
+		t.Errorf("expected no violations without ARCHITECTURE.yaml, got %v", result.BrokenInterfaceRefs)
+	}
+}
+
+func TestCollectAnalyzeResult_InterfaceRef_NoRefs(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	os.WriteFile("docs/ARCHITECTURE.yaml", []byte(`id: arch
+title: Arch
+interfaces:
+  - name: Orchestrator and Config
+    summary: Entry point
+`), 0o644)
+	os.WriteFile("docs/specs/product-requirements/prd001-core.yaml", []byte(`id: prd001-core
+title: Core
+`), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BrokenInterfaceRefs) != 0 {
+		t.Errorf("expected no violations when PRDs have no interface refs, got %v", result.BrokenInterfaceRefs)
+	}
+}

--- a/pkg/orchestrator/internal/analysis/types.go
+++ b/pkg/orchestrator/internal/analysis/types.go
@@ -46,6 +46,8 @@ type PRDDoc struct {
 	PackageContract    *PRDPackageContract            `yaml:"package_contract,omitempty"`
 	DependsOn          []PRDDependsOn                 `yaml:"depends_on,omitempty"`
 	StructRefs         []PRDStructRef                 `yaml:"struct_refs,omitempty"`
+	ImplementedBy      []string                       `yaml:"implemented_by,omitempty"`
+	UsedBy             []string                       `yaml:"used_by,omitempty"`
 }
 
 // AcceptanceCriterion is a structured acceptance criterion with an ID,
@@ -97,8 +99,14 @@ type PRDStructRef struct {
 // ArchitectureDoc corresponds to docs/ARCHITECTURE.yaml
 // (analysis-relevant fields).
 type ArchitectureDoc struct {
+	Interfaces            []ArchInterface           `yaml:"interfaces,omitempty"`
 	ComponentDependencies []ArchComponentDependency `yaml:"component_dependencies,omitempty"`
 	DependencyRules       []ArchDependencyRule      `yaml:"dependency_rules,omitempty"`
+}
+
+// ArchInterface is an interface entry from ARCHITECTURE.yaml.
+type ArchInterface struct {
+	Name string `yaml:"name"`
 }
 
 // ArchComponentDependency is a single dependency edge in the architecture.

--- a/pkg/orchestrator/internal/context/context.go
+++ b/pkg/orchestrator/internal/context/context.go
@@ -428,6 +428,8 @@ type PRDDoc struct {
 	PackageContract    *PRDPackageContract            `yaml:"package_contract,omitempty"`
 	DependsOn          []PRDDependsOn                 `yaml:"depends_on,omitempty"`
 	StructRefs         []PRDStructRef                 `yaml:"struct_refs,omitempty"`
+	ImplementedBy      []string                       `yaml:"implemented_by,omitempty"`
+	UsedBy             []string                       `yaml:"used_by,omitempty"`
 	SemanticModel      *yaml.Node                     `yaml:"semantic_model,omitempty"`
 }
 
@@ -940,6 +942,17 @@ type TestingDoc struct {
 // SemanticModelDoc corresponds to docs/constitutions/semantic-model.yaml.
 // The constitution only defines articles and sections — no additional sections.
 type SemanticModelDoc struct {
+	Articles []ConstitutionArticle `yaml:"articles"`
+	Sections []ConstitutionSection `yaml:"sections,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Interface constitution (docs/constitutions/interface.yaml)
+// ---------------------------------------------------------------------------
+
+// InterfaceDoc corresponds to docs/constitutions/interface.yaml.
+// The constitution defines articles and sections for interface governance.
+type InterfaceDoc struct {
 	Articles []ConstitutionArticle `yaml:"articles"`
 	Sections []ConstitutionSection `yaml:"sections,omitempty"`
 }


### PR DESCRIPTION
## Summary

Adds an interface constitution defining governance rules for interface specifications in ARCHITECTURE.yaml, and a new analysis check that validates PRD `implemented_by`/`used_by` fields resolve to declared architecture interfaces.

## Changes

- Created `docs/constitutions/interface.yaml` with 6 articles (I1–I6): interface location, required fields, naming conventions, PRD reference semantics, ports and adapters, traceability
- Copied constitution to `pkg/orchestrator/constitutions/interface.yaml` for scaffolding
- Added `ImplementedBy` and `UsedBy` optional string-list fields to `PRDDoc` (both context and analysis packages)
- Added `Interfaces` field to analysis `ArchitectureDoc` to load interface names
- Added Check 20 in analysis pipeline: validates every `implemented_by`/`used_by` entry matches an interface name in ARCHITECTURE.yaml
- Added `BrokenInterfaceRefs` to `AnalyzeResult` with corresponding `PrintReport` output
- Added both constitution files to `validateDocSchemas` strict YAML validation
- 5 new tests covering: broken implemented_by, broken used_by, valid refs, missing ARCHITECTURE.yaml, no interface refs

## Stats

- +201 lines across 8 files
- go_loc_prod: 19,492 | go_loc_test: 36,000

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)
- [x] New interface ref tests pass (5/5)

Closes #1968