### PR TITLE
GH-1991: Migrate existing interfaces from ARCHITECTURE.yaml to docs/interfaces/

### DIFF
--- a/docs/ARCHITECTURE.yaml
+++ b/docs/ARCHITECTURE.yaml
@@ -71,6 +71,7 @@ overview:
 
 interfaces:
   - name: Orchestrator and Config
+    spec_file: docs/interfaces/ifc-orchestrator-and-config.yaml
     summary: |
       The Orchestrator is the composition root. Consuming projects place a configuration.yaml
       at the repository root and call NewFromFile(), or construct a Config in Go and pass it
@@ -78,147 +79,78 @@ interfaces:
       all dependencies via constructor injection. Mage targets access domain structs through
       public fields (e.g., o.Generator.GeneratorStart()). Config holds all orchestrator
       settings; the YAML file is the sole source of truth for all options.
-    data_structures:
-      - "Orchestrator: composition root holding Config and 10 domain struct fields (Generator, Measure, Stitch, Builder, Scaffolder, Comparer, VsCode, Stats, Releaser, Analyzer) plus ClaudeRunner"
-      - "Config: all orchestrator settings with YAML tags (see srd001-orchestrator-core for full field spec)"
-      - "InvocationRecord: metrics per Claude invocation (Caller, StartedAt, DurationS, Tokens, LOCBefore, LOCAfter, Diff, NumTurns)"
-      - "HistoryStats: YAML-serializable per-invocation stats saved to history directory (Caller, TaskID, TaskTitle, StartedAt, Duration, Tokens, CostUSD, LOCBefore, LOCAfter, Diff, NumTurns, DurationAPIMs, RateLimitWaitS, SessionID)"
-    operations:
-      - "New(cfg Config) *Orchestrator: construct composition root, wire all domain structs"
-      - "NewFromFile(path string) (*Orchestrator, error): construct from configuration.yaml"
-      - "Config(), Tracker(), Git(): accessor methods for config, tracker, git interfaces"
-      - "DumpMeasurePrompt(): write measure prompt to stdout for debugging"
-      - "DumpStitchPrompt(): write stitch prompt to stdout for debugging"
-      - "TokenStats(): enumerate context files and report token counts (srd005)"
-      - "PrintContextFiles(): list files included in Claude prompts with sizes"
-      - "ConstitutionPreviewFile(): render constitution YAML to markdown"
-      - "GeneratorInit(): package-level function to initialize generator state from configuration.yaml"
-      - "WriteDefaultConfig(): package-level function to write a default configuration.yaml file"
 
   - name: Generation Lifecycle
+    spec_file: docs/interfaces/ifc-generation-lifecycle.yaml
     summary: |
       The Generator struct manages the generation lifecycle. It composes Measure, Stitch,
       Analyzer, Releaser, and ClaudeRunner to coordinate branch creation, measure-stitch
       cycles, merge, and cleanup. Dependencies are injected via NewGenerator(o *Orchestrator).
-    data_structures:
-      - "Generator: standalone struct with cfg, logf, git, tracker, claudeRunner, analyzer, measure, stitch, releaser, setGeneration, clearGeneration"
-    operations:
-      - "GeneratorStart(): tag base branch, create generation branch, reset sources unless preserve_sources is true (srd002)"
-      - "GeneratorRun(cycles int): run measure+stitch cycles until all issues are closed (srd002)"
-      - "GeneratorResume(): recover and continue interrupted run (srd002)"
-      - "GeneratorStop(): merge generation into base branch, tag, clean up (srd002)"
-      - "GeneratorReset(): destroy all generations, return to clean main (srd002)"
-      - "GeneratorList(): show active and past generations (srd002)"
-      - "GeneratorSwitch(): switch between generation branches (srd002)"
-      - "RunCycles(label string): run measure+stitch cycles until no open issues remain (srd002)"
-      - "Init(): initialize project (srd001)"
-      - "FullReset(): reset cobbler and generator (srd001)"
 
   - name: Measure Workflow
+    spec_file: docs/interfaces/ifc-measure-workflow.yaml
     summary: |
       The Measure struct builds the measure prompt from existing issues and project state,
       invokes Claude, parses YAML output, and creates GitHub Issues with dependency labels.
       Dependencies are injected via NewMeasure(o *Orchestrator), including function references
       for orchestrator state (setPhase, setGeneration) and generator helpers (resolveBranch,
       ensureOnBranch, enterWorktree).
-    data_structures:
-      - "Measure: standalone struct with cfg, logf, git, tracker, claudeRunner, analyzer, plus state callbacks and generator helper functions"
-    operations:
-      - "Measure(): enter generation worktree and run measure (srd003)"
-      - "MeasurePrompt(): print assembled measure prompt to stdout"
-      - "RunMeasure(): run measure phase with full lifecycle (srd003)"
-      - "buildMeasurePrompt(): assemble measure prompt from project context"
-      - "importIssues(): import Claude-proposed tasks as GitHub Issues"
 
   - name: Stitch Workflow
+    spec_file: docs/interfaces/ifc-stitch-workflow.yaml
     summary: |
       The Stitch struct picks ready GitHub Issues, creates worktrees, invokes Claude, commits
       changes, merges branches, and closes tasks. Dependencies are injected via
       NewStitch(o *Orchestrator), including function references for generator helpers
       (pickTask, createWorktree, mergeBranch, cleanupWorktree).
-    data_structures:
-      - "Stitch: standalone struct with cfg, logf, git, tracker, claudeRunner, plus state callbacks and generator helper functions"
-    operations:
-      - "Stitch(): enter generation worktree and run stitch (srd003)"
-      - "RunStitch(): run stitch phase, executing all ready tasks (srd003)"
-      - "RunStitchN(limit int): run stitch phase up to limit tasks (srd003)"
-      - "doOneTask(): execute a single task in a worktree"
-      - "resetTask(): reset a failed task to ready"
-      - "skipTask(): mark a task as skipped after retry limit"
 
   - name: Builder
+    spec_file: docs/interfaces/ifc-builder.yaml
     summary: |
       The Builder struct provides build, lint, install, clean, and credential operations.
       It depends only on Config. Created via NewBuilder(cfg Config).
-    operations:
-      - "Build(): go build the consuming project binary"
-      - "BuildAll(): go build all cmd/ sub-packages when MainPackage is empty (srd003)"
-      - "Lint(): run golangci-lint on the project"
-      - "Install(): go install the project binary"
-      - "Clean(): remove build artifacts"
-      - "ExtractCredentials(): extract Claude credentials from macOS Keychain"
 
   - name: Scaffolder
+    spec_file: docs/interfaces/ifc-scaffolder.yaml
     summary: |
       The Scaffolder struct scaffolds the orchestrator into consuming projects and manages
       test repositories. It depends on git (GitOps) and logf. Created via
       NewScaffolder(git, logf).
-    operations:
-      - "Scaffold(): scaffold orchestrator into consuming project"
-      - "Uninstall(): remove scaffold artifacts from target project"
-      - "PrepareTestRepo(): download and scaffold a test repository for E2E tests"
 
   - name: Stats and Metrics
+    spec_file: docs/interfaces/ifc-stats-and-metrics.yaml
     summary: |
       The Stats struct collects LOC counts, documentation word counts, generator status,
       release statistics, run statistics, and outcome trailer parsing. It depends on
       cfg, logf, git, and tracker. Created via NewStats(cfg, logf, git, tracker).
-    operations:
-      - "PrintStats(): print LOC and documentation metrics as YAML (srd005)"
-      - "CollectStats(): collect LOC and doc metrics programmatically (srd005)"
-      - "GeneratorStats(): print status report for the current generation run (stats:generator)"
-      - "ReleaseStats(): print per-release table with SRD counts (stats:releases)"
-      - "RunStats(name string): print aggregate statistics for a completed generation run (stats:run)"
-      - "CompareRunStats(name1, name2 string): compare two generation runs side by side (stats:compare)"
-      - "Outcomes(): parse and display outcome trailers from git history (stats:outcomes)"
 
   - name: Releaser
+    spec_file: docs/interfaces/ifc-releaser.yaml
     summary: |
       The Releaser struct manages release lifecycle state in road-map.yaml and
       configuration.yaml, and creates versioned documentation tags. It depends only on
       Config. Created via NewReleaser(cfg Config).
-    operations:
-      - "ReleaseUpdate(version string): mark a release complete — set UC statuses to implemented (release:update)"
-      - "ReleaseClear(version string): reverse ReleaseUpdate — reset UC statuses to spec_complete (release:clear)"
-      - "Tag(): create versioned doc-release tag, update version file"
 
   - name: Analyzer
+    spec_file: docs/interfaces/ifc-analyzer.yaml
     summary: |
       The Analyzer struct performs cross-artifact consistency checks, code status detection,
       and pre-cycle analysis. It depends on cfg and logf. Created via NewAnalyzer(cfg, logf).
-    operations:
-      - "Analyze(): cross-artifact consistency checking"
-      - "CodeStatus(): report spec-vs-code gaps per use case and release (srd001)"
-      - "RunPreCycleAnalysis(): write analysis.yaml before each measure/stitch cycle"
-      - "validateDocSchemas(): validate YAML schemas against typed structs"
 
   - name: Comparer
+    spec_file: docs/interfaces/ifc-comparer.yaml
     summary: |
       The Comparer struct runs cross-generation differential comparison between binary
       sources. It depends on logf and git. Created via NewComparer(logf, git).
-    operations:
-      - "Compare(): differential comparison between two git references (srd004)"
-      - "ResolverFromArg(): resolve a BinaryResolver from argument string"
 
   - name: VsCode Manager
+    spec_file: docs/interfaces/ifc-vscode-manager.yaml
     summary: |
       The VsCode struct manages VS Code extension packaging and installation. It depends
       only on logf. Created via NewVsCode(logf).
-    operations:
-      - "VscodePush(): build, package, and install VS Code extension"
-      - "VscodePop(): uninstall VS Code extension"
 
   - name: Claude Runner
+    spec_file: docs/interfaces/ifc-claude-runner.yaml
     summary: |
       The ClaudeRunner struct encapsulates all Claude execution infrastructure shared by
       Measure and Stitch: running Claude (CLI or SDK mode), capturing LOC, saving history
@@ -226,119 +158,59 @@ interfaces:
       via NewClaudeRunner(cfg, git, tracker, sdkQueryFn, logf, extractCredentials, collectStats).
       Cross-domain dependencies (extractCredentials from Builder, collectStats from Stats) are
       passed as function references to avoid circular struct dependencies.
-    data_structures:
-      - "ClaudeRunner: standalone struct with cfg, git, tracker, sdkQueryFn, logf, extractCredentials, collectStats"
-    operations:
-      - "runClaude(): execute Claude and return token usage"
-      - "runMeasureClaude(): execute Claude with measure-specific idle timeout"
-      - "runClaudeSDK(): execute Claude via Go Agent SDK"
-      - "checkClaude(): verify Claude can be invoked"
-      - "captureLOC(): snapshot current Go LOC counts"
-      - "saveHistoryReport/Stats/Prompt/Log(): save history artifacts"
-      - "HistoryClean(): remove history subdirectory"
-      - "CobblerReset(): remove cobbler scratch directory"
-      - "hasOpenIssues(): check for open orchestrator issues"
 
   - name: Git Operations
+    spec_file: docs/interfaces/ifc-git-operations.yaml
     summary: |
       Abstracts all git operations behind a GitOps interface with six role-based
       sub-interfaces. The ShellGitOps implementation executes git commands via
       exec.Command. Components declare dependencies on the narrowest sub-interface
       they need, enabling testability and future non-shell backends.
