### PR TITLE
GH-1993: Replace JSON Schema with pure YAML in interface specifications

### DIFF
--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -912,21 +912,24 @@ design_decisions:
       - "Single path only: automated path loses human review; interactive path loses throughput"
 
   - id: 11
-    title: JSON Schema envelope for interface specifications
+    title: Pure YAML interface specifications
     decision: |
-      We define interface specifications as standalone YAML files in docs/interfaces/, using
-      JSON Schema to describe data structures and a custom operations list for methods. Each
-      file is a self-contained contract with metadata, typed data structures, and operations.
-      This replaces the inlined interface entries in ARCHITECTURE.yaml, which remain as
-      summaries pointing to the full specification files.
+      We define interface specifications as standalone YAML files in docs/interfaces/. Data
+      structures use typed field lists (name, type, description, required) and operations use
+      typed parameter and return lists. The format is pure YAML throughout — no embedded JSON
+      Schema, OpenAPI, or other schema languages. Each file is a self-contained contract with
+      metadata, typed data structures, and operations. This replaces the inlined interface
+      entries in ARCHITECTURE.yaml, which remain as summaries pointing to the full
+      specification files.
     benefits:
-      - Language-agnostic — JSON Schema types (string, integer, array, object) replace Go-specific signatures
-      - Machine-parseable — standard JSON Schema validators check data structure definitions
+      - Language-agnostic — type names (string, integer, array, object) replace Go-specific signatures
+      - Single schema language — pure YAML consistent with D2, no JSON Schema mixing
+      - Uniform structure — data structure fields use the same name/type/description pattern as operation parameters
       - Modular — each interface is a separate file, reducing ARCHITECTURE.yaml size
-      - Consistent with YAML-first (D2) and existing document type patterns
     alternatives_rejected:
       - "OpenAPI YAML: designed for REST APIs (paths, HTTP methods); mapping library methods to HTTP endpoints is artificial and the tooling ecosystem targets HTTP clients, not library contracts"
       - "MCP-like JSON: oriented toward tool discovery and invocation; flat parameter schemas do not capture struct hierarchies naturally; less established validation tooling"
+      - "JSON Schema envelope: mixes two schema languages in one file (YAML wrapping JSON Schema keywords); violates D2 YAML-first principle"
 
 technology_choices:
   - component: Language

--- a/docs/constitutions/design.yaml
+++ b/docs/constitutions/design.yaml
@@ -249,16 +249,17 @@ document_types:
       - name (must match ARCHITECTURE.yaml interface entry)
       - summary (one to three sentences)
     optional_fields:
-      - "data_structures (list: name, description, schema as JSON Schema object)"
+      - "data_structures (list: name, description, fields as typed field list)"
       - "operations (list: name, description, parameters, returns)"
       - announcements (list of events the interface emits)
       - references (list of PRD or use case IDs)
     purpose: |
-      Standalone, language-agnostic interface contract. Uses JSON Schema for
-      data structures and typed parameter/return lists for operations.
-      Replaces Go-specific signatures inlined in ARCHITECTURE.yaml with
+      Standalone, language-agnostic interface contract. Uses typed field
+      lists for data structures and typed parameter/return lists for
+      operations. Pure YAML throughout, consistent with D2. Replaces
+      Go-specific signatures inlined in ARCHITECTURE.yaml with
       machine-parseable definitions. See eng10-interface-specifications for
-      the full schema and examples.
+      the full format and examples.
 
   specification:
     location: docs/SPECIFICATIONS.yaml
@@ -399,7 +400,7 @@ completeness_checklists:
     - id matches filename without extension (ifc-[kebab-case-name])
     - name matches the corresponding ARCHITECTURE.yaml interface entry
     - summary describes the interface contract in one to three sentences
-    - data_structures use JSON Schema (type, properties, required)
+    - data_structures use typed field lists (name, type, description, required)
     - operations have name, description, typed parameters, and typed returns
     - references list PRD or use case IDs the interface traces to
     - File saved as ifc-[kebab-case-name].yaml in docs/interfaces/

--- a/docs/constitutions/interface.yaml
+++ b/docs/constitutions/interface.yaml
@@ -32,9 +32,9 @@ articles:
       (path to the full specification file).
 
       Interface specification files in docs/interfaces/ must have id, name,
-      and summary. Optional fields are data_structures (with JSON Schema
-      definitions), operations (with typed parameters and returns),
-      announcements, and references.
+      and summary. Optional fields are data_structures (with typed field
+      lists), operations (with typed parameters and returns), announcements,
+      and references.
 
   - id: I3
     title: Naming conventions
