### PR TITLE
GH-1986: Align documentation with implemented code

### DIFF
--- a/docs/interfaces/ifc-generation-lifecycle.yaml
+++ b/docs/interfaces/ifc-generation-lifecycle.yaml
@@ -90,7 +90,10 @@ operations:
       - name: error
         type: error
   - name: GeneratorSwitch
-    description: Switch the working directory to a different generation branch.
+    description: >-
+      Switch to a different generation branch. When the target is the base
+      branch and the current directory is a worktree created by GeneratorStart,
+      saves work, switches to the main repo, and removes the worktree.
     parameters: []
     returns:
       - name: error

--- a/orchestrator.go.tmpl
+++ b/orchestrator.go.tmpl
@@ -84,7 +84,7 @@ func Clean() error { return newOrch().Builder.Clean() }
 // Credentials extracts Claude credentials from the macOS Keychain.
 func Credentials() error { return newOrch().Builder.ExtractCredentials() }
 
-// Analyze performs cross-artifact consistency checks (PRDs, use cases, test suites, roadmap).
+// Analyze performs cross-artifact consistency checks (SRDs, use cases, test suites, roadmap).
 func Analyze() error { return newOrch().Analyzer.Analyze() }
 
 // Tag creates a documentation release tag (v0.YYYYMMDD.N) and builds the container image.


### PR DESCRIPTION
## Summary

Align documentation after GH-2043 (GeneratorSwitch worktree fix) and GH-1988 (PRD→SRD rename). Two minor drift items found and fixed.

## Changes

- Updated GeneratorSwitch description in `docs/interfaces/ifc-generation-lifecycle.yaml` to document worktree-aware behavior
- Fixed stale "PRDs" → "SRDs" in `orchestrator.go.tmpl` comment

## Test plan

- [x] `mage analyze` passes
- [x] Documentation reviewed for consistency

Closes #1986