### PR TITLE
GH-1989: Design language-agnostic interface specification format

### DIFF
--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -911,6 +911,23 @@ design_decisions:
     alternatives_rejected:
       - "Single path only: automated path loses human review; interactive path loses throughput"
 
+  - id: 11
+    title: JSON Schema envelope for interface specifications
+    decision: |
+      We define interface specifications as standalone YAML files in docs/interfaces/, using
+      JSON Schema to describe data structures and a custom operations list for methods. Each
+      file is a self-contained contract with metadata, typed data structures, and operations.
+      This replaces the inlined interface entries in ARCHITECTURE.yaml, which remain as
+      summaries pointing to the full specification files.
+    benefits:
+      - Language-agnostic — JSON Schema types (string, integer, array, object) replace Go-specific signatures
+      - Machine-parseable — standard JSON Schema validators check data structure definitions
+      - Modular — each interface is a separate file, reducing ARCHITECTURE.yaml size
+      - Consistent with YAML-first (D2) and existing document type patterns
+    alternatives_rejected:
+      - "OpenAPI YAML: designed for REST APIs (paths, HTTP methods); mapping library methods to HTTP endpoints is artificial and the tooling ecosystem targets HTTP clients, not library contracts"
+      - "MCP-like JSON: oriented toward tool discovery and invocation; flat parameter schemas do not capture struct hierarchies naturally; less established validation tooling"
+
 technology_choices:
   - component: Language
     technology: Go 1.25

--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -241,6 +241,25 @@ document_types:
       architecture. Not PRDs (no numbered requirements). Not architecture (no
       component descriptions).
 
+  interface_specification:
+    location: "docs/interfaces/ifc-[kebab-case-name].yaml"
+    format_rule: interface-specification-format
+    required_fields:
+      - id (matches filename without extension)
+      - name (must match ARCHITECTURE.yaml interface entry)
+      - summary (one to three sentences)
+    optional_fields:
+      - "data_structures (list: name, description, schema as JSON Schema object)"
+      - "operations (list: name, description, parameters, returns)"
+      - announcements (list of events the interface emits)
+      - references (list of PRD or use case IDs)
+    purpose: |
+      Standalone, language-agnostic interface contract. Uses JSON Schema for
+      data structures and typed parameter/return lists for operations.
+      Replaces Go-specific signatures inlined in ARCHITECTURE.yaml with
+      machine-parseable definitions. See eng10-interface-specifications for
+      the full schema and examples.
+
   specification:
     location: docs/SPECIFICATIONS.yaml
     format_rule: specification-format
@@ -304,6 +323,7 @@ naming_conventions:
   use_case: "rel[NN].[N]-uc[NNN]-[short-name].yaml (e.g., rel01.0-uc001-cupboard-lifecycle.yaml)"
   test_suite: "test-[use-case-id].yaml (e.g., test-rel01.0-uc001-cupboard-lifecycle.yaml)"
   engineering_guideline: "eng[NN]-[short-name].yaml (e.g., eng01-git-integration.yaml)"
+  interface_specification: "ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml)"
   architecture: "ARCHITECTURE.yaml"
   vision: "VISION.yaml"
   specification: "SPECIFICATIONS.yaml"
@@ -375,6 +395,15 @@ completeness_checklists:
     - Expected outputs are specific and checkable
     - File saved as test-[use-case-id].yaml
 
+  interface_specification:
+    - id matches filename without extension (ifc-[kebab-case-name])
+    - name matches the corresponding ARCHITECTURE.yaml interface entry
+    - summary describes the interface contract in one to three sentences
+    - data_structures use JSON Schema (type, properties, required)
+    - operations have name, description, typed parameters, and typed returns
+    - references list PRD or use case IDs the interface traces to
+    - File saved as ifc-[kebab-case-name].yaml in docs/interfaces/
+
 sections:
   - tag: articles
     title: Core Principles
@@ -392,9 +421,10 @@ sections:
   - tag: document_types
     title: Document Types
     content: |
-      Seven document types are defined: vision, architecture, PRD, use case,
-      test suite, engineering guideline, and specification. Each has a canonical
-      location, format rule, required fields, and optional fields.
+      Eight document types are defined: vision, architecture, PRD, use case,
+      test suite, engineering guideline, interface specification, and
+      specification. Each has a canonical location, format rule, required
+      fields, and optional fields.
   - tag: naming_conventions
     title: Naming Conventions
     content: |