-    data_structures:
-      - "GitOps: primary interface, 33 methods covering all git operations"
-      - "RepoReader: read-only access (CurrentBranch, BranchExists, ListBranches, ListTags, LsFiles, RevParseHEAD)"
-      - "WorktreeManager: worktree lifecycle (WorktreeAdd, WorktreeRemove, WorktreePrune)"
-      - "BranchManager: branch operations (Checkout, CheckoutNew, CreateBranch, DeleteBranch, ForceDeleteBranch, MergeCmd)"
-      - "CommitWriter: staging and commits (StageAll, StageDir, UnstageAll, HasChanges, Stash, Commit, CommitAllowEmpty, CommitAmendTrailers, ResetSoft)"
-      - "TagManager: tag operations (Tag, TagAt, DeleteTag, RenameTag, ListTags)"
-      - "DiffInspector: diff operations (DiffShortstat, DiffNameStatus, LsTreeFiles, ShowFileContent)"
-      - "DiffStat: parsed output from git diff --shortstat (FilesChanged, Insertions, Deletions)"
-      - "FileChange: per-file diff information (Path, Status, Insertions, Deletions)"
-      - "ShellGitOps: implements GitOps using exec.Command"
 
   - name: Issue Tracking
+    spec_file: docs/interfaces/ifc-issue-tracking.yaml
     summary: |
       Abstracts all issue-tracking operations behind a WorkTracker interface.
       GitHubTracker implements WorkTracker using the gh CLI and GitHub REST API.
       The interface manages issue CRUD, DAG-based dependency promotion, generation
       labelling with 50-char truncation, sub-issue hierarchy, and garbage collection
       of stale generation issues.
-    data_structures:
-      - "WorkTracker: primary interface, 27 methods for issue lifecycle, labels, DAG promotion, defects"
-      - "GitHubTracker: implements WorkTracker using gh CLI and REST API"
-      - "CobblerIssue: issue record (Number, Title, State, Index, DependsOn, Generation, Description, Labels)"
-      - "ProposedIssue: measure output (Index, Title, Description, Dependency)"
-      - "ContextIssue: issue summary for context assembly (ID, Title, Status, Type)"
-      - "CobblerFrontMatter: YAML front-matter parsed from issue body (Generation, Index, DependsOn)"
-    operations:
-      - "DetectGitHubRepo: discover repo from git remote"
-      - "EnsureCobblerLabels: create standard cobbler labels"
-      - "CreateCobblerIssue: create issue with generation label and dependency front-matter"
-      - "ListOpenCobblerIssues: list open issues filtered by generation label"
-      - "PromoteReadyIssues: promote unblocked issues to cobbler-ready based on dependency DAG"
-      - "PickReadyIssue: pick lowest-numbered ready issue, mark in-progress (excludes cobbler-skipped)"
-      - "CloseCobblerIssue: close issue and re-promote dependents"
-      - "GcStaleGenerationIssues: garbage-collect stale generation issues in a single bulk API call"
-      - "LinkSubIssue: link child issue to parent via GitHub sub-issues API"
-      - "FileTargetRepoDefects: file defects in target repos"
-      - "GenLabel: truncate/hash generation labels to 50-char GitHub limit"
 
   - name: Claude Execution
+    spec_file: docs/interfaces/ifc-claude-execution.yaml
     summary: |
       Abstracts Claude invocation behind a Runner interface. Two implementations
       exist: CLIRunner invokes the claude binary directly on the host, SDKRunner
       uses the Go Agent SDK. The effectiveMode() function selects the implementation
       based on cobbler.mode in configuration.yaml. Both return a ClaudeResult with
       token usage, cost, and session metadata.
-    data_structures:
-      - "Runner: interface with Run(ctx, prompt, workDir, silence, extraArgs) returning ClaudeResult"
-      - "CLIRunner: implements Runner via claude CLI binary"
-      - "SDKRunner: implements Runner via Go Agent SDK with sdkEnvMu-serialised env mutation"
-      - "ClaudeResult: token usage (InputTokens, OutputTokens, CacheCreationTokens, CacheReadTokens, CostUSD, RawOutput, NumTurns, DurationAPIMs, RateLimitWaitS, SessionID)"
 
   - name: Binary Resolution
+    spec_file: docs/interfaces/ifc-binary-resolution.yaml
     summary: |
       Abstracts binary resolution for cross-generation differential comparison
       behind a BinaryResolver interface. Three implementations resolve binaries
       from different sources: git tags, GNU coreutils on PATH, and pre-built
       directories. The comparison runner resolves both sides, runs test cases
       from YAML spec test suites, and reports differences.
-    data_structures:
-      - "BinaryResolver: interface with Resolve(utility) and ListUtilities()"
-      - "GitTagResolver: builds binaries from git tags into a temp directory"
-      - "GNUResolver: resolves Homebrew GNU coreutils via g-prefix convention"
-      - "PathResolver: resolves binaries from PATH"
-      - "CompareTestCase: test case loaded from YAML test suite (Input, Expected)"
-      - "TestResult: per-test pass/fail with diff details"
 
   - name: Prompt Templates
+    spec_file: docs/interfaces/ifc-prompt-templates.yaml
     summary: |
       Prompts are Go text/template strings embedded from pkg/orchestrator/prompts/measure.tmpl
       and pkg/orchestrator/prompts/stitch.tmpl. Consuming projects can override them via
       Config.MeasurePrompt and Config.StitchPrompt. Prompts are injected with phase-specific
       constitutions (planning for measure, execution for stitch) and a ProjectContext YAML blob
       containing all docs, specs, source code, and existing issues.
-    data_structures:
-      - "MeasurePromptDoc: Role (string), ProjectContext (*ProjectContext), PlanningConstitution (*yaml.Node), IssueFormatConstitution (*yaml.Node), Task (string), Constraints (string), OutputFormat (string), GoldenExample (string), AdditionalContext (string), ValidationErrors ([]string), PackageContracts ([]OODPackageContractRef)"
-      - "StitchPromptDoc: Role (string), RepositoryFiles ([]string), ProjectContext (*ProjectContext), Context (string), ExecutionConstitution (*yaml.Node), GoStyleConstitution (*yaml.Node), Task (string), Constraints (string), Description (string), SemanticModel (*yaml.Node), SharedProtocols ([]ArchSharedProtocol), PackageContracts ([]OODPackageContractRef)"
 
   - name: Context Assembly
+    spec_file: docs/interfaces/ifc-context-assembly.yaml
     summary: |
       Builds a comprehensive YAML blob (ProjectContext) from the consuming project's
       documentation, specifications, source code, and existing issues. Over 30 struct
       types model the document schema. Phase-specific context files override global
       context settings at invocation time. The assembled context is injected into
       both measure and stitch prompts.
-    data_structures:
-      - "ProjectContext: top-level container (Vision, Architecture, Specifications, Roadmap, Specs, Engineering, Analysis, SourceCode, Issues, CompletedWork, RequirementStates, Extra)"
-      - "PhaseContext: per-phase overrides (Include, Exclude, Sources, Release, ExcludeSource, SourcePatterns, ExcludeTests, SourceMode, SummarizeCommand)"
-      - "VisionDoc, ArchitectureDoc, SpecificationsDoc, RoadmapDoc: top-level document types"
-      - "SRDDoc: product requirement with RequirementGroups, AcceptanceCriteria, ImplementedBy, UsedBy"
-      - "SRDRequirementItem: individual requirement (ID, Text, Weight)"
-      - "UseCaseDoc: use case with SuccessCriteria, InteractionSteps, Touchpoints"
-      - "TestSuiteDoc: test suite with TestCases"
-      - "SourceFile: Go source file (File, Lines)"
 
 components:
   - name: Orchestrator

--- a/docs/interfaces/ifc-analyze-component.yaml
+++ b/docs/interfaces/ifc-analyze-component.yaml
@@ -1,0 +1,55 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-analyze-component
+name: Analyze
+summary: |
+  Standalone Analyzer struct performing cross-artifact consistency checking. Validates SRDs, use
+  cases, and test suites are properly linked and complete. Reports orphaned SRDs, missing test
+  suites, broken touchpoints, schema drift, semantic model violations, and structured traceability
+  chains.
+
+operations:
+  - name: Analyze
+    description: We run the full cross-artifact consistency analysis and print results.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: CodeStatus
+    description: We detect and report the current implementation status of each specification artifact.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: RunPreCycleAnalysis
+    description: We run consistency checks before a measure/stitch cycle and write the results to the scratch directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: validateDocSchemas
+    description: We validate all documentation files against their expected YAML schemas.
+    parameters: []
+    returns:
+      - name: violations
+        type: array
+      - name: error
+        type: error
+
+  - name: CollectAnalyzeResult
+    description: We collect the full analysis result as structured objects for programmatic consumption.
+    parameters: []
+    returns:
+      - name: analysis
+        type: object
+      - name: codeStatus
+        type: object
+      - name: error
+        type: error
+
+references:
+  - srd001-orchestrator-core

--- a/docs/interfaces/ifc-analyzer.yaml
+++ b/docs/interfaces/ifc-analyzer.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-analyzer
+name: Analyzer
+summary: |
+  The Analyzer struct performs cross-artifact consistency checks, code status
+  detection, and pre-cycle analysis. It depends on cfg and logf.
+
+operations:
+  - name: Analyze
+    description: Run all cross-artifact consistency checks and report violations.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: CodeStatus
+    description: Detect the current status of code artifacts relative to specifications.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: RunPreCycleAnalysis
+    description: Execute analysis checks required before a measure-stitch cycle begins.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: validateDocSchemas
+    description: Validate all documentation files against their expected YAML schemas.
+    parameters: []
+    returns:
+      - name: violations
+        type: array
+        description: List of schema validation violation messages.
+
+references:
+  - srd001-orchestrator-core

--- a/docs/interfaces/ifc-binary-resolution.yaml
+++ b/docs/interfaces/ifc-binary-resolution.yaml
@@ -1,0 +1,74 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-binary-resolution
+name: Binary Resolution
+summary: |
+  We abstract binary resolution for cross-generation differential comparison
+  behind a BinaryResolver interface. Three implementations resolve binaries from
+  different sources: git tags, GNU coreutils on PATH, and pre-built directories.
+
+data_structures:
+  - name: BinaryResolver
+    description: Interface with Resolve and ListUtilities methods for locating comparison binaries.
+    fields: []
+
+  - name: GitTagResolver
+    description: Builds binaries from git tags into a temporary directory.
+    fields: []
+
+  - name: GNUResolver
+    description: Resolves Homebrew GNU coreutils via the g-prefix convention.
+    fields: []
+
+  - name: PathResolver
+    description: Resolves binaries from PATH.
+    fields: []
+
+  - name: CompareTestCase
+    description: Test case loaded from a YAML test suite for differential comparison.
+    fields:
+      - name: Input
+        type: string
+        description: Input data for the test case.
+        required: true
+      - name: Expected
+        type: string
+        description: Expected output from the reference binary.
+        required: true
+
+  - name: TestResult
+    description: Per-test pass or fail result with diff details.
+    fields:
+      - name: passed
+        type: boolean
+        description: Whether the test passed.
+        required: true
+      - name: diff
+        type: string
+        description: Diff output when the test fails.
+
+operations:
+  - name: Resolve
+    description: Resolve the filesystem path to a binary for the given utility name.
+    parameters:
+      - name: utility
+        type: string
+        description: Name of the utility to resolve.
+    returns:
+      - name: path
+        type: string
+      - name: error
+        type: error
+  - name: ListUtilities
+    description: List all utilities available through this resolver.
+    parameters: []
+    returns:
+      - name: utilities
+        type: array
+        description: List of available utility names.
+      - name: error
+        type: error
+
+references:
+  - srd004-differential-comparison

