### PR TITLE
GH-2043: Fix GeneratorSwitch for worktree mode

### DIFF
--- a/pkg/orchestrator/generator.go
+++ b/pkg/orchestrator/generator.go
@@ -191,6 +191,10 @@ func generationName(tag string) string {
 	return generate.GenerationName(tag)
 }
 
+func (g *Generator) saveCurrentWork() error {
+	return generate.SaveWork("save state before leaving worktree", g.genGitDeps())
+}
+
 func (g *Generator) saveAndSwitchBranch(target string) error {
 	return generate.SaveAndSwitchBranch(target, g.genGitDeps())
 }
@@ -1445,7 +1449,17 @@ func (g *Generator) GeneratorList() error {
 }
 
 // GeneratorSwitch commits current work and checks out another generation branch.
+//
+// When running inside a worktree created by GeneratorStart (GH-2043) and the
+// target is the base branch, a plain checkout would fail because git does not
+// allow the same branch to be checked out in two worktrees. In that case we
+// save work, switch to the main repo, and remove the worktree.
 func (g *Generator) GeneratorSwitch() error {
+	// If invoked from the main repo, try to enter the worktree (GH-1608).
+	if _, err := g.enterGenerationWorktree(); err != nil {
+		return err
+	}
+
 	target := g.cfg.Generation.Branch
 	baseBranch := g.cfg.Cobbler.BaseBranch
 	if target == "" {
@@ -1465,6 +1479,29 @@ func (g *Generator) GeneratorSwitch() error {
 	}
 	if current == target {
 		g.logf("generator:switch: already on %s", target)
+		return nil
+	}
+
+	// When switching to the base branch from a worktree, git checkout would
+	// fail because the base branch is already checked out in the main repo.
+	// Save work, switch to the main repo, and remove the worktree (GH-2043).
+	repoRoot := g.readRepoRoot()
+	if repoRoot != "" && target == baseBranch {
+		g.logf("generator:switch: saving work on %s before leaving worktree", current)
+		if err := g.saveCurrentWork(); err != nil {
+			return fmt.Errorf("saving work: %w", err)
+		}
+		worktreeDir, _ := filepath.Abs(".")
+		g.logf("generator:switch: switching to main repo at %s", repoRoot)
+		if err := os.Chdir(repoRoot); err != nil {
+			return fmt.Errorf("switching to main repo: %w", err)
+		}
+		g.logf("generator:switch: removing worktree %s", worktreeDir)
+		if err := g.git.WorktreeRemove(worktreeDir, "."); err != nil {
+			g.logf("generator:switch: worktree remove warning: %v", err)
+		}
+		_ = g.git.WorktreePrune(".")
+		g.logf("generator:switch: now on %s", target)
 		return nil
 	}
 

--- a/pkg/orchestrator/internal/generate/generator.go
+++ b/pkg/orchestrator/internal/generate/generator.go
@@ -79,6 +79,25 @@ func GenerationName(tag string) string {
 // Git branch helpers
 // ---------------------------------------------------------------------------
 
+// SaveWork commits or stashes uncommitted changes on the current branch
+// without switching branches. It tries a WIP commit first; if that fails
+// and the tree is still dirty, it stashes changes.
+func SaveWork(reason string, deps GitDeps) error {
+	if err := deps.StageAll("."); err != nil {
+		return fmt.Errorf("staging changes: %w", err)
+	}
+
+	msg := fmt.Sprintf("WIP: %s", reason)
+	if err := deps.Commit(msg, "."); err != nil {
+		_ = deps.UnstageAll(".")
+		if deps.HasChanges(".") {
+			Log("saveWork: commit failed, stashing dirty tree")
+			_ = deps.Stash(msg, ".")
+		}
+	}
+	return nil
+}
+
 // SaveAndSwitchBranch commits or stashes uncommitted changes on the
 // current branch, then checks out the target branch. It tries a WIP
 // commit first; if that fails and the tree is still dirty, it stashes
@@ -94,19 +113,8 @@ func SaveAndSwitchBranch(target string, deps GitDeps) error {
 		return nil
 	}
 
-	if err := deps.StageAll("."); err != nil {
-		return fmt.Errorf("staging changes: %w", err)
-	}
-
-	msg := fmt.Sprintf("WIP: save state before switching to %s", target)
-	if err := deps.Commit(msg, "."); err != nil {
-		// Commit failed (e.g. nothing to commit). Unstage and fall
-		// back to stash if the tree is still dirty.
-		_ = deps.UnstageAll(".") // best-effort; unstage before stash fallback
-		if deps.HasChanges(".") {
-			Log("saveAndSwitchBranch: commit failed, stashing dirty tree")
-			_ = deps.Stash(msg, ".") // best-effort; switching branch is the priority
-		}
+	if err := SaveWork(fmt.Sprintf("save state before switching to %s", target), deps); err != nil {
+		return err
 	}
 
 	Log("saveAndSwitchBranch: %s -> %s", current, target)

--- a/tests/rel01.0/internal/testutil/testutil.go
+++ b/tests/rel01.0/internal/testutil/testutil.go
@@ -988,3 +988,28 @@ func MeasureAndExpectIssues(t testing.TB, dir string, timeout time.Duration) int
 	t.Fatal("MeasureAndExpectIssues: Claude returned empty list on both attempts despite unresolved requirements")
 	return 0
 }
+
+// PatchConfigYAML reads configuration.yaml from dir, applies fn to the
+// decoded map, and writes it back. This allows tests to modify config
+// fields (e.g., generation.branch) without importing the orchestrator
+// package.
+func PatchConfigYAML(t testing.TB, dir string, fn func(cfg map[string]any)) {
+	t.Helper()
+	cfgPath := filepath.Join(dir, "configuration.yaml")
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("PatchConfigYAML: reading %s: %v", cfgPath, err)
+	}
+	var cfg map[string]any
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("PatchConfigYAML: parsing %s: %v", cfgPath, err)
+	}
+	fn(cfg)
+	out, err := yaml.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("PatchConfigYAML: marshaling: %v", err)
+	}
+	if err := os.WriteFile(cfgPath, out, 0o644); err != nil {
+		t.Fatalf("PatchConfigYAML: writing %s: %v", cfgPath, err)
+	}
+}

