### PR TITLE
GH-1967: stats:generator: show attempt count per task and aggregate retry totals

### DIFF
--- a/pkg/orchestrator/internal/stats/generator_stats.go
+++ b/pkg/orchestrator/internal/stats/generator_stats.go
@@ -26,17 +26,19 @@ type GeneratorIssueStats struct {
 	Status         string  // "done", "failed", "in-progress", "pending"
 	CostUSD        float64
 	DurationS      int
-	DurationAPIMs  int // Claude API execution time in ms (SDK mode, GH-1708)
-	RateLimitWaitS int // seconds spent waiting on API rate limits (GH-1805)
+	DurationAPIMs  int     // Claude API execution time in ms (SDK mode, GH-1708)
+	RateLimitWaitS int     // seconds spent waiting on API rate limits (GH-1805)
 	NumTurns       int
 	LocDeltaProd   int
 	LocDeltaTest   int
-	NumReqs        int // number of requirements in the task description
-	TotalWeight    int // sum of PRD weights for the task's R-items (GH-1832)
-	InputTokens    int // total input tokens from history stats
-	OutputTokens   int // total output tokens from history stats
+	NumReqs        int     // number of requirements in the task description
+	TotalWeight    int     // sum of PRD weights for the task's R-items (GH-1832)
+	InputTokens    int     // total input tokens from history stats
+	OutputTokens   int     // total output tokens from history stats
+	Attempts       int     // number of stitch invocations for this task (GH-1967)
+	FailedCostUSD  float64 // cost from failed attempts (GH-1967)
 	PRDs           []string
-	Release        string // roadmap release version, e.g. "01.0"
+	Release        string  // roadmap release version, e.g. "01.0"
 }
 
 // GeneratorStatsDeps holds dependencies for generator stats collection.
@@ -128,8 +130,10 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		OutputTokens   int
 		LocDeltaProd   int
 		LocDeltaTest   int
-		LastStatus     string // last history entry status: "success" or "failed"
-		StartedAt      string // earliest StartedAt for chronological ordering
+		LastStatus     string  // last history entry status: "success" or "failed"
+		StartedAt      string  // earliest StartedAt for chronological ordering
+		Attempts       int     // number of stitch invocations (GH-1967)
+		FailedCostUSD  float64 // cost from failed invocations (GH-1967)
 	}
 	stitchByTask := make(map[string]*stitchAgg)
 	var taskOrder []string // insertion order for deterministic iteration
@@ -162,7 +166,11 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 			if hs.TaskTitle != "" {
 				agg.Title = hs.TaskTitle
 			}
+			agg.Attempts++
 			agg.CostUSD += hs.CostUSD
+			if hs.Status == "failed" {
+				agg.FailedCostUSD += hs.CostUSD
+			}
 			if hs.DurationS > agg.DurationS {
 				agg.DurationS = hs.DurationS
 			}
@@ -231,6 +239,8 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	var totalStitchDurS, totalStitchAPIMs, totalRateLimitWaitS int
 	var totalTurns, totalLocProd, totalLocTest, totalReqs, totalWeight int
 	var totalInputTokens, totalOutputTokens int
+	var totalAttempts int
+	var totalFailedCost float64
 	var nDone, nFailed, nSkipped, nInProgress, nPending int
 	prdStatus := make(map[string]string) // prd name → highest-priority status
 	prdReleaseMap := BuildPRDReleaseMap()
@@ -256,6 +266,8 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 			OutputTokens:   agg.OutputTokens,
 			LocDeltaProd:   agg.LocDeltaProd,
 			LocDeltaTest:   agg.LocDeltaTest,
+			Attempts:       agg.Attempts,
+			FailedCostUSD:  agg.FailedCostUSD,
 		}
 
 		// Derive status from history; override with GitHub data when available.
@@ -309,6 +321,8 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		totalLocTest += s.LocDeltaTest
 		totalInputTokens += s.InputTokens
 		totalOutputTokens += s.OutputTokens
+		totalAttempts += s.Attempts
+		totalFailedCost += s.FailedCostUSD
 
 		s.NumReqs = CountDescriptionReqs(s.Description)
 		totalReqs += s.NumReqs
@@ -433,6 +447,16 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		fmt.Printf(", %s rate-limited", FormatDuration(totalRateLimitWaitS))
 	}
 	fmt.Println()
+	nTasks := nDone + nFailed + nSkipped + nInProgress + nPending
+	totalRetries := totalAttempts - nTasks
+	if totalRetries < 0 {
+		totalRetries = 0
+	}
+	if totalAttempts > nTasks {
+		retryRate := float64(totalRetries) * 100 / float64(totalAttempts)
+		fmt.Printf("Retries: %d retries across %d attempts (%.0f%%), $%.2f wasted\n",
+			totalRetries, totalAttempts, retryRate, totalFailedCost)
+	}
 	fmt.Printf("LOC created: %+d prod, %+d test\n", totalLocProd, totalLocTest)
 	fmt.Printf("Requirements: %d total in tasks\n", totalReqs)
 	combinedIn := totalInputTokens + totalMeasureIn