--- a/docs/interfaces/ifc-claude-execution.yaml
+++ b/docs/interfaces/ifc-claude-execution.yaml
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-claude-execution
+name: Claude Execution
+summary: |
+  We abstract Claude invocation behind a Runner interface. CLIRunner invokes the
+  claude binary directly on the host, SDKRunner uses the Go Agent SDK. The
+  effectiveMode() function selects the implementation based on cobbler.mode in
+  configuration.yaml.
+
+data_structures:
+  - name: Runner
+    description: Interface with a Run method accepting context, prompt, workDir, silence, and extraArgs.
+    fields: []
+
+  - name: CLIRunner
+    description: Implements Runner by invoking the claude CLI binary on the host.
+    fields: []
+
+  - name: SDKRunner
+    description: Implements Runner via the Go Agent SDK with serialised environment mutation.
+    fields: []
+
+  - name: ClaudeResult
+    description: Token usage and execution metadata returned from a Claude invocation.
+    fields:
+      - name: InputTokens
+        type: integer
+        description: Number of input tokens consumed.
+        required: true
+      - name: OutputTokens
+        type: integer
+        description: Number of output tokens produced.
+        required: true
+      - name: CacheCreationTokens
+        type: integer
+        description: Tokens used for cache creation.
+      - name: CacheReadTokens
+        type: integer
+        description: Tokens read from cache.
+      - name: CostUSD
+        type: number
+        description: Total cost in US dollars.
+      - name: RawOutput
+        type: string
+        description: Raw text output from Claude.
+      - name: NumTurns
+        type: integer
+        description: Number of conversational turns in the session.
+      - name: DurationAPIMs
+        type: integer
+        description: API call duration in milliseconds.
+      - name: RateLimitWaitS
+        type: number
+        description: Time spent waiting on rate limits in seconds.
+      - name: SessionID
+        type: string
+        description: Unique session identifier for the invocation.
+
+operations:
+  - name: Run
+    description: Execute a Claude prompt in the given working directory and return token usage.
+    parameters:
+      - name: prompt
+        type: string
+        description: The prompt text to send to Claude.
+      - name: workDir
+        type: string
+        description: Working directory for the Claude invocation.
+      - name: silence
+        type: boolean
+        description: Whether to suppress output during execution.
+      - name: extraArgs
+        type: array
+        description: Additional command-line arguments passed to the runner.
+    returns:
+      - name: result
+        type: ClaudeResult
+      - name: error
+        type: error
+
+references:
+  - srd003-cobbler-workflows

--- a/docs/interfaces/ifc-claude-runner.yaml
+++ b/docs/interfaces/ifc-claude-runner.yaml
@@ -1,0 +1,129 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-claude-runner
+name: Claude Runner
+summary: |
+  The ClaudeRunner struct encapsulates all Claude execution infrastructure
+  shared by Measure and Stitch: running Claude (CLI or SDK mode), capturing
+  LOC, saving history artifacts, checking credentials, and detecting open
+  issues.
+
+data_structures:
+  - name: ClaudeRunner
+    description: Standalone struct with Claude execution infrastructure shared across workflows.
+    fields:
+      - name: cfg
+        type: object
+        description: Orchestrator configuration.
+      - name: git
+        type: object
+        description: Git operations interface.
+      - name: tracker
+        type: object
+        description: Issue tracking interface.
+      - name: sdkQueryFn
+        type: object
+        description: Function for executing Claude SDK queries.
+      - name: logf
+        type: object
+        description: Logging function for execution events.
+      - name: extractCredentials
+        type: object
+        description: Function to extract Claude API credentials.
+      - name: collectStats
+        type: object
+        description: Function to collect execution statistics.
+
+operations:
+  - name: runClaude
+    description: Run Claude using the configured mode and return the execution result.
+    parameters: []
+    returns:
+      - name: result
+        type: object
+        description: Claude execution result.
+      - name: error
+        type: error
+  - name: runMeasureClaude
+    description: Run Claude in measure mode with LOC capture and history artifacts.
+    parameters: []
+    returns:
+      - name: result
+        type: object
+        description: Measure execution result.
+      - name: error
+        type: error
+  - name: runClaudeSDK
+    description: Run Claude through the SDK interface instead of the CLI.
+    parameters: []
+    returns:
+      - name: result
+        type: object
+        description: SDK execution result.
+      - name: error
+        type: error
+  - name: checkClaude
+    description: Verify that Claude credentials and configuration are valid.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: captureLOC
+    description: Capture lines-of-code metrics for the current working state.
+    parameters: []
+    returns:
+      - name: metrics
+        type: object
+        description: Captured LOC metrics.
+      - name: error
+        type: error
+  - name: saveHistoryReport
+    description: Save the execution report to the history directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: saveHistoryStats
+    description: Save execution statistics to the history directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: saveHistoryPrompt
+    description: Save the prompt used for Claude execution to the history directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: saveHistoryLog
+    description: Save the execution log to the history directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: HistoryClean
+    description: Remove all history artifacts from the history directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: CobblerReset
+    description: Reset cobbler state to a clean initial configuration.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: hasOpenIssues
+    description: Check whether there are open issues remaining in the tracker.
+    parameters: []
+    returns:
+      - name: has_open
+        type: boolean
+        description: True if open issues exist.
+      - name: error
+        type: error
+
+references:
+  - srd003-cobbler-workflows
+  - srd005-metrics-collection

--- a/docs/interfaces/ifc-cobbler-common.yaml
+++ b/docs/interfaces/ifc-cobbler-common.yaml
@@ -1,0 +1,127 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-cobbler-common
+name: Cobbler Common
+summary: |
+  Standalone ClaudeRunner struct encapsulating Claude execution infrastructure
+  shared by Measure and Stitch. Dispatches Claude invocation to CLI or SDK mode,
+  captures token usage, snapshots LOC, saves history artifacts, and logs real-time
+  progress.
+
+data_structures:
+  - name: ClaudeRunner
+    description: Shared Claude execution infrastructure composed into Measure and Stitch.
+    fields:
+      - name: config
+        type: object
+        description: Configuration object for Claude invocation settings.
+        required: true
+      - name: git
+        type: object
+        description: GitOps instance for repository operations.
+        required: true
+      - name: tracker
+        type: object
+        description: WorkTracker instance for issue management.
+        required: true
+      - name: sdk_query_fn
+        type: object
+        description: Function reference for SDK-mode Claude queries.
+      - name: log_function
+        type: object
+        description: Logging function with optional generation tagging.
+      - name: extract_credentials
+        type: object
+        description: Function reference for extracting API credentials.
+      - name: collect_stats
+        type: object
+        description: Function reference for collecting invocation statistics.
+
+operations:
+  - name: runClaude
+    description: Dispatch Claude invocation to CLI or SDK mode based on configuration.
+    parameters: []
+    returns:
+      - name: result
+        type: object
+      - name: error
+        type: error
+  - name: runMeasureClaude
+    description: Invoke Claude with the measure prompt and parse the response.
+    parameters: []
+    returns:
+      - name: result
+        type: object
+      - name: error
+        type: error
+  - name: runClaudeSDK
+    description: Invoke Claude via the SDK with structured request and response handling.
+    parameters: []
+    returns:
+      - name: result
+        type: object
+      - name: error
+        type: error
+  - name: checkClaude
+    description: Verify that the Claude CLI or SDK is available and properly configured.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: captureLOC
+    description: Snapshot lines-of-code metrics for the current repository state.
+    parameters: []
+    returns:
+      - name: stats
+        type: object
+      - name: error
+        type: error
+  - name: saveHistoryReport
+    description: Save the generation report artifact to the history directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: saveHistoryStats
+    description: Save invocation statistics artifact to the history directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: saveHistoryPrompt
+    description: Save the assembled prompt artifact to the history directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: saveHistoryLog
+    description: Save the Claude invocation log artifact to the history directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: HistoryClean
+    description: Remove all history artifacts from the history directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: CobblerReset
+    description: Reset cobbler state including history, labels, and generation artifacts.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: hasOpenIssues
+    description: Check whether any cobbler-managed issues are still open.
+    parameters: []
+    returns:
+      - name: has_open
+        type: boolean
+      - name: error
+        type: error
+
+references:
+  - srd003-cobbler-workflows
+  - srd005-metrics-collection

--- a/docs/interfaces/ifc-cobbler-measure.yaml
+++ b/docs/interfaces/ifc-cobbler-measure.yaml
@@ -1,0 +1,47 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-cobbler-measure
+name: "Cobbler - Measure"
+summary: |
+  Standalone Measure struct. Builds the measure prompt from existing issues and
+  project state, invokes Claude, parses the YAML output, and creates GitHub Issues
+  with dependency labels via the gh CLI. Records invocation metrics and saves
+  history artifacts per iteration.
+
+operations:
+  - name: Measure
+    description: Execute the full measure workflow including prompt assembly, Claude invocation, and issue creation.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: MeasurePrompt
+    description: Assemble and return the measure prompt without invoking Claude.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: RunMeasure
+    description: Run the measure phase within a generation cycle.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: buildMeasurePrompt
+    description: Build the measure prompt string from existing issues and project state.
+    parameters: []
+    returns:
+      - name: prompt
+        type: string
+      - name: error
+        type: error
+  - name: importIssues
+    description: Parse Claude YAML output and create GitHub Issues with dependency labels.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd003-cobbler-workflows

--- a/docs/interfaces/ifc-cobbler-stitch.yaml
+++ b/docs/interfaces/ifc-cobbler-stitch.yaml
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-cobbler-stitch
+name: "Cobbler - Stitch"
+summary: |
+  Standalone Stitch struct. Picks ready GitHub Issues, creates worktrees, invokes
+  Claude, commits changes, merges branches, records metrics, and closes tasks.
+  Saves history artifacts per task and handles recovery of stale tasks from
+  interrupted runs.
+
+operations:
+  - name: Stitch
+    description: Execute the full stitch workflow for all ready issues.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: RunStitch
+    description: Run the stitch phase within a generation cycle.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: RunStitchN
+    description: Run the stitch phase for up to a specified number of tasks.
+    parameters:
+      - name: limit
+        type: integer
+        description: Maximum number of tasks to stitch.
+    returns:
+      - name: error
+        type: error
+  - name: doOneTask
+    description: Execute the stitch workflow for a single ready issue.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: resetTask
+    description: Reset a task that failed or was interrupted back to the ready state.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: skipTask
+    description: Mark a task as skipped and move to the next ready issue.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd003-cobbler-workflows

--- a/docs/interfaces/ifc-code-status.yaml
+++ b/docs/interfaces/ifc-code-status.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-code-status
+name: Code Status
+summary: |
+  We implement the CodeStatus() method (exposed as mage status). We scan the
+  tests/ directory for per-use-case test subdirectories, compare presence of
+  test files against roadmap spec status, and report gaps.
+
+operations:
+  - name: CodeStatus
+    description: Scan test directories against roadmap specs and report status gaps.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: WriteCodeStatusReport
+    description: Write the code status report to the configured output destination.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd001-orchestrator-core

--- a/docs/interfaces/ifc-commands.yaml
+++ b/docs/interfaces/ifc-commands.yaml
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-commands
+name: Commands
+summary: |
+  Wrapper functions for external tools. Functions wrapping git and Go CLI commands.
+  Centralizes binary names as constants and provides structured access to command
+  output.
+
+operations:
+  - name: gitBranch
+    description: Return the current git branch name.
+    parameters: []
+    returns:
+      - name: branch
+        type: string
+      - name: error
+        type: error
+  - name: gitWorktree
+    description: Manage git worktree operations (add, remove, prune).
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: gitTag
+    description: Create or manage git tags.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: gitMerge
+    description: Merge a branch into the current branch.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: gitDiff
+    description: Run a git diff and return structured diff output.
+    parameters: []
+    returns:
+      - name: diff
+        type: object
+      - name: error
+        type: error
+  - name: goBuild
+    description: Run go build on the target package.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: goVet
+    description: Run go vet on the target package.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd001-orchestrator-core

