### PR TITLE
GH-1990: Implement interface specification file support in analyze tool

### DIFF
--- a/pkg/orchestrator/internal/analysis/analyze.go
+++ b/pkg/orchestrator/internal/analysis/analyze.go
@@ -41,6 +41,7 @@ type AnalyzeResult struct {
 	BareTouchpoints                []string // Touchpoints citing SRDs without R-group references (warning, GH-1961)
 	UCIDPrefixMismatch             []string // Use case ID prefix doesn't match assigned release in roadmap (GH-1964)
 	BrokenInterfaceRefs            []string // implemented_by/used_by references non-existent architecture interface (GH-1968)
+	MissingSpecFiles               []string // spec_file declared in ARCHITECTURE.yaml but file does not exist (GH-1990)
 }
 
 // AnalyzeCounts holds the artifact counts discovered during analysis.
@@ -445,23 +446,54 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 	deps.Log("analyze: component_dep violations found %d", len(result.ComponentDepViolations))
 
 	// Check 20: interface references — implemented_by/used_by must resolve to
-	// an interface name in ARCHITECTURE.yaml (GH-1968).
-	if archDoc != nil && len(srdInterfaceRefs) > 0 {
-		archIfaceNames := make(map[string]bool)
+	// an interface name in ARCHITECTURE.yaml or docs/interfaces/ (GH-1968, GH-1990).
+	//
+	// Build a combined index of interface names from both sources.
+	allIfaceNames := make(map[string]bool)
+	if archDoc != nil {
 		for _, iface := range archDoc.Interfaces {
-			archIfaceNames[iface.Name] = true
+			allIfaceNames[iface.Name] = true
 		}
+	}
+
+	// Load interface spec files from docs/interfaces/ifc-*.yaml (GH-1990).
+	ifcFiles, _ := filepath.Glob("docs/interfaces/ifc-*.yaml")
+	for _, path := range ifcFiles {
+		if spec := loadYAML[InterfaceSpecDoc](path); spec != nil && spec.Name != "" {
+			allIfaceNames[spec.Name] = true
+		}
+	}
+	deps.Log("analyze: loaded %d interface spec files from docs/interfaces/", len(ifcFiles))
+
+	// Validate SRD interface references against the combined index.
+	if len(allIfaceNames) > 0 && len(srdInterfaceRefs) > 0 {
 		for srdID, refs := range srdInterfaceRefs {
 			for _, ref := range refs {
-				if !archIfaceNames[ref] {
+				if !allIfaceNames[ref] {
 					result.BrokenInterfaceRefs = append(result.BrokenInterfaceRefs,
-						fmt.Sprintf("%s: interface %q not found in ARCHITECTURE.yaml", srdID, ref))
+						fmt.Sprintf("%s: interface %q not found in ARCHITECTURE.yaml or docs/interfaces/", srdID, ref))
 				}
 			}
 		}
 	}
 	sort.Strings(result.BrokenInterfaceRefs)
 	deps.Log("analyze: broken interface refs found %d", len(result.BrokenInterfaceRefs))
+
+	// Check 21: spec_file existence — when an ARCHITECTURE.yaml interface
+	// declares a spec_file, verify the file exists on disk (GH-1990).
+	if archDoc != nil {
+		for _, iface := range archDoc.Interfaces {
+			if iface.SpecFile == "" {
+				continue
+			}
+			if _, err := os.Stat(iface.SpecFile); os.IsNotExist(err) {
+				result.MissingSpecFiles = append(result.MissingSpecFiles,
+					fmt.Sprintf("%s: spec_file %q does not exist", iface.Name, iface.SpecFile))
+			}
+		}
+	}
+	sort.Strings(result.MissingSpecFiles)
+	deps.Log("analyze: missing spec files found %d", len(result.MissingSpecFiles))
 
 	// Check 15: R-item coverage by acceptance criteria.
 	// Every R-item in a SRD should appear in at least one AC's traces list.
@@ -631,6 +663,7 @@ func (r AnalyzeResult) PrintReport(srdCount, ucCount, tsCount, smCount int) erro
 	hasIssues = PrintSection("Semantic model errors (SM1 sections, SM3 traceability, SM7 naming)", r.SemanticModelErrors) || hasIssues
 	hasIssues = PrintSection("Use case ID prefix mismatch (ID prefix does not match assigned release in roadmap)", r.UCIDPrefixMismatch) || hasIssues
 	hasIssues = PrintSection("Broken interface refs (implemented_by/used_by references non-existent architecture interface)", r.BrokenInterfaceRefs) || hasIssues
+	hasIssues = PrintSection("Missing spec files (spec_file declared in ARCHITECTURE.yaml but file does not exist)", r.MissingSpecFiles) || hasIssues
 	hasIssues = PrintSection("Uncovered R-items (R-item not traced by any acceptance criterion)", r.UncoveredRItems) || hasIssues
 	PrintSection("Uncovered ACs (AC not covered by any test case — warning)", r.UncoveredACs)
 	PrintSection("Untraced success criteria (S-item with no AC trace — warning)", r.UntracedSuccessCriteria)

--- a/pkg/orchestrator/internal/analysis/analyze_test.go
+++ b/pkg/orchestrator/internal/analysis/analyze_test.go
@@ -2125,3 +2125,198 @@ title: Core
 		t.Errorf("expected no violations when SRDs have no interface refs, got %v", result.BrokenInterfaceRefs)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Interface spec file support (GH-1990)
+// ---------------------------------------------------------------------------
+
+func TestCollectAnalyzeResult_InterfaceRef_ResolvedFromSpecFile(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	// ARCHITECTURE.yaml has no interfaces section — the interface is
+	// defined only in docs/interfaces/.
+	os.WriteFile("docs/ARCHITECTURE.yaml", []byte(`id: arch
+title: Arch
+interfaces: []
+`), 0o644)
+	os.MkdirAll("docs/interfaces", 0o755)
+	os.WriteFile("docs/interfaces/ifc-builder.yaml", []byte(`id: ifc-builder
+name: Builder
+summary: Build operations
+`), 0o644)
+	os.WriteFile("docs/specs/software-requirements/srd001-core.yaml", []byte(`id: srd001-core
+title: Core
+implemented_by:
+  - Builder
+`), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BrokenInterfaceRefs) != 0 {
+		t.Errorf("expected interface resolved from spec file, got broken refs: %v", result.BrokenInterfaceRefs)
+	}
+}
+
+func TestCollectAnalyzeResult_InterfaceRef_CombinedIndex(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	// One interface in ARCHITECTURE.yaml, another only in docs/interfaces/.
+	os.WriteFile("docs/ARCHITECTURE.yaml", []byte(`id: arch
+title: Arch
+interfaces:
+  - name: Orchestrator and Config
+    summary: Entry point
+`), 0o644)
+	os.MkdirAll("docs/interfaces", 0o755)
+	os.WriteFile("docs/interfaces/ifc-builder.yaml", []byte(`id: ifc-builder
+name: Builder
+summary: Build operations
+`), 0o644)
+	os.WriteFile("docs/specs/software-requirements/srd001-core.yaml", []byte(`id: srd001-core
+title: Core
+implemented_by:
+  - Orchestrator and Config
+  - Builder
+`), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BrokenInterfaceRefs) != 0 {
+		t.Errorf("expected both interfaces resolved, got broken refs: %v", result.BrokenInterfaceRefs)
+	}
+}
+
+func TestCollectAnalyzeResult_InterfaceRef_StillBrokenWithSpecFiles(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	os.WriteFile("docs/ARCHITECTURE.yaml", []byte(`id: arch
+title: Arch
+interfaces:
+  - name: Orchestrator and Config
+    summary: Entry point
+`), 0o644)
+	os.MkdirAll("docs/interfaces", 0o755)
+	os.WriteFile("docs/interfaces/ifc-builder.yaml", []byte(`id: ifc-builder
+name: Builder
+summary: Build operations
+`), 0o644)
+	os.WriteFile("docs/specs/software-requirements/srd001-core.yaml", []byte(`id: srd001-core
+title: Core
+implemented_by:
+  - Nonexistent Interface
+`), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BrokenInterfaceRefs) != 1 {
+		t.Fatalf("expected 1 broken interface ref, got %d: %v",
+			len(result.BrokenInterfaceRefs), result.BrokenInterfaceRefs)
+	}
+	if !strings.Contains(result.BrokenInterfaceRefs[0], "Nonexistent Interface") {
+		t.Errorf("violation should mention Nonexistent Interface, got %q", result.BrokenInterfaceRefs[0])
+	}
+}
+
+func TestCollectAnalyzeResult_MissingSpecFile(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	os.WriteFile("docs/ARCHITECTURE.yaml", []byte(`id: arch
+title: Arch
+interfaces:
+  - name: Builder
+    summary: Build operations
+    spec_file: docs/interfaces/ifc-builder.yaml
+`), 0o644)
+	// No docs/interfaces/ directory — spec_file does not exist.
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.MissingSpecFiles) != 1 {
+		t.Fatalf("expected 1 missing spec file, got %d: %v",
+			len(result.MissingSpecFiles), result.MissingSpecFiles)
+	}
+	if !strings.Contains(result.MissingSpecFiles[0], "ifc-builder.yaml") {
+		t.Errorf("violation should mention ifc-builder.yaml, got %q", result.MissingSpecFiles[0])
+	}
+}
+
+func TestCollectAnalyzeResult_SpecFileExists(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	os.MkdirAll("docs/interfaces", 0o755)
+	os.WriteFile("docs/interfaces/ifc-builder.yaml", []byte(`id: ifc-builder
+name: Builder
+summary: Build operations
+`), 0o644)
+	os.WriteFile("docs/ARCHITECTURE.yaml", []byte(`id: arch
+title: Arch
+interfaces:
+  - name: Builder
+    summary: Build operations
+    spec_file: docs/interfaces/ifc-builder.yaml
+`), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.MissingSpecFiles) != 0 {
+		t.Errorf("expected no missing spec files, got %v", result.MissingSpecFiles)
+	}
+}
+
+func TestCollectAnalyzeResult_InterfaceRef_OnlySpecFiles(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	// No ARCHITECTURE.yaml at all — interfaces only from spec files.
+	os.MkdirAll("docs/interfaces", 0o755)
+	os.WriteFile("docs/interfaces/ifc-builder.yaml", []byte(`id: ifc-builder
+name: Builder
+summary: Build operations
+`), 0o644)
+	os.WriteFile("docs/specs/software-requirements/srd001-core.yaml", []byte(`id: srd001-core
+title: Core
+implemented_by:
+  - Builder
+`), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BrokenInterfaceRefs) != 0 {
+		t.Errorf("expected interface resolved from spec file alone, got broken refs: %v", result.BrokenInterfaceRefs)
+	}
+}