@@ -495,6 +519,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		ID        string
 		Status    string
 		Started   string // display-formatted StartedAt timestamp (GH-1884)
+		Att       string // attempt count (GH-1967)
 		Rel       string
 		Reqs      string
 		Weight    string // total weight from PRD annotations (GH-1832)
@@ -532,6 +557,10 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 		}
 		if tr.Rel == "" {
 			tr.Rel = "-"
+		}
+		tr.Att = "-"
+		if r.Attempts > 0 {
+			tr.Att = strconv.Itoa(r.Attempts)
 		}
 		tr.Cost = "-"
 		if r.CostUSD > 0 {
@@ -599,6 +628,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 			ID:        mid,
 			Status:    "done",
 			Started:   formatStarted(m.StartedAt),
+			Att:       "-",
 			Rel:       "-",
 			Reqs:      "-",
 			Weight:    "-",
@@ -639,6 +669,7 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 			ID:        strconv.Itoa(iss.Number),
 			Status:    "in-progress",
 			Started:   "-",
+			Att:       "-",
 			Rel:       "-",
 			Reqs:      "-",
 			Weight:    "-",
@@ -710,10 +741,10 @@ func PrintGeneratorStats(deps GeneratorStatsDeps) error {
 	}
 
 	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(w, "#\tStatus\tStarted\tRel\tReqs\tWeight\tCost\tDuration\tRateLimit\tTurns\tTokIn\tTokOut\tProd\tTest\tParent\tTitle")
+	fmt.Fprintln(w, "#\tStatus\tStarted\tAtt\tRel\tReqs\tWeight\tCost\tDuration\tRateLimit\tTurns\tTokIn\tTokOut\tProd\tTest\tParent\tTitle")
 	for _, tr := range tableRows {
-		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
-			tr.ID, tr.Status, tr.Started, tr.Rel, tr.Reqs, tr.Weight, tr.Cost, tr.Dur, tr.RateLimit, tr.Turns, tr.TokIn, tr.TokOut, tr.Prod, tr.Test, tr.Parent, tr.Title)
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+			tr.ID, tr.Status, tr.Started, tr.Att, tr.Rel, tr.Reqs, tr.Weight, tr.Cost, tr.Dur, tr.RateLimit, tr.Turns, tr.TokIn, tr.TokOut, tr.Prod, tr.Test, tr.Parent, tr.Title)
 	}
 	if err := w.Flush(); err != nil {
 		return err

--- a/pkg/orchestrator/internal/stats/generator_stats_test.go
+++ b/pkg/orchestrator/internal/stats/generator_stats_test.go
@@ -1936,3 +1936,197 @@ requirements:
 		t.Errorf("expected 'Cost: calculating...' in output, got:\n%s", output)
 	}
 }