--- a/docs/interfaces/ifc-comparer.yaml
+++ b/docs/interfaces/ifc-comparer.yaml
@@ -1,0 +1,28 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-comparer
+name: Comparer
+summary: |
+  The Comparer struct runs cross-generation differential comparison between
+  binary sources. It depends on logf and git.
+
+operations:
+  - name: Compare
+    description: Run differential comparison between binary sources across generations.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: ResolverFromArg
+    description: Resolve a comparison target from a command-line argument.
+    parameters: []
+    returns:
+      - name: resolver
+        type: object
+        description: The resolved comparison target.
+      - name: error
+        type: error
+
+references:
+  - srd004-differential-comparison

--- a/docs/interfaces/ifc-config-component.yaml
+++ b/docs/interfaces/ifc-config-component.yaml
@@ -1,0 +1,44 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-config-component
+name: Config
+summary: |
+  Config struct with YAML tags, LoadConfig() for reading configuration.yaml, SeedData template
+  data, and applyDefaults() for zero-value fields. CobblerConfig includes MinMeasureIssues,
+  MaxRequirementsPerTask, and MaxWeightPerTask.
+
+operations:
+  - name: LoadConfig
+    description: We read and parse the configuration.yaml file at the given path into a Config struct.
+    parameters:
+      - name: path
+        type: string
+        description: Path to the configuration.yaml file.
+    returns:
+      - name: config
+        type: object
+      - name: error
+        type: error
+
+  - name: Silence
+    description: We return whether the configuration has silenced all output.
+    parameters: []
+    returns:
+      - name: silenced
+        type: boolean
+
+  - name: EffectiveTokenFile
+    description: We return the resolved path to the token file, applying defaults if not explicitly configured.
+    parameters: []
+    returns:
+      - name: path
+        type: string
+
+  - name: applyDefaults
+    description: We fill zero-value fields in the config with their default values.
+    parameters: []
+    returns: []
+
+references:
+  - srd001-orchestrator-core

--- a/docs/interfaces/ifc-constitutions.yaml
+++ b/docs/interfaces/ifc-constitutions.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-constitutions
+name: Constitutions
+summary: |
+  Seven YAML constitutions govern different workflow phases. Design, planning, and execution are
+  the three primary constitutions. Go-style, issue-format, testing, and interface provide
+  supplementary rules. Design and interface are scaffolded to consuming projects; all others are
+  embedded in the binary.
+
+operations:
+  - name: ConstitutionToMarkdown
+    description: We convert constitution sections into a markdown string for prompt inclusion.
+    parameters:
+      - name: sections
+        type: array
+        description: List of constitution sections to render.
+    returns:
+      - name: markdown
+        type: string
+
+  - name: ConstitutionPreviewFile
+    description: We write a preview of the constitution at the given path for inspection.
+    parameters:
+      - name: path
+        type: string
+        description: Path to the constitution file to preview.
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd001-orchestrator-core

--- a/docs/interfaces/ifc-context-assembly-component.yaml
+++ b/docs/interfaces/ifc-context-assembly-component.yaml
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-context-assembly-component
+name: Context Assembly
+summary: |
+  We build a comprehensive YAML blob (ProjectContext) from documentation, specifications, source
+  code, and existing issues. Over 30 struct types model the document schema. Phase-specific context
+  files override global context settings at invocation time.
+
+data_structures:
+  - name: ProjectContext
+    description: Top-level container aggregating all project documentation, code, and issue state.
+    fields:
+      - name: vision
+        type: object
+        description: Parsed vision document.
+      - name: architecture
+        type: object
+        description: Parsed architecture document.
+      - name: specifications
+        type: object
+        description: Parsed specifications document.
+      - name: roadmap
+        type: object
+        description: Parsed roadmap document.
+      - name: specs
+        type: object
+        description: Collection of SRDs and use cases.
+      - name: engineering
+        type: array
+        description: List of parsed engineering guidelines.
+      - name: interface_specs
+        type: array
+        description: List of parsed interface specifications.
+      - name: analysis
+        type: object
+        description: Cross-artifact analysis results.
+      - name: source_code
+        type: array
+        description: List of source code file entries.
+      - name: issues
+        type: array
+        description: List of open issues for context.
+      - name: completed_work
+        type: array
+        description: List of completed issues for historical context.
+      - name: requirement_states
+        type: object
+        description: Mapping of requirement IDs to their implementation states.
+      - name: extra
+        type: array
+        description: Additional context entries from phase-specific overrides.
+
+  - name: PhaseContext
+    description: Per-phase overrides controlling what context is assembled for a given invocation.
+    fields:
+      - name: include
+        type: string
+        description: Glob pattern for documents to include.
+      - name: exclude
+        type: string
+        description: Glob pattern for documents to exclude.
+      - name: sources
+        type: string
+        description: Source inclusion directive.
+      - name: release
+        type: string
+        description: Release identifier to scope context to.
+      - name: exclude_source
+        type: boolean
+        description: Whether to exclude source code from context.
+      - name: source_patterns
+        type: string
+        description: Glob patterns for source file selection.
+      - name: exclude_tests
+        type: boolean
+        description: Whether to exclude test files from context.
+      - name: source_mode
+        type: string
+        description: Source inclusion mode (full, summary, none).
+      - name: summarize_command
+        type: string
+        description: Command to run for source summarization.
+
+operations:
+  - name: BuildProjectContext
+    description: We assemble the full project context from documentation, code, and issue state.
+    parameters:
+      - name: existingIssuesJSON
+        type: string
+        description: JSON-encoded list of existing issues.
+      - name: project
+        type: object
+        description: Project configuration.
+      - name: phaseCtx
+        type: object
+        description: Phase-specific context overrides.
+      - name: cobblerDir
+        type: string
+        description: Path to the cobbler configuration directory.
+    returns:
+      - name: context
+        type: object
+      - name: error
+        type: error
+
+  - name: LoadPhaseContext
+    description: We load phase-specific context overrides from a YAML file.
+    parameters:
+      - name: path
+        type: string
+        description: Path to the phase context YAML file.
+    returns:
+      - name: phaseCtx
+        type: object
+      - name: error
+        type: error
+
+  - name: ResolveStandardFiles
+    description: We resolve the standard set of context files from the project directory.
+    parameters: []
+    returns:
+      - name: files
+        type: array
+
+  - name: ClassifyContextFile
+    description: We classify a context file by its path into a document category.
+    parameters:
+      - name: path
+        type: string
+        description: Path to the context file to classify.
+    returns:
+      - name: category
+        type: string
+
+  - name: LoadSRDSemanticModel
+    description: We load the SRD semantic model for interface-aware code generation.
+    parameters: []
+    returns:
+      - name: model
+        type: object
+
+references:
+  - srd003-cobbler-workflows
+  - eng08-phase-context-files

--- a/docs/interfaces/ifc-context-assembly.yaml
+++ b/docs/interfaces/ifc-context-assembly.yaml
@@ -1,0 +1,130 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-context-assembly
+name: Context Assembly
+summary: |
+  We build a comprehensive YAML blob (ProjectContext) from the consuming project's
+  documentation, specifications, source code, and existing issues. Over 30 struct
+  types model the document schema. Phase-specific context files override global
+  context settings at invocation time.
+
+data_structures:
+  - name: ProjectContext
+    description: Top-level container aggregating all project documentation, code, and issue state.
+    fields:
+      - name: Vision
+        type: object
+        description: Parsed vision document.
+      - name: Architecture
+        type: object
+        description: Parsed architecture document.
+      - name: Specifications
+        type: object
+        description: Parsed specifications document.
+      - name: Roadmap
+        type: object
+        description: Parsed roadmap document.
+      - name: Specs
+        type: object
+        description: Collection of SRDs and use cases.
+      - name: Engineering
+        type: array
+        description: List of parsed engineering guidelines.
+      - name: InterfaceSpecs
+        type: array
+        description: List of parsed interface specifications.
+      - name: Analysis
+        type: object
+        description: Cross-artifact analysis results.
+      - name: SourceCode
+        type: array
+        description: List of source code file entries.
+      - name: Issues
+        type: array
+        description: List of open issues for context.
+      - name: CompletedWork
+        type: array
+        description: List of completed issues for historical context.
+      - name: RequirementStates
+        type: object
+        description: Mapping of requirement IDs to their implementation states.
+      - name: Extra
+        type: array
+        description: Additional context entries from phase-specific overrides.
+
+  - name: PhaseContext
+    description: Per-phase overrides controlling what context is assembled for a given invocation.
+    fields:
+      - name: Include
+        type: string
+        description: Glob pattern for documents to include.
+      - name: Exclude
+        type: string
+        description: Glob pattern for documents to exclude.
+      - name: Sources
+        type: string
+        description: Source inclusion directive.
+      - name: Release
+        type: string
+        description: Release identifier to scope context to.
+      - name: ExcludeSource
+        type: boolean
+        description: Whether to exclude source code from context.
+      - name: SourcePatterns
+        type: string
+        description: Glob patterns for source file selection.
+      - name: ExcludeTests
+        type: boolean
+        description: Whether to exclude test files from context.
+      - name: SourceMode
+        type: string
+        description: Source inclusion mode (full, summary, none).
+      - name: SummarizeCommand
+        type: string
+        description: Command to run for source summarization.
+
+operations:
+  - name: BuildProjectContext
+    description: Assemble the full project context from documentation, code, and issue state.
+    parameters:
+      - name: existingIssuesJSON
+        type: string
+        description: JSON-encoded list of existing issues.
+      - name: project
+        type: object
+        description: Project configuration.
+      - name: phaseCtx
+        type: PhaseContext
+        description: Phase-specific context overrides.
+      - name: cobblerDir
+        type: string
+        description: Path to the cobbler configuration directory.
+    returns:
+      - name: context
+        type: ProjectContext
+      - name: error
+        type: error
+  - name: LoadPhaseContext
+    description: Load phase-specific context overrides from a YAML file.
+    parameters:
+      - name: path
+        type: string
+        description: Path to the phase context YAML file.
+    returns:
+      - name: phaseCtx
+        type: PhaseContext
+      - name: error
+        type: error
+  - name: LoadSRDSemanticModel
+    description: Load the SRD semantic model for interface-aware code generation.
+    parameters: []
+    returns:
+      - name: model
+        type: object
+      - name: error
+        type: error
+
+references:
+  - srd003-cobbler-workflows
+  - eng08-phase-context-files

--- a/docs/interfaces/ifc-cross-generation-comparison.yaml
+++ b/docs/interfaces/ifc-cross-generation-comparison.yaml
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-cross-generation-comparison
+name: Cross-Generation Comparison
+summary: |
+  We build binaries from two git references and run test cases loaded from YAML
+  spec test suites to detect behavioral differences between implementations.
+
+data_structures:
+  - name: CompareTestCase
+    description: Test case loaded from a YAML test suite for cross-generation comparison.
+    fields:
+      - name: input
+        type: string
+        description: Input data for the test case.
+      - name: expected
+        type: string
+        description: Expected output for the test case.
+      - name: command
+        type: string
+        description: Command to execute for the test case.
+
+  - name: TestResult
+    description: Per-test result from a cross-generation comparison run.
+    fields:
+      - name: name
+        type: string
+        description: Name of the test case.
+      - name: passed
+        type: boolean
+        description: Whether the test case passed.
+      - name: diff
+        type: string
+        description: Diff output when the test case failed.
+
+operations:
+  - name: Compare
+    description: Build binaries from two git references and compare their test outputs.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: ResolverFromArg
+    description: Create a binary resolver from a git reference argument.
+    parameters:
+      - name: arg
+        type: string
+        description: Git reference or path argument to resolve.
+    returns:
+      - name: resolver
+        type: object
+      - name: error
+        type: error
+  - name: RunTestCases
+    description: Run loaded test cases against two resolved binaries and collect results.
+    parameters:
+      - name: resolver1
+        type: object
+        description: First binary resolver.
+      - name: resolver2
+        type: object
+        description: Second binary resolver.
+    returns:
+      - name: results
+        type: array
+        description: List of TestResult entries.
+      - name: error
+        type: error
+
+references:
+  - srd004-differential-comparison

