### PR TITLE
GH-2068: Remove interface specs from StandardContextPatterns

### DIFF
--- a/pkg/orchestrator/internal/context/context.go
+++ b/pkg/orchestrator/internal/context/context.go
@@ -1516,7 +1516,6 @@ var StandardContextPatterns = []string{
 	"docs/specs/test-suites/test-rel*.yaml",
 	"docs/specs/dependency-map.yaml",
 	"docs/specs/sources.yaml",
-	"docs/interfaces/ifc-*.yaml",
 }
 
 // TypedDocPaths lists documents that must always be loaded through their

--- a/pkg/orchestrator/internal/context/context_test.go
+++ b/pkg/orchestrator/internal/context/context_test.go
@@ -1208,18 +1208,34 @@ operations:
         type: error
 `), 0o644)
 
+	// Interface specs are opt-in via context_sources (GH-2068).
+	// They are not in StandardContextPatterns, so without context_sources
+	// they should not appear.
 	project := ContextConfig{}
 	ctx, err := BuildProjectContext("", project, nil, ".cobbler")
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(ctx.InterfaceSpecs) != 1 {
-		t.Fatalf("expected 1 interface spec, got %d", len(ctx.InterfaceSpecs))
+	if len(ctx.InterfaceSpecs) != 0 {
+		t.Fatalf("expected 0 interface specs without opt-in, got %d", len(ctx.InterfaceSpecs))
 	}
-	if ctx.InterfaceSpecs[0].Name != "Builder" {
-		t.Errorf("expected name Builder, got %q", ctx.InterfaceSpecs[0].Name)
+
+	// With context_sources, interface specs appear as Extra documents.
+	project2 := ContextConfig{
+		ContextSources: "docs/interfaces/ifc-*.yaml",
 	}
-	if len(ctx.InterfaceSpecs[0].Operations) != 1 {
-		t.Errorf("expected 1 operation, got %d", len(ctx.InterfaceSpecs[0].Operations))
+	ctx2, err := BuildProjectContext("", project2, nil, ".cobbler")
+	if err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, doc := range ctx2.Extra {
+		if doc.Name == "ifc-builder" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected ifc-builder in Extra documents via context_sources, not found")
 	}
 }


### PR DESCRIPTION
## Summary

Interface spec files (`docs/interfaces/ifc-*.yaml`) are removed from `StandardContextPatterns` so they are no longer bulk-loaded into every measure/stitch prompt. Repos opt in via `context_sources` in `configuration.yaml`. ARCHITECTURE.yaml serves as the discovery index.

## Changes

- Removed `docs/interfaces/ifc-*.yaml` from `StandardContextPatterns` in `context.go`
- Updated `TestBuildProjectContext_InterfaceSpecs` to verify opt-in behavior: no specs without config, available as Extra with `context_sources`

## Test plan

- [x] `mage analyze` passes
- [x] All unit tests pass
- [x] Interface test verifies opt-in semantics

Closes #2068