--- a/docs/constitutions/interface.yaml
+++ b/docs/constitutions/interface.yaml
@@ -7,22 +7,34 @@
 
 articles:
   - id: I1
-    title: Interfaces live in ARCHITECTURE.yaml
+    title: Interfaces live in ARCHITECTURE.yaml with optional specification files
     rule: |
       Every interface is declared in the interfaces section of
       ARCHITECTURE.yaml. An interface groups related data structures and
       operations under a name that components reference. Interfaces are not
       declared in PRDs; PRDs reference interfaces defined in the architecture.
 
+      Each interface entry in ARCHITECTURE.yaml may include a spec_file field
+      pointing to a standalone specification file in docs/interfaces/. When
+      spec_file is present, the ARCHITECTURE.yaml entry is a summary and the
+      specification file is the authoritative contract. See
+      eng10-interface-specifications for the full format.
+
   - id: I2
     title: Required interface fields
     rule: |
-      Every interface entry must have a name and a summary. The name is a
-      short, unique identifier (e.g., "Orchestrator and Config", "Prompt
-      Templates"). The summary describes what the interface provides in one
-      to three sentences. Optional fields are data_structures (list of type
-      names with brief descriptions) and operations (list of method or
-      function signatures).
+      Every interface entry in ARCHITECTURE.yaml must have a name and a
+      summary. The name is a short, unique identifier (e.g., "Orchestrator
+      and Config", "Prompt Templates"). The summary describes what the
+      interface provides in one to three sentences. Optional fields are
+      data_structures (list of type names with brief descriptions),
+      operations (list of method or function signatures), and spec_file
+      (path to the full specification file).
+
+      Interface specification files in docs/interfaces/ must have id, name,
+      and summary. Optional fields are data_structures (with JSON Schema
+      definitions), operations (with typed parameters and returns),
+      announcements, and references.
 
   - id: I3
     title: Naming conventions
@@ -32,6 +44,9 @@ articles:
       ARCHITECTURE.yaml. Abbreviations are permitted when the abbreviation
       is standard in the domain (e.g., "OOD" for object-oriented design),
       but must be explained in the summary on first use.
+
+      Specification file names use kebab case matching the interface name:
+      ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml).
 
   - id: I4
     title: PRD interface references
@@ -66,33 +81,49 @@ articles:
       port, not the adapter. Analysis enforces that every referenced
       interface name resolves to a declared port.
 
+      When a specification file exists (spec_file), the port contract is
+      defined in that file using JSON Schema for data structures and typed
+      operations. The ARCHITECTURE.yaml entry remains the discovery point;
+      the specification file is the contract.
+
   - id: I6
     title: Interface traceability
     rule: |
       The traceability chain for interfaces runs: ARCHITECTURE.yaml
-      (declares the interface) -> PRD implemented_by (provides the
+      (declares the interface) -> specification file in docs/interfaces/
+      (defines the contract) -> PRD implemented_by (provides the
       implementation) -> PRD used_by (consumes the interface). Analysis
       validates both directions: every name in implemented_by and used_by
       must match an interface name in ARCHITECTURE.yaml. Broken references
       fail the analysis check.
+
+      Specification files include a references field listing PRD and use
+      case IDs that the interface traces to, completing the bidirectional
+      link.
 
 sections:
   - tag: articles
     title: Core Principles
     content: |
       Six principles govern interface specifications: interfaces live in
-      ARCHITECTURE.yaml (I1), required fields are name and summary (I2),
-      names use title case and must be unique (I3), PRDs reference
-      interfaces via implemented_by and used_by (I4), interfaces follow
-      ports and adapters semantics (I5), and traceability runs from
-      architecture through PRDs (I6).
+      ARCHITECTURE.yaml with optional specification files in docs/interfaces/
+      (I1), required fields are name and summary with spec_file as optional
+      (I2), names use title case and specification files use kebab case (I3),
+      PRDs reference interfaces via implemented_by and used_by (I4),
+      interfaces follow ports and adapters semantics (I5), and traceability
+      runs from architecture through specification files through PRDs (I6).
   - tag: structure
     title: Interface Structure
     content: |
-      An interface entry in ARCHITECTURE.yaml is a YAML mapping with four
+      An interface entry in ARCHITECTURE.yaml is a YAML mapping with five
       fields: name (required), summary (required), data_structures
-      (optional list), and operations (optional list). PRDs reference
-      interfaces by name using implemented_by and used_by string lists.
+      (optional list), operations (optional list), and spec_file (optional
+      path). PRDs reference interfaces by name using implemented_by and
+      used_by string lists.
+
+      Specification files in docs/interfaces/ use JSON Schema for data
+      structures and typed parameter/return lists for operations. See
+      eng10-interface-specifications for the full schema.
   - tag: validation
     title: Analysis Validation
     content: |
@@ -100,4 +131,5 @@ sections:
       in a PRD's implemented_by and used_by lists must match the name
       field of an interface in ARCHITECTURE.yaml. Unresolved references
       are reported as errors. Missing or empty interface lists are not
-      errors; the fields are optional.
+      errors; the fields are optional. When spec_file is present, analyze
+      can validate that the referenced file exists.

--- a/docs/engineering/eng10-interface-specifications.yaml
+++ b/docs/engineering/eng10-interface-specifications.yaml
@@ -1,0 +1,147 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: eng10-interface-specifications
+title: Interface Specification Format
+
+introduction: |
+  Interfaces in ARCHITECTURE.yaml serve as summaries: a name, a paragraph
+  of prose, and optional lists of data structures and operations written in
+  Go-specific notation. This works for orientation but breaks down when
+  tooling needs to validate contracts, generate stubs, or check that a PRD's
+  implemented_by claim actually matches the interface it references.
+
+  We introduce a standalone interface specification file format that lives in
+  docs/interfaces/. Each file is a self-contained YAML document using JSON
+  Schema to describe data structures and a typed operations list for methods.
+  ARCHITECTURE.yaml retains the summary entries and gains a spec_file field
+  pointing to the full specification. The interface constitution (I1-I6)
+  governs both the summary and the specification file.
+
+sections:
+  - title: File Location and Naming
+    content: |
+      Interface specification files live in docs/interfaces/ and follow the
+      naming pattern ifc-[kebab-case-name].yaml, where the name matches the
+      interface name in ARCHITECTURE.yaml converted to kebab case. For
+      example, the "Generation Lifecycle" interface becomes
+      ifc-generation-lifecycle.yaml.
+
+      ARCHITECTURE.yaml interface entries gain an optional spec_file field
+      that points to the specification file path relative to the repository
+      root. When spec_file is present, the ARCHITECTURE.yaml entry is a
+      summary; the specification file is the authoritative contract.
+
+  - title: File Structure
+    content: |
+      Every interface specification file has four top-level fields:
+
+      Table: Interface specification fields
+
+      | Field | Required | Description |
+      |-------|----------|-------------|
+      | id | yes | Matches filename without extension (e.g., ifc-generation-lifecycle) |
+      | name | yes | Interface name, must match the ARCHITECTURE.yaml entry |
+      | summary | yes | One to three sentences describing the interface contract |
+      | data_structures | no | List of typed data structure definitions using JSON Schema |
+      | operations | no | List of method definitions with typed parameters and returns |
+      | announcements | no | List of events or signals the interface emits |
+      | references | no | List of PRD or use case IDs this interface traces to |
+
+  - title: Data Structure Definitions
+    content: |
+      Each entry in data_structures is a YAML mapping with three fields:
+      name (the type name), description (one sentence), and schema (a JSON
+      Schema object defining the structure's fields).
+
+      JSON Schema types replace Go types. Use string, integer, number,
+      boolean, array, and object. The format keyword extends basic types
+      (e.g., format: date-time for timestamps, format: duration for time
+      durations). Use $ref to reference other data structures within the
+      same file.
+
+      Example:
+
+      ```yaml
+      data_structures:
+        - name: DiffStat
+          description: Parsed output from a git diff --shortstat command.
+          schema:
+            type: object
+            properties:
+              files_changed:
+                type: integer
+                description: Number of files changed.
+              insertions:
+                type: integer
+                description: Lines added.
+              deletions:
+                type: integer
+                description: Lines removed.
+            required: [files_changed, insertions, deletions]
+      ```
+
+      Struct hierarchies use nested objects. References between structures
+      in the same file use $ref with a JSON pointer:
+
+      ```yaml
+      schema:
+        type: object
+        properties:
+          diff:
+            $ref: "#/data_structures/DiffStat"
+      ```
+
+  - title: Operation Definitions
+    content: |
+      Each entry in operations is a YAML mapping with four fields: name (the
+      method name), description (one sentence), parameters (list of typed
+      parameters), and returns (list of typed return values). Parameters and
+      returns each have name, type, and an optional description.
+
+      Types in parameters and returns use JSON Schema type names (string,
+      integer, boolean, object, array) or reference data structures defined
+      in the same file by name. Use "void" when a method returns nothing
+      besides an error. Use "error" as the conventional error return type.
+
+      Example:
+
+      ```yaml
+      operations:
+        - name: GeneratorStart
+          description: Tag base branch, create generation branch, and reset sources.
+          parameters: []
+          returns:
+            - name: error
+              type: error
+        - name: GeneratorRun
+          description: Run measure and stitch cycles until all issues are closed.
+          parameters:
+            - name: cycles
+              type: integer
+              description: Maximum number of cycles to execute.
+          returns:
+            - name: error
+              type: error
+      ```
+
+  - title: Versioning and Evolution
+    content: |
+      Interface specifications are versioned through git like all other
+      documentation. When an interface changes, update both the specification
+      file and the ARCHITECTURE.yaml summary. The spec_file field in
+      ARCHITECTURE.yaml serves as the link between the summary and the full
+      contract.
+
+      Breaking changes (removing operations, changing parameter types) should
+      be documented in the specification file's summary or in a design
+      decision in ARCHITECTURE.yaml.
+
+  - title: Relationship to mage analyze
+    content: |
+      The analyze target validates that every interface name in a PRD's
+      implemented_by and used_by lists resolves to an entry in
+      ARCHITECTURE.yaml's interfaces section (I6). When spec_file is
+      present, analyze can optionally validate that the specification file
+      exists at the declared path. Full schema validation of specification
+      file contents is a future extension.

--- a/docs/interfaces/ifc-builder.yaml
+++ b/docs/interfaces/ifc-builder.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-builder
+name: Builder
+summary: |
+  We provide build, lint, install, clean, and credential extraction operations
+  through the Builder struct. Builder depends only on Config and has no
+  cross-domain dependencies. Consuming projects invoke these operations as
+  Mage targets for Go toolchain management.
+
+operations:
+  - name: Build
+    description: Build the consuming project binary using go build.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: BuildAll
+    description: Build all cmd/ sub-packages when MainPackage is empty.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: Lint
+    description: Run golangci-lint on the project source.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: Install
+    description: Install the project binary using go install.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: Clean
+    description: Remove build artifacts from the project directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: ExtractCredentials
+    description: Extract Claude API credentials from the macOS Keychain.
+    parameters: []
+    returns:
+      - name: credentials
+        type: object
+        description: Extracted credential data.
+      - name: error
+        type: error
+
+references:
+  - prd001-orchestrator-core
+  - prd003-cobbler-workflows

--- a/docs/interfaces/ifc-generation-lifecycle.yaml
+++ b/docs/interfaces/ifc-generation-lifecycle.yaml
@@ -1,0 +1,124 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-generation-lifecycle
+name: Generation Lifecycle
+summary: |
+  We manage the generation lifecycle through the Generator struct. A generation
+  starts from a tagged main state, creates a branch, runs measure-stitch cycles,
+  and merges the result back to main. The Generator composes Measure, Stitch,
+  Analyzer, Releaser, and ClaudeRunner to coordinate these phases.
+
+data_structures:
+  - name: Generator
+    description: |
+      Standalone struct managing the generation lifecycle. Composes domain
+      structs and state callbacks for branch and phase management.
+    schema:
+      type: object
+      properties:
+        config:
+          type: object
+          description: Orchestrator configuration.
+        log_function:
+          type: object
+          description: Logging function for generation events.
+        git:
+          type: object
+          description: Git operations interface.
+        tracker:
+          type: object
+          description: Issue tracking interface.
+        claude_runner:
+          type: object
+          description: Claude execution infrastructure.
+        analyzer:
+          type: object
+          description: Cross-artifact consistency checker.
+        measure:
+          type: object
+          description: Measure workflow struct.
+        stitch:
+          type: object
+          description: Stitch workflow struct.
+        releaser:
+          type: object
+          description: Release lifecycle manager.
+        set_generation:
+          type: object
+          description: Callback to set the active generation on the orchestrator.
+        clear_generation:
+          type: object
+          description: Callback to clear the active generation.
+
+operations:
+  - name: GeneratorStart
+    description: Tag base branch, create generation branch, and reset sources unless preserve_sources is true.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorRun
+    description: Run measure and stitch cycles until all issues are closed or the cycle limit is reached.
+    parameters:
+      - name: cycles
+        type: integer
+        description: Maximum number of measure-stitch cycles to execute.
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorResume
+    description: Recover stale tasks from an interrupted run and continue execution.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorStop
+    description: Merge generation branch into base branch, tag the result, and clean up.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorReset
+    description: Destroy all generations and return to a clean main state.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorList
+    description: List active and past generations with their lifecycle state.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorSwitch
+    description: Switch the working directory to a different generation branch.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: RunCycles
+    description: Run measure and stitch cycles until no open issues remain.
+    parameters:
+      - name: label
+        type: string
+        description: Label identifying this cycle run for logging.
+    returns:
+      - name: error
+        type: error
+  - name: Init
+    description: Initialize the project for orchestrator use.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: FullReset
+    description: Reset both cobbler state and generator state.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - prd002-generation-lifecycle
+  - prd001-orchestrator-core

--- a/docs/interfaces/ifc-git-operations.yaml
+++ b/docs/interfaces/ifc-git-operations.yaml
@@ -1,0 +1,272 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-git-operations
+name: Git Operations
+summary: |
+  We abstract all git operations behind a GitOps interface with six role-based
+  sub-interfaces. The ShellGitOps implementation executes git commands via
+  exec.Command. Components declare dependencies on the narrowest sub-interface
+  they need, enabling testability and future non-shell backends.
+
+data_structures:
+  - name: DiffStat
+    description: Parsed output from a git diff --shortstat command.
+    schema:
+      type: object
+      properties:
+        files_changed:
+          type: integer
+          description: Number of files changed.
+        insertions:
+          type: integer
+          description: Number of lines added.
+        deletions:
+          type: integer
+          description: Number of lines removed.
+      required: [files_changed, insertions, deletions]
+
+  - name: FileChange
+    description: Per-file diff information from git diff --name-status.
+    schema:
+      type: object
+      properties:
+        path:
+          type: string
+          description: File path relative to the repository root.
+        status:
+          type: string
+          description: Git status code (A, M, D, R).
+        insertions:
+          type: integer
+          description: Lines added in this file.
+        deletions:
+          type: integer
+          description: Lines removed from this file.
+      required: [path, status]
+
+operations:
+  # RepoReader sub-interface
+  - name: CurrentBranch
+    description: Return the name of the currently checked-out branch.
+    parameters: []
+    returns:
+      - name: branch
+        type: string
+      - name: error
+        type: error
+  - name: BranchExists
+    description: Check whether a branch exists locally.
+    parameters:
+      - name: branch
+        type: string
+        description: Branch name to check.
+    returns:
+      - name: exists
+        type: boolean
+      - name: error
+        type: error
+  - name: ListBranches
+    description: List all local branches.
+    parameters: []
+    returns:
+      - name: branches
+        type: array
+        description: List of branch names.
+      - name: error
+        type: error
+  - name: ListTags
+    description: List all tags matching an optional pattern.
+    parameters:
+      - name: pattern
+        type: string
+        description: Glob pattern for filtering tags. Empty returns all.
+    returns:
+      - name: tags
+        type: array
+        description: List of tag names.
+      - name: error
+        type: error
+  - name: LsFiles
+    description: List tracked files matching a pattern.
+    parameters:
+      - name: pattern
+        type: string
+        description: File glob pattern.
+    returns:
+      - name: files
+        type: array
+      - name: error
+        type: error
+  - name: RevParseHEAD
+    description: Return the commit hash of HEAD.
+    parameters: []
+    returns:
+      - name: hash
+        type: string
+      - name: error
+        type: error
+
+  # WorktreeManager sub-interface
+  - name: WorktreeAdd
+    description: Create a new git worktree at the given path on a new branch.
+    parameters:
+      - name: path
+        type: string
+        description: Filesystem path for the new worktree.
+      - name: branch
+        type: string
+        description: Branch name for the worktree.
+    returns:
+      - name: error
+        type: error
+  - name: WorktreeRemove
+    description: Remove an existing git worktree.
+    parameters:
+      - name: path
+        type: string
+        description: Filesystem path of the worktree to remove.
+    returns:
+      - name: error
+        type: error
+  - name: WorktreePrune
+    description: Prune stale worktree metadata.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  # BranchManager sub-interface
+  - name: Checkout
+    description: Check out an existing branch.
+    parameters:
+      - name: branch
+        type: string
+        description: Branch name to check out.
+    returns:
+      - name: error
+        type: error
+  - name: CheckoutNew
+    description: Create and check out a new branch from the current HEAD.
+    parameters:
+      - name: branch
+        type: string
+        description: New branch name.
+    returns:
+      - name: error
+        type: error
+  - name: CreateBranch
+    description: Create a new branch without switching to it.
+    parameters:
+      - name: branch
+        type: string
+        description: New branch name.
+    returns:
+      - name: error
+        type: error
+  - name: DeleteBranch
+    description: Delete a local branch (safe delete, fails if unmerged).
+    parameters:
+      - name: branch
+        type: string
+        description: Branch name to delete.
+    returns:
+      - name: error
+        type: error
+  - name: MergeCmd
+    description: Merge a branch into the current branch.
+    parameters:
+      - name: branch
+        type: string
+        description: Branch name to merge.
+    returns:
+      - name: error
+        type: error
+
+  # CommitWriter sub-interface
+  - name: StageAll
+    description: Stage all changes in the working directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: HasChanges
+    description: Check whether the working directory has uncommitted changes.
+    parameters: []
+    returns:
+      - name: has_changes
+        type: boolean
+      - name: error
+        type: error
+  - name: Commit
+    description: Create a commit with the given message.
+    parameters:
+      - name: message
+        type: string
+        description: Commit message.
+    returns:
+      - name: error
+        type: error
+  - name: CommitAllowEmpty
+    description: Create a commit even if there are no staged changes.
+    parameters:
+      - name: message
+        type: string
+        description: Commit message.
+    returns:
+      - name: error
+        type: error
+
+  # TagManager sub-interface
+  - name: Tag
+    description: Create a lightweight tag at HEAD.
+    parameters:
+      - name: name
+        type: string
+        description: Tag name.
+    returns:
+      - name: error
+        type: error
+  - name: DeleteTag
+    description: Delete a local tag.
+    parameters:
+      - name: name
+        type: string
+        description: Tag name to delete.
+    returns:
+      - name: error
+        type: error
+
+  # DiffInspector sub-interface
+  - name: DiffShortstat
+    description: Return parsed diff statistics between two references.
+    parameters:
+      - name: from_ref
+        type: string
+        description: Base reference (commit, branch, or tag).
+      - name: to_ref
+        type: string
+        description: Target reference.
+    returns:
+      - name: stat
+        type: DiffStat
+      - name: error
+        type: error
+  - name: DiffNameStatus
+    description: Return per-file change information between two references.
+    parameters:
+      - name: from_ref
+        type: string
+        description: Base reference.
+      - name: to_ref
+        type: string
+        description: Target reference.
+    returns:
+      - name: changes
+        type: array
+        description: List of FileChange entries.
+      - name: error
+        type: error
+
+references:
+  - prd001-orchestrator-core

--- a/pkg/orchestrator/constitutions/design.yaml
+++ b/pkg/orchestrator/constitutions/design.yaml
@@ -241,6 +241,25 @@ document_types:
       architecture. Not PRDs (no numbered requirements). Not architecture (no
       component descriptions).
 
+  interface_specification:
+    location: "docs/interfaces/ifc-[kebab-case-name].yaml"
+    format_rule: interface-specification-format
+    required_fields:
+      - id (matches filename without extension)
+      - name (must match ARCHITECTURE.yaml interface entry)
+      - summary (one to three sentences)
+    optional_fields:
+      - "data_structures (list: name, description, schema as JSON Schema object)"
+      - "operations (list: name, description, parameters, returns)"
+      - announcements (list of events the interface emits)
+      - references (list of PRD or use case IDs)
+    purpose: |
+      Standalone, language-agnostic interface contract. Uses JSON Schema for
+      data structures and typed parameter/return lists for operations.
+      Replaces Go-specific signatures inlined in ARCHITECTURE.yaml with
+      machine-parseable definitions. See eng10-interface-specifications for
+      the full schema and examples.
+
   specification:
     location: docs/SPECIFICATIONS.yaml
     format_rule: specification-format
@@ -304,6 +323,7 @@ naming_conventions:
   use_case: "rel[NN].[N]-uc[NNN]-[short-name].yaml (e.g., rel01.0-uc001-cupboard-lifecycle.yaml)"
   test_suite: "test-[use-case-id].yaml (e.g., test-rel01.0-uc001-cupboard-lifecycle.yaml)"
   engineering_guideline: "eng[NN]-[short-name].yaml (e.g., eng01-git-integration.yaml)"
+  interface_specification: "ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml)"
   architecture: "ARCHITECTURE.yaml"
   vision: "VISION.yaml"
   specification: "SPECIFICATIONS.yaml"
@@ -375,6 +395,15 @@ completeness_checklists:
     - Expected outputs are specific and checkable
     - File saved as test-[use-case-id].yaml
 
+  interface_specification:
+    - id matches filename without extension (ifc-[kebab-case-name])
+    - name matches the corresponding ARCHITECTURE.yaml interface entry
+    - summary describes the interface contract in one to three sentences
+    - data_structures use JSON Schema (type, properties, required)
+    - operations have name, description, typed parameters, and typed returns
+    - references list PRD or use case IDs the interface traces to
+    - File saved as ifc-[kebab-case-name].yaml in docs/interfaces/
+
 sections:
   - tag: articles
     title: Core Principles
@@ -392,9 +421,10 @@ sections:
   - tag: document_types
     title: Document Types
     content: |
-      Seven document types are defined: vision, architecture, PRD, use case,
-      test suite, engineering guideline, and specification. Each has a canonical
-      location, format rule, required fields, and optional fields.
+      Eight document types are defined: vision, architecture, PRD, use case,
+      test suite, engineering guideline, interface specification, and
+      specification. Each has a canonical location, format rule, required
+      fields, and optional fields.
   - tag: naming_conventions
     title: Naming Conventions
     content: |

--- a/pkg/orchestrator/constitutions/interface.yaml
+++ b/pkg/orchestrator/constitutions/interface.yaml
@@ -7,22 +7,34 @@
 
 articles:
   - id: I1
-    title: Interfaces live in ARCHITECTURE.yaml
+    title: Interfaces live in ARCHITECTURE.yaml with optional specification files
     rule: |
       Every interface is declared in the interfaces section of
       ARCHITECTURE.yaml. An interface groups related data structures and
       operations under a name that components reference. Interfaces are not
       declared in PRDs; PRDs reference interfaces defined in the architecture.
 
+      Each interface entry in ARCHITECTURE.yaml may include a spec_file field
+      pointing to a standalone specification file in docs/interfaces/. When
+      spec_file is present, the ARCHITECTURE.yaml entry is a summary and the
+      specification file is the authoritative contract. See
+      eng10-interface-specifications for the full format.
+
   - id: I2
     title: Required interface fields
     rule: |
-      Every interface entry must have a name and a summary. The name is a
-      short, unique identifier (e.g., "Orchestrator and Config", "Prompt
-      Templates"). The summary describes what the interface provides in one
-      to three sentences. Optional fields are data_structures (list of type
-      names with brief descriptions) and operations (list of method or
-      function signatures).
+      Every interface entry in ARCHITECTURE.yaml must have a name and a
+      summary. The name is a short, unique identifier (e.g., "Orchestrator
+      and Config", "Prompt Templates"). The summary describes what the
+      interface provides in one to three sentences. Optional fields are
+      data_structures (list of type names with brief descriptions),
+      operations (list of method or function signatures), and spec_file
+      (path to the full specification file).
+
+      Interface specification files in docs/interfaces/ must have id, name,
+      and summary. Optional fields are data_structures (with JSON Schema
+      definitions), operations (with typed parameters and returns),
+      announcements, and references.
 
   - id: I3
     title: Naming conventions
@@ -32,6 +44,9 @@ articles:
       ARCHITECTURE.yaml. Abbreviations are permitted when the abbreviation
       is standard in the domain (e.g., "OOD" for object-oriented design),
       but must be explained in the summary on first use.
+
+      Specification file names use kebab case matching the interface name:
+      ifc-[kebab-case-name].yaml (e.g., ifc-generation-lifecycle.yaml).
 
   - id: I4
     title: PRD interface references
@@ -66,33 +81,49 @@ articles:
       port, not the adapter. Analysis enforces that every referenced
       interface name resolves to a declared port.
 
+      When a specification file exists (spec_file), the port contract is
+      defined in that file using JSON Schema for data structures and typed
+      operations. The ARCHITECTURE.yaml entry remains the discovery point;
+      the specification file is the contract.
+
   - id: I6
     title: Interface traceability
     rule: |
       The traceability chain for interfaces runs: ARCHITECTURE.yaml
-      (declares the interface) -> PRD implemented_by (provides the
+      (declares the interface) -> specification file in docs/interfaces/
+      (defines the contract) -> PRD implemented_by (provides the
       implementation) -> PRD used_by (consumes the interface). Analysis
       validates both directions: every name in implemented_by and used_by
       must match an interface name in ARCHITECTURE.yaml. Broken references
       fail the analysis check.
+
+      Specification files include a references field listing PRD and use
+      case IDs that the interface traces to, completing the bidirectional
+      link.
 
 sections:
   - tag: articles
     title: Core Principles
     content: |
       Six principles govern interface specifications: interfaces live in
-      ARCHITECTURE.yaml (I1), required fields are name and summary (I2),
-      names use title case and must be unique (I3), PRDs reference
-      interfaces via implemented_by and used_by (I4), interfaces follow
-      ports and adapters semantics (I5), and traceability runs from
-      architecture through PRDs (I6).
+      ARCHITECTURE.yaml with optional specification files in docs/interfaces/
+      (I1), required fields are name and summary with spec_file as optional
+      (I2), names use title case and specification files use kebab case (I3),
+      PRDs reference interfaces via implemented_by and used_by (I4),
+      interfaces follow ports and adapters semantics (I5), and traceability
+      runs from architecture through specification files through PRDs (I6).
   - tag: structure
     title: Interface Structure
     content: |
-      An interface entry in ARCHITECTURE.yaml is a YAML mapping with four
+      An interface entry in ARCHITECTURE.yaml is a YAML mapping with five
       fields: name (required), summary (required), data_structures
-      (optional list), and operations (optional list). PRDs reference
-      interfaces by name using implemented_by and used_by string lists.
+      (optional list), operations (optional list), and spec_file (optional
+      path). PRDs reference interfaces by name using implemented_by and
+      used_by string lists.
+
+      Specification files in docs/interfaces/ use JSON Schema for data
+      structures and typed parameter/return lists for operations. See
+      eng10-interface-specifications for the full schema.
   - tag: validation
     title: Analysis Validation
     content: |
@@ -100,4 +131,5 @@ sections:
       in a PRD's implemented_by and used_by lists must match the name
       field of an interface in ARCHITECTURE.yaml. Unresolved references
       are reported as errors. Missing or empty interface lists are not
-      errors; the fields are optional.
+      errors; the fields are optional. When spec_file is present, analyze
+      can validate that the referenced file exists.


### PR DESCRIPTION
## Summary

Chose JSON Schema + custom YAML envelope as the interface specification format after evaluating OpenAPI and MCP-like JSON alternatives. Created the schema definition, three example specs, and updated all governing documents (constitutions, design.yaml, ARCHITECTURE.yaml).

## Changes

- Added design decision DD11 to ARCHITECTURE.yaml documenting format choice
- Created eng10-interface-specifications.yaml defining the full schema
- Created three example interface specs in docs/interfaces/ (Generation Lifecycle, Builder, Git Operations)
- Updated interface constitution I1-I6 for spec_file, docs/interfaces/ location, and JSON Schema
- Added interface_specification document type to design.yaml with format rule, naming convention, and completeness checklist
- Synced embedded constitutions in pkg/orchestrator/constitutions/

## Stats

- go_loc_prod: 20,273 (delta: -154, from embedded constitution reformatting)
- go_loc_test: 36,502 (no change)
- spec_words: prd 9,584 / test_suite 3,676 / use_case 7,710 (no change)
- 9 files changed, +779/-40 lines

## Test plan

- [x] `mage analyze` passes
- [ ] Documentation reviewed for consistency

Closes #1989