--- a/docs/interfaces/ifc-generator-component.yaml
+++ b/docs/interfaces/ifc-generator-component.yaml
@@ -1,0 +1,80 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-generator-component
+name: Generator
+summary: |
+  Standalone Generator struct managing the generation lifecycle. Composes Measure,
+  Stitch, Analyzer, Releaser, and ClaudeRunner. Creates generation branches, runs
+  cycles, merges results to the base branch, handles resume from interrupted runs.
+
+operations:
+  - name: GeneratorStart
+    description: Start a new generation by creating a generation branch and initializing state.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorRun
+    description: Run a specified number of measure-stitch cycles within the current generation.
+    parameters:
+      - name: cycles
+        type: integer
+        description: Number of cycles to execute.
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorResume
+    description: Resume an interrupted generation from its last checkpoint.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorStop
+    description: Stop the current generation gracefully and merge results to the base branch.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorReset
+    description: Reset generation state, discarding uncommitted generation progress.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorList
+    description: List all existing generations with their status.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GeneratorSwitch
+    description: Switch to a different existing generation branch.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: RunCycles
+    description: Execute measure-stitch cycles with a descriptive label for logging.
+    parameters:
+      - name: label
+        type: string
+        description: Descriptive label for the cycle run.
+    returns:
+      - name: error
+        type: error
+  - name: Init
+    description: Initialize the generator, validating configuration and prerequisites.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: FullReset
+    description: Perform a complete reset of all generation state including branches and tags.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd002-generation-lifecycle

--- a/docs/interfaces/ifc-github-issues.yaml
+++ b/docs/interfaces/ifc-github-issues.yaml
@@ -1,0 +1,146 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-github-issues
+name: GitHub Issues
+summary: |
+  We manage GitHub Issues as the task tracker for cobbler workflows. GitHubTracker
+  implements the WorkTracker interface using the gh CLI and GitHub REST API. Provides
+  DAG-based promotion of ready issues and garbage collection of stale generation
+  issues.
+
+data_structures:
+  - name: WorkTracker
+    description: Primary interface defining 27 methods for issue lifecycle, labels, DAG promotion, and defects.
+    fields: []
+
+  - name: GitHubTracker
+    description: Implements WorkTracker using the gh CLI and GitHub REST API.
+    fields: []
+
+  - name: CobblerIssue
+    description: Issue record representing a cobbler-managed GitHub issue.
+    fields:
+      - name: number
+        type: integer
+        description: GitHub issue number.
+        required: true
+      - name: title
+        type: string
+        description: Issue title.
+        required: true
+      - name: state
+        type: string
+        description: Issue state (open, closed).
+        required: true
+      - name: index
+        type: integer
+        description: Position index within the generation.
+        required: true
+      - name: depends_on
+        type: array
+        description: List of issue indices this issue depends on.
+      - name: generation
+        type: string
+        description: Generation label this issue belongs to.
+      - name: description
+        type: string
+        description: Issue body text.
+      - name: labels
+        type: array
+        description: GitHub labels applied to the issue.
+
+  - name: CobblerFrontMatter
+    description: YAML front-matter parsed from the issue body.
+    fields:
+      - name: generation
+        type: string
+        description: Generation label.
+        required: true
+      - name: index
+        type: integer
+        description: Position index within the generation.
+        required: true
+      - name: depends_on
+        type: array
+        description: List of issue indices this issue depends on.
+
+operations:
+  - name: DetectGitHubRepo
+    description: Detect the GitHub repository from the current git remote.
+    parameters: []
+    returns:
+      - name: repo
+        type: string
+      - name: error
+        type: error
+  - name: EnsureCobblerLabels
+    description: Create cobbler-managed labels in the repository if they do not exist.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: CreateCobblerIssue
+    description: Create a new cobbler-managed GitHub issue with front-matter and labels.
+    parameters: []
+    returns:
+      - name: number
+        type: integer
+      - name: error
+        type: error
+  - name: ListOpenCobblerIssues
+    description: List all open issues with the cobbler label.
+    parameters: []
+    returns:
+      - name: issues
+        type: array
+        description: List of CobblerIssue entries.
+      - name: error
+        type: error
+  - name: PromoteReadyIssues
+    description: Promote issues whose DAG dependencies are satisfied to the ready state.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: PickReadyIssue
+    description: Select the next ready issue for stitch execution.
+    parameters: []
+    returns:
+      - name: issue
+        type: object
+      - name: error
+        type: error
+  - name: CloseCobblerIssue
+    description: Close a cobbler-managed issue after successful stitch.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GcStaleGenerationIssues
+    description: Garbage-collect open issues from previous generations that are no longer relevant.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: LinkSubIssue
+    description: Link a sub-issue to its parent in the GitHub issue hierarchy.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: FileTargetRepoDefects
+    description: File defect issues in the target repository for failures detected during stitch.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GenLabel
+    description: Generate a generation label with 50-character truncation.
+    parameters: []
+    returns:
+      - name: label
+        type: string
+
+references:
+  - srd003-cobbler-workflows

--- a/docs/interfaces/ifc-gitops.yaml
+++ b/docs/interfaces/ifc-gitops.yaml
@@ -1,0 +1,226 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-gitops
+name: GitOps
+summary: |
+  We define a GitOps interface that abstracts all git operations. The ShellGitOps
+  implementation executes git commands via exec.Command. The interface enables
+  testing with mock implementations.
+
+data_structures:
+  - name: GitOps
+    description: Primary interface with 50+ git operations covering branches, tags, worktrees, diffs, and commits.
+    fields: []
+
+  - name: RepoReader
+    description: Read-only sub-interface for repository state queries.
+    fields:
+      - name: CurrentBranch
+        type: string
+        description: Return the current branch name.
+      - name: BranchExists
+        type: boolean
+        description: Check whether a branch exists.
+      - name: ListBranches
+        type: array
+        description: List all local branches.
+      - name: ListTags
+        type: array
+        description: List all tags.
+      - name: LsFiles
+        type: array
+        description: List tracked files.
+      - name: RevParseHEAD
+        type: string
+        description: Return the SHA of HEAD.
+
+  - name: WorktreeManager
+    description: Worktree lifecycle sub-interface for adding, removing, and pruning worktrees.
+    fields:
+      - name: WorktreeAdd
+        type: object
+        description: Add a new worktree at a path for a branch.
+      - name: WorktreeRemove
+        type: object
+        description: Remove an existing worktree.
+      - name: WorktreePrune
+        type: object
+        description: Prune stale worktree references.
+
+  - name: BranchManager
+    description: Branch operations sub-interface for checkout, creation, deletion, and merge.
+    fields:
+      - name: Checkout
+        type: object
+        description: Check out an existing branch.
+      - name: CheckoutNew
+        type: object
+        description: Create and check out a new branch.
+      - name: CreateBranch
+        type: object
+        description: Create a new branch without checking it out.
+      - name: DeleteBranch
+        type: object
+        description: Delete a branch.
+      - name: MergeCmd
+        type: object
+        description: Merge a branch into the current branch.
+
+  - name: CommitWriter
+    description: Staging and commits sub-interface for adding, checking, and committing changes.
+    fields:
+      - name: StageAll
+        type: object
+        description: Stage all changes for commit.
+      - name: HasChanges
+        type: boolean
+        description: Check whether the working tree has uncommitted changes.
+      - name: Commit
+        type: object
+        description: Create a commit with a message.
+      - name: CommitAllowEmpty
+        type: object
+        description: Create a commit even when there are no changes.
+
+  - name: TagManager
+    description: Tag operations sub-interface for creating, deleting, renaming, and listing tags.
+    fields:
+      - name: Tag
+        type: object
+        description: Create a tag at HEAD.
+      - name: TagAt
+        type: object
+        description: Create a tag at a specific ref.
+      - name: DeleteTag
+        type: object
+        description: Delete a tag.
+      - name: RenameTag
+        type: object
+        description: Rename a tag.
+      - name: ListTags
+        type: array
+        description: List all tags.
+
+  - name: DiffInspector
+    description: Diff operations sub-interface for statistics, file status, and content inspection.
+    fields:
+      - name: DiffShortstat
+        type: object
+        description: Return parsed diff statistics between two refs.
+      - name: DiffNameStatus
+        type: object
+        description: Return per-file change status between two refs.
+      - name: LsTreeFiles
+        type: array
+        description: List files in a tree object.
+      - name: ShowFileContent
+        type: string
+        description: Return file content at a specific ref.
+
+  - name: DiffStat
+    description: Parsed diff statistics for a range of commits.
+    fields:
+      - name: files_changed
+        type: integer
+        description: Number of files changed.
+        required: true
+      - name: insertions
+        type: integer
+        description: Number of lines inserted.
+        required: true
+      - name: deletions
+        type: integer
+        description: Number of lines deleted.
+        required: true
+
+  - name: FileChange
+    description: Per-file diff information including path, status, and line counts.
+    fields:
+      - name: path
+        type: string
+        description: File path relative to the repository root.
+        required: true
+      - name: status
+        type: string
+        description: Change status (added, modified, deleted, renamed).
+        required: true
+      - name: insertions
+        type: integer
+        description: Number of lines inserted in this file.
+        required: true
+      - name: deletions
+        type: integer
+        description: Number of lines deleted in this file.
+        required: true
+
+  - name: ShellGitOps
+    description: Implements GitOps using exec.Command to execute git commands in a shell.
+    fields: []
+
+operations:
+  - name: Checkout
+    description: Check out an existing branch.
+    parameters:
+      - name: branch
+        type: string
+        description: Branch name to check out.
+    returns:
+      - name: error
+        type: error
+  - name: CreateBranch
+    description: Create a new branch at the current HEAD.
+    parameters:
+      - name: branch
+        type: string
+        description: Name of the branch to create.
+    returns:
+      - name: error
+        type: error
+  - name: Tag
+    description: Create a tag at HEAD.
+    parameters:
+      - name: name
+        type: string
+        description: Tag name.
+    returns:
+      - name: error
+        type: error
+  - name: Commit
+    description: Create a commit with the given message.
+    parameters:
+      - name: message
+        type: string
+        description: Commit message.
+    returns:
+      - name: error
+        type: error
+  - name: DiffShortstat
+    description: Return parsed diff statistics between two refs.
+    parameters:
+      - name: from
+        type: string
+        description: Starting ref for the diff.
+      - name: to
+        type: string
+        description: Ending ref for the diff.
+    returns:
+      - name: stat
+        type: DiffStat
+      - name: error
+        type: error
+  - name: WorktreeAdd
+    description: Add a new worktree at the given path for the specified branch.
+    parameters:
+      - name: path
+        type: string
+        description: Filesystem path for the worktree.
+      - name: branch
+        type: string
+        description: Branch to check out in the worktree.
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd001-orchestrator-core