@@ -82,9 +82,10 @@ articles:
       interface name resolves to a declared port.
 
       When a specification file exists (spec_file), the port contract is
-      defined in that file using JSON Schema for data structures and typed
-      operations. The ARCHITECTURE.yaml entry remains the discovery point;
-      the specification file is the contract.
+      defined in that file using typed field lists for data structures and
+      typed parameter/return lists for operations. The ARCHITECTURE.yaml
+      entry remains the discovery point; the specification file is the
+      contract.
 
   - id: I6
     title: Interface traceability
@@ -121,9 +122,9 @@ sections:
       path). PRDs reference interfaces by name using implemented_by and
       used_by string lists.
 
-      Specification files in docs/interfaces/ use JSON Schema for data
-      structures and typed parameter/return lists for operations. See
-      eng10-interface-specifications for the full schema.
+      Specification files in docs/interfaces/ use typed field lists for
+      data structures and typed parameter/return lists for operations.
+      See eng10-interface-specifications for the full format.
   - tag: validation
     title: Analysis Validation
     content: |

--- a/docs/engineering/eng10-interface-specifications.yaml
+++ b/docs/engineering/eng10-interface-specifications.yaml
@@ -12,8 +12,8 @@ introduction: |
   implemented_by claim actually matches the interface it references.
 
   We introduce a standalone interface specification file format that lives in
-  docs/interfaces/. Each file is a self-contained YAML document using JSON
-  Schema to describe data structures and a typed operations list for methods.
+  docs/interfaces/. Each file is a self-contained YAML document with typed
+  field lists for data structures and a typed operations list for methods.
   ARCHITECTURE.yaml retains the summary entries and gains a spec_file field
   pointing to the full specification. The interface constitution (I1-I6)
   governs both the summary and the specification file.
@@ -43,7 +43,7 @@ sections:
       | id | yes | Matches filename without extension (e.g., ifc-generation-lifecycle) |
       | name | yes | Interface name, must match the ARCHITECTURE.yaml entry |
       | summary | yes | One to three sentences describing the interface contract |
-      | data_structures | no | List of typed data structure definitions using JSON Schema |
+      | data_structures | no | List of typed data structure definitions with field lists |
       | operations | no | List of method definitions with typed parameters and returns |
       | announcements | no | List of events or signals the interface emits |
       | references | no | List of PRD or use case IDs this interface traces to |
@@ -51,14 +51,15 @@ sections:
   - title: Data Structure Definitions
     content: |
       Each entry in data_structures is a YAML mapping with three fields:
-      name (the type name), description (one sentence), and schema (a JSON
-      Schema object defining the structure's fields).
+      name (the type name), description (one sentence), and fields (a list
+      of typed field definitions).
 
-      JSON Schema types replace Go types. Use string, integer, number,
-      boolean, array, and object. The format keyword extends basic types
-      (e.g., format: date-time for timestamps, format: duration for time
-      durations). Use $ref to reference other data structures within the
-      same file.
+      Each field has name, type, and an optional description. The type uses
+      language-agnostic names: string, integer, number, boolean, array, and
+      object. Add a required field set to true for fields that must be
+      present. Fields without required default to optional. Reference other
+      data structures defined in the same file by using their name as the
+      type.
 
       Example:
 
@@ -66,30 +67,29 @@ sections:
       data_structures:
         - name: DiffStat
           description: Parsed output from a git diff --shortstat command.
-          schema:
-            type: object
-            properties:
-              files_changed:
-                type: integer
-                description: Number of files changed.
-              insertions:
-                type: integer
-                description: Lines added.
-              deletions:
-                type: integer
-                description: Lines removed.
-            required: [files_changed, insertions, deletions]
+          fields:
+            - name: files_changed
+              type: integer
+              description: Number of files changed.
+              required: true
+            - name: insertions
+              type: integer
+              description: Lines added.
+              required: true
+            - name: deletions
+              type: integer
+              description: Lines removed.
+              required: true
       ```
 
-      Struct hierarchies use nested objects. References between structures
-      in the same file use $ref with a JSON pointer:
+      Nested structures use object as the type with a nested fields list,
+      or reference another data structure by name:
 
       ```yaml
-      schema:
-        type: object
-        properties:
-          diff:
-            $ref: "#/data_structures/DiffStat"
+      fields:
+        - name: diff
+          type: DiffStat
+          description: Aggregate diff statistics.
       ```
 
   - title: Operation Definitions
@@ -99,10 +99,11 @@ sections:
       parameters), and returns (list of typed return values). Parameters and
       returns each have name, type, and an optional description.
 
-      Types in parameters and returns use JSON Schema type names (string,
-      integer, boolean, object, array) or reference data structures defined
-      in the same file by name. Use "void" when a method returns nothing
-      besides an error. Use "error" as the conventional error return type.
+      Types in parameters and returns use the same language-agnostic names
+      (string, integer, boolean, object, array) or reference data structures
+      defined in the same file by name. Use "void" when a method returns
+      nothing besides an error. Use "error" as the conventional error return
+      type.
 
       Example:
 

--- a/docs/interfaces/ifc-generation-lifecycle.yaml
+++ b/docs/interfaces/ifc-generation-lifecycle.yaml
@@ -14,42 +14,40 @@ data_structures:
     description: |
       Standalone struct managing the generation lifecycle. Composes domain
       structs and state callbacks for branch and phase management.
-    schema:
-      type: object
-      properties:
-        config:
-          type: object
-          description: Orchestrator configuration.
-        log_function:
-          type: object
-          description: Logging function for generation events.
-        git:
-          type: object
-          description: Git operations interface.
-        tracker:
-          type: object
-          description: Issue tracking interface.
-        claude_runner:
-          type: object
-          description: Claude execution infrastructure.
-        analyzer:
-          type: object
-          description: Cross-artifact consistency checker.
-        measure:
-          type: object
-          description: Measure workflow struct.
-        stitch:
-          type: object
-          description: Stitch workflow struct.
-        releaser:
-          type: object
-          description: Release lifecycle manager.
-        set_generation:
-          type: object
-          description: Callback to set the active generation on the orchestrator.
-        clear_generation:
-          type: object
-          description: Callback to clear the active generation.
+    fields:
+      - name: config
+        type: object
+        description: Orchestrator configuration.
+      - name: log_function
+        type: object
+        description: Logging function for generation events.
+      - name: git
+        type: object
+        description: Git operations interface.
+      - name: tracker
+        type: object
+        description: Issue tracking interface.
+      - name: claude_runner
+        type: object
+        description: Claude execution infrastructure.
+      - name: analyzer
+        type: object
+        description: Cross-artifact consistency checker.
+      - name: measure
+        type: object
+        description: Measure workflow struct.
+      - name: stitch
+        type: object
+        description: Stitch workflow struct.
+      - name: releaser
+        type: object
+        description: Release lifecycle manager.
+      - name: set_generation
+        type: object
+        description: Callback to set the active generation on the orchestrator.
+      - name: clear_generation
+        type: object
+        description: Callback to clear the active generation.
 
 operations:
   - name: GeneratorStart

--- a/docs/interfaces/ifc-git-operations.yaml
+++ b/docs/interfaces/ifc-git-operations.yaml
@@ -12,38 +12,37 @@ summary: |
 data_structures:
   - name: DiffStat
     description: Parsed output from a git diff --shortstat command.
-    schema:
-      type: object
-      properties:
-        files_changed:
-          type: integer
-          description: Number of files changed.
-        insertions:
-          type: integer
-          description: Number of lines added.
-        deletions:
-          type: integer
-          description: Number of lines removed.
-      required: [files_changed, insertions, deletions]
+    fields:
+      - name: files_changed
+        type: integer
+        description: Number of files changed.
+        required: true
+      - name: insertions
+        type: integer
+        description: Number of lines added.
+        required: true
+      - name: deletions
+        type: integer
+        description: Number of lines removed.
+        required: true
 
   - name: FileChange
     description: Per-file diff information from git diff --name-status.
-    schema:
-      type: object
-      properties:
-        path:
-          type: string
-          description: File path relative to the repository root.
-        status:
-          type: string
-          description: Git status code (A, M, D, R).
-        insertions:
-          type: integer
-          description: Lines added in this file.
-        deletions:
-          type: integer
-          description: Lines removed from this file.
-      required: [path, status]
+    fields:
+      - name: path
+        type: string
+        description: File path relative to the repository root.
+        required: true
+      - name: status
+        type: string
+        description: Git status code (A, M, D, R).
+        required: true
+      - name: insertions
+        type: integer
+        description: Lines added in this file.
+      - name: deletions
+        type: integer
+        description: Lines removed from this file.
 
 operations:
   # RepoReader sub-interface

--- a/pkg/orchestrator/constitutions/design.yaml
+++ b/pkg/orchestrator/constitutions/design.yaml
@@ -249,16 +249,17 @@ document_types:
       - name (must match ARCHITECTURE.yaml interface entry)
       - summary (one to three sentences)
     optional_fields:
-      - "data_structures (list: name, description, schema as JSON Schema object)"
+      - "data_structures (list: name, description, fields as typed field list)"
       - "operations (list: name, description, parameters, returns)"
       - announcements (list of events the interface emits)
       - references (list of PRD or use case IDs)
     purpose: |
-      Standalone, language-agnostic interface contract. Uses JSON Schema for
-      data structures and typed parameter/return lists for operations.
-      Replaces Go-specific signatures inlined in ARCHITECTURE.yaml with
+      Standalone, language-agnostic interface contract. Uses typed field
+      lists for data structures and typed parameter/return lists for
+      operations. Pure YAML throughout, consistent with D2. Replaces
+      Go-specific signatures inlined in ARCHITECTURE.yaml with
       machine-parseable definitions. See eng10-interface-specifications for
-      the full schema and examples.
+      the full format and examples.
 
   specification:
     location: docs/SPECIFICATIONS.yaml
@@ -399,7 +400,7 @@ completeness_checklists:
     - id matches filename without extension (ifc-[kebab-case-name])
     - name matches the corresponding ARCHITECTURE.yaml interface entry
     - summary describes the interface contract in one to three sentences
-    - data_structures use JSON Schema (type, properties, required)
+    - data_structures use typed field lists (name, type, description, required)
     - operations have name, description, typed parameters, and typed returns
     - references list PRD or use case IDs the interface traces to
     - File saved as ifc-[kebab-case-name].yaml in docs/interfaces/

--- a/pkg/orchestrator/constitutions/interface.yaml
+++ b/pkg/orchestrator/constitutions/interface.yaml
@@ -32,9 +32,9 @@ articles:
       (path to the full specification file).
 
       Interface specification files in docs/interfaces/ must have id, name,
-      and summary. Optional fields are data_structures (with JSON Schema
-      definitions), operations (with typed parameters and returns),
-      announcements, and references.
+      and summary. Optional fields are data_structures (with typed field
+      lists), operations (with typed parameters and returns), announcements,
+      and references.
 
   - id: I3
     title: Naming conventions
@@ -82,9 +82,10 @@ articles:
       interface name resolves to a declared port.
 
       When a specification file exists (spec_file), the port contract is
-      defined in that file using JSON Schema for data structures and typed
-      operations. The ARCHITECTURE.yaml entry remains the discovery point;
-      the specification file is the contract.
+      defined in that file using typed field lists for data structures and
+      typed parameter/return lists for operations. The ARCHITECTURE.yaml
+      entry remains the discovery point; the specification file is the
+      contract.
 
   - id: I6
     title: Interface traceability
@@ -121,9 +122,9 @@ sections:
       path). PRDs reference interfaces by name using implemented_by and
       used_by string lists.
 
-      Specification files in docs/interfaces/ use JSON Schema for data
-      structures and typed parameter/return lists for operations. See
-      eng10-interface-specifications for the full schema.
+      Specification files in docs/interfaces/ use typed field lists for
+      data structures and typed parameter/return lists for operations.
+      See eng10-interface-specifications for the full format.
   - tag: validation
     title: Analysis Validation
     content: |


### PR DESCRIPTION
## Summary

Replaced JSON Schema constructs (schema, properties, required, $ref) with pure YAML typed field lists in all interface specification files. Data structure fields now use the same name/type/description pattern as operation parameters, making the format consistent and YAML-only per D2.

## Changes

- Converted data_structures in ifc-generation-lifecycle.yaml and ifc-git-operations.yaml from JSON Schema to typed field lists
- Rewrote eng10 Data Structure Definitions section to document the fields pattern
- Updated DD11 to "Pure YAML interface specifications" with JSON Schema envelope as rejected alternative
- Removed 3 JSON Schema references from interface constitution (I2, I5, structure section)
- Updated design.yaml interface_specification type and completeness checklist
- Synced embedded constitutions

## Stats

- 8 files changed, +143/-138 lines (net +5)
- No Go production or test code changes

## Test plan

- [x] `mage analyze` passes
- [x] No JSON Schema keywords in interface files (verified via grep)
- [ ] Documentation reviewed for consistency

Closes #1993