+
+// --- Attempt tracking (GH-1967) ---
+
+// TestPrintGeneratorStats_AttemptsColumn verifies that the Att column shows
+// the number of stitch invocations per task, and the retry summary line is
+// printed when retries occur.
+func TestPrintGeneratorStats_AttemptsColumn(t *testing.T) {
+	dir := t.TempDir()
+
+	histDir := filepath.Join(dir, "history")
+	os.MkdirAll(histDir, 0o755)
+
+	// Task 200: two failed attempts, then one success = 3 attempts.
+	fail1 := `caller: stitch
+task_id: "200"
+task_title: "[stitch] prd001 R1 flaky task"
+status: failed
+started_at: "2026-03-10T10:00:00Z"
+duration_s: 120
+tokens:
+  input: 50000
+  output: 2000
+cost_usd: 0.40
+num_turns: 5
+loc_before:
+  production: 500
+  test: 200
+loc_after:
+  production: 0
+  test: 0
+`
+	fail2 := `caller: stitch
+task_id: "200"
+task_title: "[stitch] prd001 R1 flaky task"
+status: failed
+started_at: "2026-03-10T10:05:00Z"
+duration_s: 90
+tokens:
+  input: 50000
+  output: 2000
+cost_usd: 0.35
+num_turns: 4
+loc_before:
+  production: 500
+  test: 200
+loc_after:
+  production: 0
+  test: 0
+`
+	success := `caller: stitch
+task_id: "200"
+task_title: "[stitch] prd001 R1 flaky task"
+status: success
+started_at: "2026-03-10T10:10:00Z"
+duration_s: 200
+tokens:
+  input: 60000
+  output: 3000
+cost_usd: 0.50
+num_turns: 8
+loc_before:
+  production: 500
+  test: 200
+loc_after:
+  production: 530
+  test: 220
+`
+	// Task 201: single success = 1 attempt.
+	single := `caller: stitch
+task_id: "201"
+task_title: "[stitch] prd002 R1 clean task"
+status: success
+started_at: "2026-03-10T11:00:00Z"
+duration_s: 150
+tokens:
+  input: 40000
+  output: 2000
+cost_usd: 0.30
+num_turns: 6
+loc_before:
+  production: 530
+  test: 220
+loc_after:
+  production: 560
+  test: 240
+`
+	os.WriteFile(filepath.Join(histDir, "2026-03-10-10-00-00-stitch-stats.yaml"), []byte(fail1), 0o644)
+	os.WriteFile(filepath.Join(histDir, "2026-03-10-10-05-00-stitch-stats.yaml"), []byte(fail2), 0o644)
+	os.WriteFile(filepath.Join(histDir, "2026-03-10-10-10-00-stitch-stats.yaml"), []byte(success), 0o644)
+	os.WriteFile(filepath.Join(histDir, "2026-03-10-11-00-00-stitch-stats.yaml"), []byte(single), 0o644)
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	deps := GeneratorStatsDeps{
+		Log:                    func(format string, args ...any) {},
+		ListGenerationBranches: func() []string { return []string{"generation-main"} },
+		GenerationBranch:       "generation-main",
+		CurrentBranch:          "generation-main",
+		HistoryDir:             histDir,
+	}
+
+	err := PrintGeneratorStats(deps)
+	w.Close()
+	captured, _ := io.ReadAll(r)
+	os.Stdout = oldStdout
+	output := string(captured)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Table header should include Att column.
+	if !strings.Contains(output, "Att") {
+		t.Errorf("expected Att column header in output:\n%s", output)
+	}
+
+	// The retry summary line should appear.
+	if !strings.Contains(output, "Retries: 2 retries across 4 attempts") {
+		t.Errorf("expected retry summary in output:\n%s", output)
+	}
+	if !strings.Contains(output, "50%") {
+		t.Errorf("expected 50%% retry rate in output:\n%s", output)
+	}
+	// Wasted cost = $0.40 + $0.35 = $0.75
+	if !strings.Contains(output, "$0.75 wasted") {
+		t.Errorf("expected $0.75 wasted in output:\n%s", output)
+	}
+}
+
+// TestPrintGeneratorStats_NoRetrySummaryWhenNoRetries verifies that the retry
+// summary line is omitted when all tasks succeed on the first attempt.
+func TestPrintGeneratorStats_NoRetrySummaryWhenNoRetries(t *testing.T) {
+	dir := t.TempDir()
+
+	histDir := filepath.Join(dir, "history")
+	os.MkdirAll(histDir, 0o755)
+
+	single := `caller: stitch
+task_id: "300"
+task_title: "[stitch] prd001 R1 clean"
+status: success
+started_at: "2026-03-10T12:00:00Z"
+duration_s: 100
+tokens:
+  input: 30000
+  output: 1000
+cost_usd: 0.20
+num_turns: 4
+loc_before:
+  production: 100
+  test: 50
+loc_after:
+  production: 120
+  test: 60
+`
+	os.WriteFile(filepath.Join(histDir, "2026-03-10-12-00-00-stitch-stats.yaml"), []byte(single), 0o644)
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { os.Chdir(orig) })
+	os.Chdir(dir)
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	deps := GeneratorStatsDeps{
+		Log:                    func(format string, args ...any) {},
+		ListGenerationBranches: func() []string { return []string{"generation-main"} },
+		GenerationBranch:       "generation-main",
+		CurrentBranch:          "generation-main",
+		HistoryDir:             histDir,
+	}
+
+	err := PrintGeneratorStats(deps)
+	w.Close()
+	captured, _ := io.ReadAll(r)
+	os.Stdout = oldStdout
+	output := string(captured)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// No retry summary when all tasks have 1 attempt.
+	if strings.Contains(output, "Retries:") {
+		t.Errorf("retry summary should not appear when no retries:\n%s", output)
+	}
+}


### PR DESCRIPTION
## Summary

Adds per-task attempt counting and aggregate retry statistics to the `stats:generator` output. Each task row now shows how many stitch invocations were made, and the header includes a retry summary with total retries, retry rate, and wasted cost from failed attempts.

## Changes

- Added `Attempts` and `FailedCostUSD` fields to `GeneratorIssueStats` and internal `stitchAgg` struct
- Count stitch history entries per TaskID during aggregation; track cost from `status: "failed"` entries
- Added "Att" column to the output table (after Started, before Rel)
- Print retry summary line when any task has more than one attempt: `Retries: N retries across M attempts (X%), $Y.YY wasted`
- 2 new tests: multi-attempt task with retry/wasted-cost validation, no-summary when all first-try

## Stats

- go_loc_prod: 19,523 (+31) | go_loc_test: 36,194 (+194)
- 2 files changed, +237 -12

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)
- [x] New retry stats tests pass (2/2)

Closes #1967