--- a/docs/interfaces/ifc-issue-tracking.yaml
+++ b/docs/interfaces/ifc-issue-tracking.yaml
@@ -1,0 +1,186 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-issue-tracking
+name: Issue Tracking
+summary: |
+  We abstract all issue-tracking operations behind a WorkTracker interface.
+  GitHubTracker implements WorkTracker using the gh CLI and GitHub REST API.
+  The interface manages issue CRUD, DAG-based dependency promotion, generation
+  labelling with 50-char truncation, sub-issue hierarchy, and garbage collection
+  of stale generation issues.
+
+data_structures:
+  - name: WorkTracker
+    description: Primary interface defining 27 methods for issue lifecycle, labels, DAG promotion, and defects.
+    fields: []
+
+  - name: GitHubTracker
+    description: Implements WorkTracker using the gh CLI and GitHub REST API.
+    fields: []
+
+  - name: CobblerIssue
+    description: Issue record representing a cobbler-managed GitHub issue.
+    fields:
+      - name: Number
+        type: integer
+        description: GitHub issue number.
+        required: true
+      - name: Title
+        type: string
+        description: Issue title.
+        required: true
+      - name: State
+        type: string
+        description: Issue state (open, closed).
+        required: true
+      - name: Index
+        type: integer
+        description: Position index within the generation.
+        required: true
+      - name: DependsOn
+        type: array
+        description: List of issue indices this issue depends on.
+      - name: Generation
+        type: string
+        description: Generation label this issue belongs to.
+      - name: Description
+        type: string
+        description: Issue body text.
+      - name: Labels
+        type: array
+        description: GitHub labels applied to the issue.
+
+  - name: ProposedIssue
+    description: Measure output representing a proposed issue before creation.
+    fields:
+      - name: Index
+        type: integer
+        description: Position index in the proposed plan.
+        required: true
+      - name: Title
+        type: string
+        description: Proposed issue title.
+        required: true
+      - name: Description
+        type: string
+        description: Proposed issue body.
+        required: true
+      - name: Dependency
+        type: integer
+        description: Index of the issue this one depends on.
+
+  - name: ContextIssue
+    description: Issue summary used for context assembly.
+    fields:
+      - name: ID
+        type: integer
+        description: GitHub issue number.
+        required: true
+      - name: Title
+        type: string
+        description: Issue title.
+        required: true
+      - name: Status
+        type: string
+        description: Current issue status.
+        required: true
+      - name: Type
+        type: string
+        description: Issue type classification.
+        required: true
+
+  - name: CobblerFrontMatter
+    description: YAML front-matter parsed from the issue body.
+    fields:
+      - name: Generation
+        type: string
+        description: Generation label.
+        required: true
+      - name: Index
+        type: integer
+        description: Position index within the generation.
+        required: true
+      - name: DependsOn
+        type: array
+        description: List of issue indices this issue depends on.
+
+operations:
+  - name: DetectGitHubRepo
+    description: Detect the GitHub repository from the current git remote.
+    parameters: []
+    returns:
+      - name: repo
+        type: string
+      - name: error
+        type: error
+  - name: EnsureCobblerLabels
+    description: Create cobbler-managed labels in the repository if they do not exist.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: CreateCobblerIssue
+    description: Create a new cobbler-managed GitHub issue with front-matter and labels.
+    parameters: []
+    returns:
+      - name: number
+        type: integer
+      - name: error
+        type: error
+  - name: ListOpenCobblerIssues
+    description: List all open issues with the cobbler label.
+    parameters: []
+    returns:
+      - name: issues
+        type: array
+        description: List of CobblerIssue entries.
+      - name: error
+        type: error
+  - name: PromoteReadyIssues
+    description: Promote issues whose DAG dependencies are satisfied to the ready state.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: PickReadyIssue
+    description: Select the next ready issue for stitch execution.
+    parameters: []
+    returns:
+      - name: issue
+        type: CobblerIssue
+      - name: error
+        type: error
+  - name: CloseCobblerIssue
+    description: Close a cobbler-managed issue after successful stitch.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GcStaleGenerationIssues
+    description: Garbage-collect open issues from previous generations that are no longer relevant.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: LinkSubIssue
+    description: Link a sub-issue to its parent in the GitHub issue hierarchy.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: FileTargetRepoDefects
+    description: File defect issues in the target repository for failures detected during stitch.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: GenLabel
+    description: Generate a generation label with 50-character truncation.
+    parameters: []
+    returns:
+      - name: label
+        type: string
+
+references:
+  - srd003-cobbler-workflows

--- a/docs/interfaces/ifc-logging.yaml
+++ b/docs/interfaces/ifc-logging.yaml
@@ -1,0 +1,50 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-logging
+name: Logging
+summary: |
+  Phase-aware structured logging to stderr. The logf() function includes timestamp, generation
+  name (when set), and phase name with elapsed time. Domain structs receive logf and state
+  callbacks via constructor injection.
+
+operations:
+  - name: logf
+    description: We write a formatted log message to stderr with timestamp, generation, and phase context.
+    parameters:
+      - name: format
+        type: string
+        description: Printf-style format string.
+      - name: args
+        type: array
+        description: Arguments for the format string.
+    returns: []
+
+  - name: setPhase
+    description: We set the current phase name for subsequent log messages and start the phase timer.
+    parameters:
+      - name: name
+        type: string
+        description: Name of the phase to set.
+    returns: []
+
+  - name: clearPhase
+    description: We clear the current phase name and stop the phase timer.
+    parameters: []
+    returns: []
+
+  - name: setGeneration
+    description: We set the current generation name for subsequent log messages.
+    parameters:
+      - name: name
+        type: string
+        description: Name of the generation to set.
+    returns: []
+
+  - name: clearGeneration
+    description: We clear the current generation name from subsequent log messages.
+    parameters: []
+    returns: []
+
+references:
+  - srd001-orchestrator-core

--- a/docs/interfaces/ifc-measure-workflow.yaml
+++ b/docs/interfaces/ifc-measure-workflow.yaml
@@ -1,0 +1,86 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-measure-workflow
+name: Measure Workflow
+summary: |
+  The Measure struct builds the measure prompt from existing issues and project state, invokes
+  Claude, parses YAML output, and creates GitHub Issues with dependency labels.
+
+data_structures:
+  - name: Measure
+    description: Standalone struct that drives the measure workflow from prompt assembly through issue creation.
+    fields:
+      - name: cfg
+        type: object
+        description: Resolved orchestrator configuration.
+        required: true
+      - name: logf
+        type: object
+        description: Structured logger function.
+        required: true
+      - name: git
+        type: object
+        description: GitOps instance for repository operations.
+        required: true
+      - name: tracker
+        type: object
+        description: WorkTracker for task state management.
+        required: true
+      - name: claudeRunner
+        type: object
+        description: Shared ClaudeRunner for invoking Claude.
+        required: true
+      - name: analyzer
+        type: object
+        description: Analyzer instance for project analysis.
+        required: true
+      - name: stateCallbacks
+        type: object
+        description: Callbacks invoked on workflow state transitions.
+        required: false
+      - name: generatorHelpers
+        type: object
+        description: Helper functions provided by the generator subsystem.
+        required: false
+
+operations:
+  - name: Measure
+    description: We run the full measure workflow, building the prompt, invoking Claude, parsing output, and creating GitHub Issues.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: MeasurePrompt
+    description: We build and print the measure prompt without invoking Claude.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: RunMeasure
+    description: We execute the measure invocation and process its results into GitHub Issues.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: buildMeasurePrompt
+    description: We assemble the full measure prompt from existing issues, project state, and constitution files.
+    parameters: []
+    returns:
+      - name: prompt
+        type: string
+      - name: error
+        type: error
+
+  - name: importIssues
+    description: We import externally defined issues into the tracker as GitHub Issues with dependency labels.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd003-cobbler-workflows

--- a/docs/interfaces/ifc-orchestrator-and-config.yaml
+++ b/docs/interfaces/ifc-orchestrator-and-config.yaml
@@ -1,0 +1,295 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-orchestrator-and-config
+name: Orchestrator and Config
+summary: |
+  The Orchestrator is the composition root. Consuming projects place a configuration.yaml at the
+  repository root and call NewFromFile(), or construct a Config in Go and pass it to New(). The
+  constructor builds 10 domain structs and a shared ClaudeRunner, wiring all dependencies via
+  constructor injection.
+
+data_structures:
+  - name: Orchestrator
+    description: Composition root holding Config and 10 domain struct fields plus ClaudeRunner.
+    fields:
+      - name: config
+        type: object
+        description: Resolved orchestrator configuration.
+        required: true
+      - name: generator
+        type: object
+        description: Generator domain struct.
+        required: true
+      - name: measure
+        type: object
+        description: Measure domain struct.
+        required: true
+      - name: stitch
+        type: object
+        description: Stitch domain struct.
+        required: true
+      - name: builder
+        type: object
+        description: Builder domain struct.
+        required: true
+      - name: scaffolder
+        type: object
+        description: Scaffolder domain struct.
+        required: true
+      - name: comparer
+        type: object
+        description: Comparer domain struct.
+        required: true
+      - name: vscode
+        type: object
+        description: VsCode domain struct.
+        required: true
+      - name: stats
+        type: object
+        description: Stats domain struct.
+        required: true
+      - name: releaser
+        type: object
+        description: Releaser domain struct.
+        required: true
+      - name: analyzer
+        type: object
+        description: Analyzer domain struct.
+        required: true
+      - name: claudeRunner
+        type: object
+        description: Shared ClaudeRunner used by measure and stitch workflows.
+        required: true
+
+  - name: Config
+    description: All orchestrator settings with YAML tags.
+    fields:
+      - name: projectName
+        type: string
+        description: Name of the consuming project.
+        required: true
+      - name: repoOwner
+        type: string
+        description: GitHub repository owner.
+        required: true
+      - name: repoName
+        type: string
+        description: GitHub repository name.
+        required: true
+      - name: mainBranch
+        type: string
+        description: Name of the main branch.
+        required: true
+      - name: buildCommand
+        type: string
+        description: Command to build the project.
+        required: false
+      - name: testCommand
+        type: string
+        description: Command to run tests.
+        required: false
+      - name: claudeModel
+        type: string
+        description: Claude model identifier for invocations.
+        required: false
+      - name: historyDir
+        type: string
+        description: Directory for storing run history and stats.
+        required: false
+      - name: constitutionDir
+        type: string
+        description: Directory containing constitution YAML files.
+        required: false
+
+  - name: InvocationRecord
+    description: Metrics collected per Claude invocation.
+    fields:
+      - name: caller
+        type: string
+        description: Name of the calling workflow (measure or stitch).
+        required: true
+      - name: startedAt
+        type: string
+        description: ISO 8601 timestamp when the invocation started.
+        required: true
+      - name: durationS
+        type: number
+        description: Wall-clock duration in seconds.
+        required: true
+      - name: tokens
+        type: integer
+        description: Total tokens consumed by the invocation.
+        required: true
+      - name: locBefore
+        type: integer
+        description: Lines of code before the invocation.
+        required: true
+      - name: locAfter
+        type: integer
+        description: Lines of code after the invocation.
+        required: true
+      - name: diff
+        type: integer
+        description: Net change in lines of code.
+        required: true
+      - name: numTurns
+        type: integer
+        description: Number of conversational turns in the invocation.
+        required: true
+
+  - name: HistoryStats
+    description: YAML-serializable per-invocation stats saved to the history directory.
+    fields:
+      - name: caller
+        type: string
+        description: Name of the calling workflow.
+        required: true
+      - name: taskID
+        type: string
+        description: Identifier of the task being processed.
+        required: true
+      - name: taskTitle
+        type: string
+        description: Title of the task being processed.
+        required: true
+      - name: startedAt
+        type: string
+        description: ISO 8601 timestamp when the invocation started.
+        required: true
+      - name: duration
+        type: string
+        description: Human-readable duration string.
+        required: true
+      - name: tokens
+        type: integer
+        description: Total tokens consumed.
+        required: true
+      - name: costUSD
+        type: number
+        description: Estimated cost in US dollars.
+        required: true
+      - name: locBefore
+        type: integer
+        description: Lines of code before the invocation.
+        required: true
+      - name: locAfter
+        type: integer
+        description: Lines of code after the invocation.
+        required: true
+      - name: diff
+        type: integer
+        description: Net change in lines of code.
+        required: true
+      - name: numTurns
+        type: integer
+        description: Number of conversational turns.
+        required: true
+      - name: durationAPIMs
+        type: integer
+        description: Total API call duration in milliseconds.
+        required: true
+      - name: rateLimitWaitS
+        type: number
+        description: Total time spent waiting on rate limits in seconds.
+        required: true
+      - name: sessionID
+        type: string
+        description: Unique session identifier for the run.
+        required: true
+
+operations:
+  - name: New
+    description: We construct an Orchestrator from a fully populated Config, building all domain structs and wiring dependencies.
+    parameters:
+      - name: cfg
+        type: object
+        description: Resolved orchestrator configuration.
+    returns:
+      - name: orchestrator
+        type: object
+
+  - name: NewFromFile
+    description: We read a configuration.yaml from the given path and construct an Orchestrator.
+    parameters:
+      - name: path
+        type: string
+        description: Filesystem path to the configuration YAML file.
+    returns:
+      - name: orchestrator
+        type: object
+      - name: error
+        type: error
+
+  - name: Config
+    description: We return the resolved Config from the Orchestrator.
+    parameters: []
+    returns:
+      - name: config
+        type: object
+
+  - name: Tracker
+    description: We return the WorkTracker used by the Orchestrator.
+    parameters: []
+    returns:
+      - name: tracker
+        type: object
+
+  - name: Git
+    description: We return the GitOps instance used by the Orchestrator.
+    parameters: []
+    returns:
+      - name: git
+        type: object
+
+  - name: DumpMeasurePrompt
+    description: We print the fully assembled measure prompt to stdout for debugging.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: DumpStitchPrompt
+    description: We print the fully assembled stitch prompt to stdout for debugging.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: TokenStats
+    description: We print token usage statistics for recent invocations.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: PrintContextFiles
+    description: We print the list of context files that would be sent to Claude.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: ConstitutionPreviewFile
+    description: We generate a preview of the assembled constitution file.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: GeneratorInit
+    description: We initialize the generator subsystem for the consuming project.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: WriteDefaultConfig
+    description: We write a default configuration.yaml to the consuming project root.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd001-orchestrator-core