--- a/tests/rel01.0/uc002/lifecycle_test.go
+++ b/tests/rel01.0/uc002/lifecycle_test.go
@@ -138,10 +138,47 @@ func TestRel01_UC002_ResetReturnsToCleanMain(t *testing.T) {
 }
 
 func TestRel01_UC002_SwitchSavesAndChangesBranch(t *testing.T) {
-	// GH-1608: generator:switch to main from a worktree fails because git
-	// does not allow the same branch to be checked out in two worktrees.
-	// This needs a follow-up to adapt generator:switch for worktree mode.
-	t.Skip("generator:switch to main is incompatible with worktree mode (GH-1608)")
+	t.Parallel()
+	dir := testutil.SetupRepo(t, snapshotDir)
+
+	if err := testutil.RunMage(t, dir, "init"); err != nil {
+		t.Fatalf("init: %v", err)
+	}
+	wtDir := testutil.GeneratorStart(t, dir)
+	t.Cleanup(func() { testutil.RunMage(t, dir, "generator:reset") }) //nolint:errcheck
+
+	genBranch := testutil.GitBranch(t, wtDir)
+	if !strings.HasPrefix(genBranch, "generation-") {
+		t.Fatalf("expected generation branch after start, got %q", genBranch)
+	}
+
+	// Create a file in the worktree so there is work to save.
+	sentinel := filepath.Join(wtDir, "switch-test.txt")
+	if err := os.WriteFile(sentinel, []byte("dirty"), 0o644); err != nil {
+		t.Fatalf("writing sentinel: %v", err)
+	}
+
+	// Set generation.branch to main so generator:switch targets the base branch.
+	testutil.PatchConfigYAML(t, dir, func(cfg map[string]any) {
+		gen := cfg["generation"].(map[string]any)
+		gen["branch"] = "main"
+	})
+
+	// Switch from generation worktree back to main. This exercises the
+	// worktree-aware path added in GH-2043.
+	if err := testutil.RunMage(t, dir, "generator:switch"); err != nil {
+		t.Fatalf("generator:switch: %v", err)
+	}
+
+	// After switch, the main repo should be on main.
+	if branch := testutil.GitBranch(t, dir); branch != "main" {
+		t.Errorf("expected main after switch, got %q", branch)
+	}
+
+	// The generation worktree should have been removed.
+	if _, err := os.Stat(wtDir); !os.IsNotExist(err) {
+		t.Errorf("expected worktree %s to be removed after switch to main", wtDir)
+	}
 }
 
 func TestRel01_UC002_StartFailsWhenDirty(t *testing.T) {


### PR DESCRIPTION
## Summary

Fix `GeneratorSwitch` to handle worktree mode when switching to the base branch. When invoked from a generation worktree targeting `main`, saves work, switches to the main repo, and removes the worktree — mirroring the pattern used by `GeneratorStop` and `GeneratorReset`.

## Changes

- Added worktree-aware path to `GeneratorSwitch` in `pkg/orchestrator/generator.go`
- Extracted `SaveWork` from `SaveAndSwitchBranch` in `pkg/orchestrator/internal/generate/generator.go`
- Unskipped and implemented `TestRel01_UC002_SwitchSavesAndChangesBranch`
- Added `PatchConfigYAML` test helper to `tests/rel01.0/internal/testutil/testutil.go`

## Test plan

- [x] `mage analyze` passes
- [x] All 15 UC002 tests pass (0 skipped)
- [x] All unit tests pass

Closes #2043