--- a/pkg/orchestrator/internal/analysis/types.go
+++ b/pkg/orchestrator/internal/analysis/types.go
@@ -106,13 +106,21 @@ type ArchitectureDoc struct {
 
 // ArchInterface is an interface entry from ARCHITECTURE.yaml.
 type ArchInterface struct {
-	Name string `yaml:"name"`
+	Name     string `yaml:"name"`
+	SpecFile string `yaml:"spec_file,omitempty"`
 }
 
 // ArchComponentDependency is a single dependency edge in the architecture.
 type ArchComponentDependency struct {
 	From string `yaml:"from"`
 	To   string `yaml:"to"`
+}
+
+// InterfaceSpecDoc holds the fields parsed from docs/interfaces/ifc-*.yaml
+// that are needed for cross-artifact consistency checks (GH-1990).
+type InterfaceSpecDoc struct {
+	ID   string `yaml:"id"`
+	Name string `yaml:"name"`
 }
 
 // ArchDependencyRule is a constraint on component dependencies.

--- a/pkg/orchestrator/internal/context/context.go
+++ b/pkg/orchestrator/internal/context/context.go
@@ -157,8 +157,9 @@ type ProjectContext struct {
 	Specifications *SpecificationsDoc `yaml:"specifications,omitempty"`
 	Roadmap        *RoadmapDoc        `yaml:"roadmap,omitempty"`
 	Specs          *SpecsCollection   `yaml:"specs,omitempty"`
-	Engineering    []*EngineeringDoc  `yaml:"engineering,omitempty"`
-	Analysis       any                `yaml:"analysis,omitempty"`
+	Engineering    []*EngineeringDoc    `yaml:"engineering,omitempty"`
+	InterfaceSpecs []*InterfaceSpecDoc `yaml:"interface_specs,omitempty"`
+	Analysis       any                 `yaml:"analysis,omitempty"`
 	SourceCode     []SourceFile       `yaml:"source_code,omitempty"`
 	Issues         []ContextIssue     `yaml:"issues,omitempty"`
 	CompletedWork     []string                                     `yaml:"completed_work,omitempty"`
@@ -241,6 +242,7 @@ type ArchOverview struct {
 type ArchInterface struct {
 	Name           string   `yaml:"name"`
 	Summary        string   `yaml:"summary"`
+	SpecFile       string   `yaml:"spec_file,omitempty"`
 	DataStructures []string `yaml:"data_structures,omitempty"`
 	Operations     []string `yaml:"operations,omitempty"`
 }
@@ -689,6 +691,52 @@ type EngineeringDoc struct {
 type DocSection struct {
 	Title   string `yaml:"title"`
 	Content string `yaml:"content"`
+}
+
+// ---------------------------------------------------------------------------
+// Interface specification (docs/interfaces/ifc-*.yaml, GH-1990)
+// ---------------------------------------------------------------------------
+
+// InterfaceSpecDoc corresponds to docs/interfaces/ifc-*.yaml.
+type InterfaceSpecDoc struct {
+	File       string                  `yaml:"file,omitempty"`
+	ID         string                  `yaml:"id"`
+	Name       string                  `yaml:"name"`
+	Summary    string                  `yaml:"summary"`
+	DataStructures []InterfaceDataStructure `yaml:"data_structures,omitempty"`
+	Operations     []InterfaceOperation     `yaml:"operations,omitempty"`
+	Announcements  []string                 `yaml:"announcements,omitempty"`
+	References     []string                 `yaml:"references,omitempty"`
+}
+
+// InterfaceDataStructure is a typed data structure in an interface spec.
+type InterfaceDataStructure struct {
+	Name        string           `yaml:"name"`
+	Description string           `yaml:"description"`
+	Fields      []InterfaceField `yaml:"fields,omitempty"`
+}
+
+// InterfaceField is a typed field in an interface data structure.
+type InterfaceField struct {
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type"`
+	Description string `yaml:"description"`
+	Required    bool   `yaml:"required,omitempty"`
+}
+
+// InterfaceOperation is a typed operation in an interface spec.
+type InterfaceOperation struct {
+	Name        string           `yaml:"name"`
+	Description string           `yaml:"description"`
+	Parameters  []InterfaceParam `yaml:"parameters,omitempty"`
+	Returns     []InterfaceParam `yaml:"returns,omitempty"`
+}
+
+// InterfaceParam is a typed parameter or return value in an interface operation.
+type InterfaceParam struct {
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type"`
+	Description string `yaml:"description,omitempty"`
 }
 
 // ---------------------------------------------------------------------------
@@ -1438,6 +1486,8 @@ func ClassifyContextFile(path string) string {
 		return "test_suite"
 	case dir == filepath.Join("docs", "specs"):
 		return "spec_aux"
+	case dir == filepath.Join("docs", "interfaces"):
+		return "interface_spec"
 	case dir == filepath.Join("docs", "engineering"):
 		return "engineering"
 	case dir == filepath.Join("docs", "constitutions"):
@@ -1466,6 +1516,7 @@ var StandardContextPatterns = []string{
 	"docs/specs/test-suites/test-rel*.yaml",
 	"docs/specs/dependency-map.yaml",
 	"docs/specs/sources.yaml",
+	"docs/interfaces/ifc-*.yaml",
 }
 
 // TypedDocPaths lists documents that must always be loaded through their
@@ -1825,6 +1876,11 @@ func LoadContextFileInto(ctx *ProjectContext, path string, rf ReleaseFilter) {
 			default:
 				ctx.Extra = append(ctx.Extra, v)
 			}
+		}
+	case "interface_spec":
+		if v := LoadYAML[InterfaceSpecDoc](path); v != nil {
+			v.File = path
+			ctx.InterfaceSpecs = append(ctx.InterfaceSpecs, v)
 		}
 	case "engineering":
 		if v := LoadYAML[EngineeringDoc](path); v != nil {

--- a/pkg/orchestrator/internal/context/context_test.go
+++ b/pkg/orchestrator/internal/context/context_test.go
@@ -452,6 +452,7 @@ func TestClassifyContextFile_AllTypes(t *testing.T) {
 		{filepath.Join("docs", "specs", "use-cases", "rel01.0-uc001-init.yaml"), "use_case"},
 		{filepath.Join("docs", "specs", "test-suites", "test-rel-01.0.yaml"), "test_suite"},
 		{filepath.Join("docs", "specs", "dependency-map.yaml"), "spec_aux"},
+		{filepath.Join("docs", "interfaces", "ifc-builder.yaml"), "interface_spec"},
 		{filepath.Join("docs", "engineering", "eng01-guidelines.yaml"), "engineering"},
 		{filepath.Join("docs", "constitutions", "design.yaml"), "constitution"},
 		{"docs/custom.yaml", "extra"},
@@ -1187,5 +1188,38 @@ func TestLoadSRDSemanticModel_NoSRDs(t *testing.T) {
 	node := LoadSRDSemanticModel()
 	if node != nil {
 		t.Errorf("expected nil when no SRD files exist, got non-nil")
+	}
+}
+
+func TestBuildProjectContext_InterfaceSpecs(t *testing.T) {
+	_, cleanup := setupContextTestDir(t)
+	defer cleanup()
+
+	os.MkdirAll("docs/interfaces", 0o755)
+	os.WriteFile("docs/interfaces/ifc-builder.yaml", []byte(`id: ifc-builder
+name: Builder
+summary: Build operations
+operations:
+  - name: Build
+    description: Build the project
+    parameters: []
+    returns:
+      - name: error
+        type: error
+`), 0o644)
+
+	project := ContextConfig{}
+	ctx, err := BuildProjectContext("", project, nil, ".cobbler")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ctx.InterfaceSpecs) != 1 {
+		t.Fatalf("expected 1 interface spec, got %d", len(ctx.InterfaceSpecs))
+	}
+	if ctx.InterfaceSpecs[0].Name != "Builder" {
+		t.Errorf("expected name Builder, got %q", ctx.InterfaceSpecs[0].Name)
+	}
+	if len(ctx.InterfaceSpecs[0].Operations) != 1 {
+		t.Errorf("expected 1 operation, got %d", len(ctx.InterfaceSpecs[0].Operations))
 	}
 }


### PR DESCRIPTION
## Summary

Load interface specifications from `docs/interfaces/ifc-*.yaml` and build a combined name index with ARCHITECTURE.yaml for SRD `implemented_by`/`used_by` validation. Add `spec_file` field to ArchInterface with existence validation, and include interface specs in ProjectContext for Claude prompts.

## Changes

- Added `InterfaceSpecDoc` type in both analysis and context packages for parsing `ifc-*.yaml` files
- Combined interface name index resolves from both ARCHITECTURE.yaml and `docs/interfaces/` (backward compatible)
- New `spec_file` optional field on `ArchInterface` with file existence validation (Check 21)
- `docs/interfaces/ifc-*.yaml` added to `StandardContextPatterns` for automatic context assembly
- `interface_spec` file classification and `InterfaceSpecs` field on `ProjectContext`
- `MissingSpecFiles` result field and report section in analyze output
- 7 new analysis tests, 2 new context tests

## Stats

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| go_loc_prod | 20,427 | 20,370 | -57 |
| go_loc_test | 36,502 | 36,731 | +229 |
| StandardContextPatterns | 9 | 10 | +1 |
| Interface spec files loaded | 0 | 3 | +3 |

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)
- [x] Existing interface ref tests still pass with updated error message
- [x] New tests cover: spec file resolution, combined index, missing spec_file, context loading

Closes #1990