--- a/docs/interfaces/ifc-orchestrator-component.yaml
+++ b/docs/interfaces/ifc-orchestrator-component.yaml
@@ -1,0 +1,84 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-orchestrator-component
+name: Orchestrator
+summary: |
+  Composition root holding Config, providing New() and NewFromFile() constructors,
+  managing logging with optional generation tagging. Constructs and wires 10 domain
+  structs and a shared ClaudeRunner via constructor injection.
+
+operations:
+  - name: New
+    description: Construct an Orchestrator from an in-memory Config object.
+    parameters:
+      - name: cfg
+        type: object
+        description: Configuration object for the orchestrator.
+    returns:
+      - name: orchestrator
+        type: object
+      - name: error
+        type: error
+  - name: NewFromFile
+    description: Construct an Orchestrator by loading Config from a file path.
+    parameters:
+      - name: path
+        type: string
+        description: Filesystem path to the configuration file.
+    returns:
+      - name: orchestrator
+        type: object
+      - name: error
+        type: error
+  - name: Config
+    description: Return the current configuration object.
+    parameters: []
+    returns:
+      - name: config
+        type: object
+  - name: Tracker
+    description: Return the issue tracker instance.
+    parameters: []
+    returns:
+      - name: tracker
+        type: object
+  - name: Git
+    description: Return the GitOps instance.
+    parameters: []
+    returns:
+      - name: git
+        type: object
+  - name: DumpMeasurePrompt
+    description: Print the assembled measure prompt to stdout for debugging.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: DumpStitchPrompt
+    description: Print the assembled stitch prompt to stdout for debugging.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: TokenStats
+    description: Display token usage statistics for recent Claude invocations.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: PrintContextFiles
+    description: Print the list of context files assembled for prompt construction.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: ConstitutionPreviewFile
+    description: Write a preview of the stitched constitution to a temporary file.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd001-orchestrator-core

--- a/docs/interfaces/ifc-outcomes.yaml
+++ b/docs/interfaces/ifc-outcomes.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-outcomes
+name: Outcomes
+summary: |
+  We parse outcome trailers from git commit messages written by stitch tasks.
+  Trailers record token usage, LOC deltas, cost, and duration per task.
+
+operations:
+  - name: Outcomes
+    description: Parse outcome trailers from git commit messages and report aggregated metrics.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd005-metrics-collection

--- a/docs/interfaces/ifc-pre-cycle-analysis.yaml
+++ b/docs/interfaces/ifc-pre-cycle-analysis.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-pre-cycle-analysis
+name: Pre-Cycle Analysis
+summary: |
+  We run cross-artifact consistency checks and code status detection before each measure/stitch
+  cycle. The combined result is written as analysis.yaml into the cobbler scratch directory so
+  Claude sees the current project health in both prompts.
+
+operations:
+  - name: RunPreCycleAnalysis
+    description: We run consistency checks and code status detection, then write the combined result to the scratch directory.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: LoadAnalysisDoc
+    description: We load a previously written analysis.yaml from the cobbler scratch directory.
+    parameters:
+      - name: cobblerDir
+        type: string
+        description: Path to the cobbler scratch directory.
+    returns:
+      - name: analysis
+        type: object
+
+references:
+  - srd003-cobbler-workflows

--- a/docs/interfaces/ifc-prompt-builder.yaml
+++ b/docs/interfaces/ifc-prompt-builder.yaml
@@ -1,0 +1,126 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-prompt-builder
+name: Prompt Builder
+summary: |
+  We define the typed document structures for measure and stitch prompts
+  (MeasurePromptDoc and StitchPromptDoc) and the shared promptTemplate parser.
+  We provide parseYAMLNode and substitutePlaceholders utilities used when
+  assembling prompts.
+
+data_structures:
+  - name: MeasurePromptDoc
+    description: Measure prompt envelope containing all sections for a measure-phase prompt.
+    fields:
+      - name: role
+        type: string
+        description: System role directive for the LLM.
+      - name: project_context
+        type: object
+        description: Assembled project context blob.
+      - name: planning_constitution
+        type: object
+        description: Planning constitution governing measure behavior.
+      - name: issue_format_constitution
+        type: object
+        description: Constitution defining the expected issue output format.
+      - name: task
+        type: string
+        description: Task description for the measure phase.
+      - name: constraints
+        type: string
+        description: Constraints applied to the measure output.
+      - name: output_format
+        type: string
+        description: Expected output format specification.
+      - name: golden_example
+        type: string
+        description: Example output demonstrating the desired format.
+      - name: additional_context
+        type: string
+        description: Extra context appended to the prompt.
+      - name: validation_errors
+        type: array
+        description: List of validation errors from prior attempts.
+      - name: package_contracts
+        type: array
+        description: List of package contract definitions included in the prompt.
+
+  - name: StitchPromptDoc
+    description: Stitch prompt envelope containing all sections for a stitch-phase prompt.
+    fields:
+      - name: role
+        type: string
+        description: System role directive for the LLM.
+      - name: repository_files
+        type: array
+        description: List of repository file entries provided as context.
+      - name: project_context
+        type: object
+        description: Assembled project context blob.
+      - name: context
+        type: string
+        description: Additional context string for the stitch phase.
+      - name: execution_constitution
+        type: object
+        description: Execution constitution governing stitch behavior.
+      - name: go_style_constitution
+        type: object
+        description: Go style constitution for code generation.
+      - name: task
+        type: string
+        description: Task description for the stitch phase.
+      - name: constraints
+        type: string
+        description: Constraints applied to the stitch output.
+      - name: description
+        type: string
+        description: Human-readable description of the stitch task.
+      - name: semantic_model
+        type: object
+        description: SRD semantic model for interface-aware generation.
+      - name: shared_protocols
+        type: array
+        description: List of shared protocol definitions included in the prompt.
+      - name: package_contracts
+        type: array
+        description: List of package contract definitions included in the prompt.
+
+operations:
+  - name: parseYAMLNode
+    description: Parse a YAML string into a generic object tree.
+    parameters:
+      - name: data
+        type: string
+        description: Raw YAML content to parse.
+    returns:
+      - name: node
+        type: object
+      - name: error
+        type: error
+  - name: substitutePlaceholders
+    description: Replace placeholder tokens in a template string with values from a variable map.
+    parameters:
+      - name: text
+        type: string
+        description: Template string containing placeholders.
+      - name: vars
+        type: object
+        description: Map of placeholder names to replacement values.
+    returns:
+      - name: result
+        type: string
+  - name: validatePromptTemplate
+    description: Validate a prompt template file and return any structural errors.
+    parameters:
+      - name: path
+        type: string
+        description: Path to the prompt template file.
+    returns:
+      - name: errors
+        type: array
+        description: List of validation error messages.
+
+references:
+  - srd003-cobbler-workflows

--- a/docs/interfaces/ifc-prompt-files.yaml
+++ b/docs/interfaces/ifc-prompt-files.yaml
@@ -1,0 +1,21 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-prompt-files
+name: Prompt Files
+summary: |
+  We enumerate all files that BuildProjectContext loads, annotated with source,
+  category, line count, and estimated token count. Mirrors the include/exclude
+  logic of context assembly.
+
+operations:
+  - name: PrintPromptFiles
+    description: Enumerate and print all context files with source, category, line count, and token estimate.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd003-cobbler-workflows
+  - srd005-metrics-collection

--- a/docs/interfaces/ifc-prompt-templates.yaml
+++ b/docs/interfaces/ifc-prompt-templates.yaml
@@ -1,0 +1,101 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-prompt-templates
+name: Prompt Templates
+summary: |
+  Prompts are Go text/template strings embedded from measure.tmpl and stitch.tmpl.
+  Consuming projects can override them via Config. Prompts are injected with
+  phase-specific constitutions and a ProjectContext YAML blob.
+
+data_structures:
+  - name: MeasurePromptDoc
+    description: Measure prompt envelope containing role, context, constitutions, and task directives.
+    fields:
+      - name: Role
+        type: string
+        description: Role instruction for the Claude session.
+        required: true
+      - name: ProjectContext
+        type: object
+        description: Assembled project context YAML blob.
+        required: true
+      - name: PlanningConstitution
+        type: object
+        description: Planning-phase constitution governing issue decomposition.
+        required: true
+      - name: IssueFormatConstitution
+        type: object
+        description: Constitution governing issue formatting rules.
+        required: true
+      - name: Task
+        type: string
+        description: Task directive for the measure phase.
+        required: true
+      - name: Constraints
+        type: string
+        description: Constraints on the measure output.
+      - name: OutputFormat
+        type: string
+        description: Expected output format specification.
+      - name: GoldenExample
+        type: string
+        description: Example output for few-shot guidance.
+      - name: AdditionalContext
+        type: string
+        description: Extra context appended to the prompt.
+      - name: ValidationErrors
+        type: array
+        description: Validation errors from a previous measure attempt for retry.
+      - name: PackageContracts
+        type: array
+        description: Package contract definitions injected into the prompt.
+
+  - name: StitchPromptDoc
+    description: Stitch prompt envelope containing role, repository state, and execution directives.
+    fields:
+      - name: Role
+        type: string
+        description: Role instruction for the Claude session.
+        required: true
+      - name: RepositoryFiles
+        type: array
+        description: List of repository file paths included in context.
+        required: true
+      - name: ProjectContext
+        type: object
+        description: Assembled project context YAML blob.
+        required: true
+      - name: Context
+        type: string
+        description: Additional context for the stitch phase.
+      - name: ExecutionConstitution
+        type: object
+        description: Execution-phase constitution governing code generation.
+        required: true
+      - name: GoStyleConstitution
+        type: object
+        description: Go style constitution governing code formatting and idioms.
+      - name: Task
+        type: string
+        description: Task directive for the stitch phase.
+        required: true
+      - name: Constraints
+        type: string
+        description: Constraints on the stitch output.
+      - name: Description
+        type: string
+        description: Issue description being stitched.
+        required: true
+      - name: SemanticModel
+        type: object
+        description: SRD semantic model for interface-aware code generation.
+      - name: SharedProtocols
+        type: array
+        description: Shared protocol definitions injected into the prompt.
+      - name: PackageContracts
+        type: array
+        description: Package contract definitions injected into the prompt.
+
+references:
+  - srd003-cobbler-workflows

