### PR TITLE
GH-1892: Upgrade sdd-hello-world v0.20260322.0 → v0.20260404.0

### DIFF
--- a/orchestrator.go.tmpl
+++ b/orchestrator.go.tmpl
@@ -64,88 +64,88 @@ func logf(format string, args ...any) {
 // --- Top-level targets ---
 
 // Init initializes the project.
-func Init() error { return newOrch().Init() }
+func Init() error { return newOrch().Generator.Init() }
 
 // Reset performs a full reset: cobbler and generator.
-func Reset() error { return newOrch().FullReset() }
+func Reset() error { return newOrch().Generator.FullReset() }
 
 // Build compiles the project binary.
-func Build() error { return newOrch().Build() }
+func Build() error { return newOrch().Builder.Build() }
 
 // Lint runs golangci-lint on the project.
-func Lint() error { return newOrch().Lint() }
+func Lint() error { return newOrch().Builder.Lint() }
 
 // Install runs go install for the main package.
-func Install() error { return newOrch().Install() }
+func Install() error { return newOrch().Builder.Install() }
 
 // Clean removes build artifacts.
-func Clean() error { return newOrch().Clean() }
+func Clean() error { return newOrch().Builder.Clean() }
 
 // Credentials extracts Claude credentials from the macOS Keychain.
-func Credentials() error { return newOrch().ExtractCredentials() }
+func Credentials() error { return newOrch().Builder.ExtractCredentials() }
 
 // Analyze performs cross-artifact consistency checks (PRDs, use cases, test suites, roadmap).
-func Analyze() error { return newOrch().Analyze() }
+func Analyze() error { return newOrch().Analyzer.Analyze() }
 
 // Tag creates a documentation release tag (v0.YYYYMMDD.N) and builds the container image.
-func Tag() error { return newOrch().Tag() }
+func Tag() error { return newOrch().Releaser.Tag() }
 
 // --- Scaffold targets ---
 
 // Pop removes orchestrator-managed files from the target repository:
 // magefiles/orchestrator.go, docs/constitutions/, docs/prompts/, and
 // configuration.yaml. Pass "." for the current directory.
-func (Scaffold) Pop(target string) error { return newOrch().Uninstall(target) }
+func (Scaffold) Pop(target string) error { return newOrch().Scaffolder.Uninstall(target) }
 
 // --- Cobbler targets ---
 
 // Measure assesses project state and proposes new tasks via Claude.
-func (Cobbler) Measure() error { return newOrch().Measure() }
+func (Cobbler) Measure() error { return newOrch().Measure.Measure() }
 
 // Stitch picks ready tasks and invokes Claude to execute them.
-func (Cobbler) Stitch() error { return newOrch().Stitch() }
+func (Cobbler) Stitch() error { return newOrch().Stitch.Stitch() }
 
 // Reset removes the cobbler scratch directory.
-func (Cobbler) Reset() error { return newOrch().CobblerReset() }
+func (Cobbler) Reset() error { return newOrch().ClaudeRunner.CobblerReset() }
 
 // --- Generator targets ---
 
 // Start begins a new generation trail.
-func (Generator) Start() error { return newOrch().GeneratorStart() }
+func (Generator) Start() error { return newOrch().Generator.GeneratorStart() }
 
 // Run executes measure + stitch cycles using the generation.cycles value in configuration.yaml.
 // Use RunN to override the cycle count for a single invocation.
-func (Generator) Run() error { return newOrch().GeneratorRun(0) }
+func (Generator) Run() error { return newOrch().Generator.GeneratorRun(0) }
 
 // RunN executes exactly n cycles of measure + stitch within the current generation.
 // Pass n > 0 to override generation.cycles in configuration.yaml for this run only.
-func (Generator) RunN(n int) error { return newOrch().GeneratorRun(n) }
+func (Generator) RunN(n int) error { return newOrch().Generator.GeneratorRun(n) }
 
 // Resume recovers from an interrupted run and continues.
-func (Generator) Resume() error { return newOrch().GeneratorResume() }
+func (Generator) Resume() error { return newOrch().Generator.GeneratorResume() }
 
 // Stop completes a generation trail and merges it into main.
-func (Generator) Stop() error { return newOrch().GeneratorStop() }
+func (Generator) Stop() error { return newOrch().Generator.GeneratorStop() }
 
 // List shows active branches and past generations.
-func (Generator) List() error { return newOrch().GeneratorList() }
+func (Generator) List() error { return newOrch().Generator.GeneratorList() }
 
 // Switch commits current work and checks out another generation branch.
-func (Generator) Switch() error { return newOrch().GeneratorSwitch() }
+func (Generator) Switch() error { return newOrch().Generator.GeneratorSwitch() }
 
 // Reset destroys generation branches, worktrees, and Go source directories.
-func (Generator) Reset() error { return newOrch().GeneratorReset() }
+func (Generator) Reset() error { return newOrch().Generator.GeneratorReset() }
 
 // --- Stats targets ---
 
 // Loc prints Go lines of code and documentation word counts.
-func (Stats) Loc() error { return newOrch().Stats() }
+func (Stats) Loc() error { return newOrch().Stats.PrintStats() }
 
 // Tokens enumerates prompt-attached files and counts tokens via the Anthropic API.
 func (Stats) Tokens() error { return newOrch().TokenStats() }
 
 // Generator prints a status report for the current generation run.
-func (Stats) Generator() error { return newOrch().GeneratorStats() }
+func (Stats) Generator() error { return newOrch().Stats.GeneratorStats() }
 
 // --- Prompt targets ---
 

--- a/tests/e2e/requirements_tracking_test.go
+++ b/tests/e2e/requirements_tracking_test.go
@@ -58,7 +58,7 @@ func TestRequirementTracking_GeneratorStartProducesRequirements(t *testing.T) {
 	defer os.Chdir(origDir)
 
 	o := orchestrator.New(cfg)
-	if err := o.GeneratorStart(); err != nil {
+	if err := o.Generator.GeneratorStart(); err != nil {
 		t.Fatalf("GeneratorStart: %v", err)
 	}
 

--- a/tests/rel01.0/internal/testutil/snapshot.go
+++ b/tests/rel01.0/internal/testutil/snapshot.go
@@ -49,7 +49,7 @@ func PrepareSnapshot(orchRoot string) (string, func(), error) {
 	}
 	fmt.Fprintf(os.Stderr, "e2e: using %s@%s\n", ScaffoldModule, version)
 
-	repoDir, err := orch.PrepareTestRepo(ScaffoldModule, version, orchRoot)
+	repoDir, err := orch.Scaffolder.PrepareTestRepo(ScaffoldModule, version, orchRoot)
 	if err != nil {
 		return "", nil, fmt.Errorf("PrepareTestRepo: %w", err)
 	}

--- a/tests/rel01.0/uc006/scaffold_test.go
+++ b/tests/rel01.0/uc006/scaffold_test.go
@@ -116,12 +116,12 @@ func TestRel01_UC006_PushIdempotent(t *testing.T) {
 	}
 
 	// First scaffold.
-	if err := orch.Scaffold(dir, orchRoot); err != nil {
+	if err := orch.Scaffolder.Scaffold(dir, orchRoot); err != nil {
 		t.Fatalf("first Scaffold: %v", err)
 	}
 
 	// Second scaffold (idempotent overwrite).
-	if err := orch.Scaffold(dir, orchRoot); err != nil {
+	if err := orch.Scaffolder.Scaffold(dir, orchRoot); err != nil {
 		t.Fatalf("second Scaffold: %v", err)
 	}
 
@@ -164,7 +164,7 @@ func TestRel01_UC006_ConfigPreservedOnReScaffold(t *testing.T) {
 	}
 
 	// First scaffold: creates configuration.yaml from detected project structure.
-	if err := orch.Scaffold(dir, orchRoot); err != nil {
+	if err := orch.Scaffolder.Scaffold(dir, orchRoot); err != nil {
 		t.Fatalf("first Scaffold: %v", err)
 	}
 
@@ -176,7 +176,7 @@ func TestRel01_UC006_ConfigPreservedOnReScaffold(t *testing.T) {
 	}
 
 	// Second scaffold: must not overwrite the existing configuration.yaml.
-	if err := orch.Scaffold(dir, orchRoot); err != nil {
+	if err := orch.Scaffolder.Scaffold(dir, orchRoot); err != nil {
 		t.Fatalf("second Scaffold: %v", err)
 	}
 
@@ -214,7 +214,7 @@ func TestRel01_UC006_PopOnNonScaffolded(t *testing.T) {
 
 	// Uninstall on a repo that was never scaffolded should succeed as a
 	// no-op: all the files it tries to remove are already absent.
-	if err := orch.Uninstall(dir); err != nil {
+	if err := orch.Scaffolder.Uninstall(dir); err != nil {
 		t.Fatalf("Uninstall on non-scaffolded repo should be a no-op, got error: %v", err)
 	}
 
@@ -255,7 +255,7 @@ func TestRel01_UC006_PushPopRoundTrip(t *testing.T) {
 	}
 
 	// --- Push: scaffold the orchestrator into the empty repo ---
-	if err := orch.Scaffold(dir, orchRoot); err != nil {
+	if err := orch.Scaffolder.Scaffold(dir, orchRoot); err != nil {
 		t.Fatalf("Scaffold: %v", err)
 	}
 
@@ -287,7 +287,7 @@ func TestRel01_UC006_PushPopRoundTrip(t *testing.T) {
 	}
 
 	// --- Pop: remove the scaffold ---
-	if err := orch.Uninstall(dir); err != nil {
+	if err := orch.Scaffolder.Uninstall(dir); err != nil {
 		t.Fatalf("Uninstall: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

Upgrade the sdd-hello-world E2E test target from v0.20260322.0 to v0.20260404.0. Upstream refactored Orchestrator methods into domain sub-structs, renamed PRD to SRD, and added interface specification support. The scaffold template and test code are updated to match the new API.

## Changes

- Updated `orchestrator.go.tmpl` to call methods on domain sub-structs (Builder, Scaffolder, Generator, Analyzer, Releaser, Measure, Stitch, ClaudeRunner, Stats)
- Fixed `snapshot.go` to use `orch.Scaffolder.PrepareTestRepo`
- Fixed `scaffold_test.go` to use `orch.Scaffolder.Scaffold` and `orch.Scaffolder.Uninstall`
- Fixed `requirements_tracking_test.go` to use `o.Generator.GeneratorStart`

## Test plan

- [x] `mage analyze` passes
- [x] All unit tests pass
- [x] UC001-UC007 local tests pass
- [x] E2E tests pass
- [x] UC004 Claude-dependent: 2 LLM-flaky failures (known pattern, not caused by this change)

Closes #1892