--- a/docs/interfaces/ifc-release-stats.yaml
+++ b/docs/interfaces/ifc-release-stats.yaml
@@ -1,0 +1,19 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-release-stats
+name: Release Stats
+summary: |
+  We load road-map.yaml, SRD files, and use case touchpoints to produce a
+  per-release table showing SRD completion status and requirement counts.
+
+operations:
+  - name: ReleaseStats
+    description: Load roadmap and SRD data to produce a per-release completion table.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd005-metrics-collection

--- a/docs/interfaces/ifc-releaser.yaml
+++ b/docs/interfaces/ifc-releaser.yaml
@@ -1,0 +1,38 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-releaser
+name: Releaser
+summary: |
+  The Releaser struct manages release lifecycle state in road-map.yaml and
+  configuration.yaml, and creates versioned documentation tags. It depends
+  only on Config.
+
+operations:
+  - name: ReleaseUpdate
+    description: Update road-map.yaml and configuration.yaml to reflect a new release version.
+    parameters:
+      - name: version
+        type: string
+        description: The release version identifier.
+    returns:
+      - name: error
+        type: error
+  - name: ReleaseClear
+    description: Remove release state for the given version from road-map.yaml and configuration.yaml.
+    parameters:
+      - name: version
+        type: string
+        description: The release version identifier to clear.
+    returns:
+      - name: error
+        type: error
+  - name: Tag
+    description: Create a versioned documentation tag from the current release state.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd001-orchestrator-core

--- a/docs/interfaces/ifc-scaffold-component.yaml
+++ b/docs/interfaces/ifc-scaffold-component.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-scaffold-component
+name: Scaffold
+summary: |
+  Standalone Scaffolder struct. Scaffolds the orchestrator into consuming projects by detecting
+  project structure, generating configuration.yaml, writing magefiles template, copying
+  constitutions, and wiring go.mod. Also provides Uninstall() and PrepareTestRepo().
+
+operations:
+  - name: Scaffold
+    description: We scaffold the orchestrator configuration, constitutions, and supporting files into the consuming project.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: Uninstall
+    description: We remove all scaffolded orchestrator files from the consuming project.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: PrepareTestRepo
+    description: We set up a test repository with the minimal structure needed to exercise the orchestrator.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - eng03-project-initialization

--- a/docs/interfaces/ifc-scaffolder.yaml
+++ b/docs/interfaces/ifc-scaffolder.yaml
@@ -1,0 +1,34 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-scaffolder
+name: Scaffolder
+summary: |
+  The Scaffolder struct scaffolds the orchestrator into consuming projects and manages test
+  repositories. It depends on git (GitOps) and logf.
+
+operations:
+  - name: Scaffold
+    description: We scaffold the orchestrator configuration, constitutions, and supporting files into the consuming project.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: Uninstall
+    description: We remove all scaffolded orchestrator files from the consuming project.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: PrepareTestRepo
+    description: We set up a test repository with the minimal structure needed to exercise the orchestrator.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd001-orchestrator-core
+  - eng03-project-initialization

--- a/docs/interfaces/ifc-stats-and-metrics.yaml
+++ b/docs/interfaces/ifc-stats-and-metrics.yaml
@@ -1,0 +1,72 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-stats-and-metrics
+name: Stats and Metrics
+summary: |
+  The Stats struct collects LOC counts, documentation word counts, generator status, release
+  statistics, run statistics, and outcome trailer parsing.
+
+operations:
+  - name: PrintStats
+    description: We print a summary of all collected statistics to stdout.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: CollectStats
+    description: We gather LOC counts, documentation word counts, and generator status into a single stats object.
+    parameters: []
+    returns:
+      - name: stats
+        type: object
+      - name: error
+        type: error
+
+  - name: GeneratorStats
+    description: We print statistics about generator output and coverage.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: ReleaseStats
+    description: We print statistics for the current release including task completion and LOC deltas.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: RunStats
+    description: We print detailed statistics for a specific named run.
+    parameters:
+      - name: name
+        type: string
+        description: Name of the run to report on.
+    returns:
+      - name: error
+        type: error
+
+  - name: CompareRunStats
+    description: We print a side-by-side comparison of two named runs.
+    parameters:
+      - name: name1
+        type: string
+        description: Name of the first run to compare.
+      - name: name2
+        type: string
+        description: Name of the second run to compare.
+    returns:
+      - name: error
+        type: error
+
+  - name: Outcomes
+    description: We parse outcome trailers from completed stitch runs and print a summary.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd005-metrics-collection

--- a/docs/interfaces/ifc-stats-component.yaml
+++ b/docs/interfaces/ifc-stats-component.yaml
@@ -1,0 +1,66 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-stats-component
+name: Stats
+summary: |
+  Standalone Stats struct collecting Go LOC counts (production and test) and documentation word
+  counts. Uses configured GoSourceDirs and SpecGlobs. Run statistics aggregate per-generation-run
+  metrics from history artifacts.
+
+operations:
+  - name: PrintStats
+    description: We print a summary of all collected statistics to stdout.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: CollectStats
+    description: We gather LOC counts, documentation word counts, and generator status into a single stats object.
+    parameters: []
+    returns:
+      - name: stats
+        type: object
+      - name: error
+        type: error
+
+  - name: GeneratorStats
+    description: We print statistics about generator output and coverage.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: ReleaseStats
+    description: We print statistics for the current release including task completion and LOC deltas.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: RunStats
+    description: We print detailed statistics for a specific named run.
+    parameters:
+      - name: name
+        type: string
+        description: Name of the run to report on.
+    returns:
+      - name: error
+        type: error
+
+  - name: CompareRunStats
+    description: We print a side-by-side comparison of two named runs.
+    parameters:
+      - name: name1
+        type: string
+        description: Name of the first run to compare.
+      - name: name2
+        type: string
+        description: Name of the second run to compare.
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd005-metrics-collection

--- a/docs/interfaces/ifc-stitch-workflow.yaml
+++ b/docs/interfaces/ifc-stitch-workflow.yaml
@@ -1,0 +1,90 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-stitch-workflow
+name: Stitch Workflow
+summary: |
+  The Stitch struct picks ready GitHub Issues, creates worktrees, invokes Claude, commits changes,
+  merges branches, and closes tasks.
+
+data_structures:
+  - name: Stitch
+    description: Standalone struct that drives the stitch workflow from task selection through merge and close.
+    fields:
+      - name: cfg
+        type: object
+        description: Resolved orchestrator configuration.
+        required: true
+      - name: logf
+        type: object
+        description: Structured logger function.
+        required: true
+      - name: git
+        type: object
+        description: GitOps instance for repository operations.
+        required: true
+      - name: tracker
+        type: object
+        description: WorkTracker for task state management.
+        required: true
+      - name: claudeRunner
+        type: object
+        description: Shared ClaudeRunner for invoking Claude.
+        required: true
+      - name: stateCallbacks
+        type: object
+        description: Callbacks invoked on workflow state transitions.
+        required: false
+      - name: generatorHelpers
+        type: object
+        description: Helper functions provided by the generator subsystem.
+        required: false
+
+operations:
+  - name: Stitch
+    description: We run the full stitch workflow, picking one ready task, creating a worktree, invoking Claude, and merging the result.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: RunStitch
+    description: We execute a single stitch cycle without the outer scheduling loop.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: RunStitchN
+    description: We execute up to the specified number of stitch cycles in sequence.
+    parameters:
+      - name: limit
+        type: integer
+        description: Maximum number of tasks to process in this run.
+    returns:
+      - name: error
+        type: error
+
+  - name: doOneTask
+    description: We process a single task from worktree creation through commit and merge.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: resetTask
+    description: We reset the current task state so it can be retried in a future stitch cycle.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+  - name: skipTask
+    description: We mark the current task as skipped so it will not be picked again.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd003-cobbler-workflows

--- a/docs/interfaces/ifc-token-stats.yaml
+++ b/docs/interfaces/ifc-token-stats.yaml
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-token-stats
+name: Token Stats
+summary: |
+  We enumerate all files that BuildProjectContext would load, grouped by
+  category, and report their byte sizes. Optionally calls the Anthropic Token
+  Counting API for exact token counts.
+
+operations:
+  - name: TokenStats
+    description: Compute and display token and byte statistics for all context files.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: PrintContextFiles
+    description: Print the list of context files grouped by category with their sizes.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd005-metrics-collection

--- a/docs/interfaces/ifc-vscode-extension.yaml
+++ b/docs/interfaces/ifc-vscode-extension.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-vscode-extension
+name: VS Code Extension
+summary: |
+  A TypeScript extension providing editor-integrated visibility into
+  orchestrator state. Ten source modules implement six use cases: lifecycle
+  commands, generation browser, branch comparison, issue tracker, metrics
+  dashboard, and specification browser.
+
+operations:
+  - name: activate
+    description: Initialize the VS Code extension and register all commands and views.
+    parameters: []
+    returns:
+      - name: void
+        type: void
+  - name: deactivate
+    description: Clean up resources when the VS Code extension is deactivated.
+    parameters: []
+    returns:
+      - name: void
+        type: void
+  - name: VscodePush
+    description: Push the VS Code extension scaffold to the consuming repository.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: VscodePop
+    description: Pop the VS Code extension scaffold into the consuming repository working tree.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd006-vscode-extension

--- a/docs/interfaces/ifc-vscode-manager.yaml
+++ b/docs/interfaces/ifc-vscode-manager.yaml
@@ -1,0 +1,25 @@
+# Copyright (c) 2026 Petar Djukic. All rights reserved.
+# SPDX-License-Identifier: MIT
+
+id: ifc-vscode-manager
+name: VsCode Manager
+summary: |
+  The VsCode struct manages VS Code extension packaging and installation.
+  It depends only on logf.
+
+operations:
+  - name: VscodePush
+    description: Package and install the VS Code extension into the local environment.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+  - name: VscodePop
+    description: Remove the installed VS Code extension from the local environment.
+    parameters: []
+    returns:
+      - name: error
+        type: error
+
+references:
+  - srd006-vscode-extension


### PR DESCRIPTION
## Summary

Extracted all 42 interface definitions from ARCHITECTURE.yaml into standalone files in docs/interfaces/ following the eng10 interface specification format. ARCHITECTURE.yaml now retains only name, summary, and spec_file references. Interface names are preserved so all SRD implemented_by/used_by references continue to resolve.

## Changes

- Created 39 new docs/interfaces/ifc-*.yaml files with typed field lists and typed parameter/return lists
- Updated ARCHITECTURE.yaml interfaces section: removed inline data_structures/operations, added spec_file references
- 3 pre-existing interface files (ifc-builder, ifc-generation-lifecycle, ifc-git-operations) unchanged
- StandardContextPatterns now loads 72 files (was 33) including all interface specs

## Stats

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Interface files | 3 | 42 | +39 |
| Context files loaded | 33 | 72 | +39 |
| ARCHITECTURE.yaml interfaces lines | ~270 | ~145 | -125 |

## Test plan

- [x] `mage analyze` passes with all consistency checks
- [x] All Go tests pass
- [x] All SRD interface references resolve against combined index
- [x] All spec_file references point to existing files

Closes #1991