### PR TITLE
GH-2070: Separate weight enforcement from granularity and file-naming validation

### DIFF
--- a/pkg/orchestrator/config.go
+++ b/pkg/orchestrator/config.go
@@ -205,11 +205,31 @@ type CobblerConfig struct {
 	// Set to -1 to disable budget enforcement entirely.
 	MaxContextBytes int `yaml:"max_context_bytes"`
 
-	// EnforceMeasureValidation enables strict validation of measure output.
-	// When true, issues that violate P9 granularity ranges or P7 file naming
-	// are rejected and measure retries. When false (default), violations are
-	// logged as advisory warnings and import proceeds.
+	// EnforceMeasureValidation enables strict validation of all measure
+	// output checks. When true, it acts as a shorthand that enables
+	// EnforceWeightValidation, EnforceGranularityValidation, and
+	// EnforceFileNamingValidation (existing behavior). When false
+	// (default), the three granular flags control enforcement
+	// independently. See GH-2070.
 	EnforceMeasureValidation bool `yaml:"enforce_measure_validation"`
+
+	// EnforceWeightValidation rejects proposed tasks whose total
+	// requirement weight exceeds MaxWeightPerTask (or whose expanded
+	// count exceeds MaxRequirementsPerTask). This is the most useful
+	// enforcement flag — it catches oversized tasks that will fail
+	// during stitch. Default false (GH-2070).
+	EnforceWeightValidation bool `yaml:"enforce_weight_validation"`
+
+	// EnforceGranularityValidation rejects proposed tasks that violate
+	// P9 granularity ranges (requirement count 5-8, AC count 5-8,
+	// design decisions 3-5 for code; 2-4/3-5 for documentation).
+	// Default false (GH-2070).
+	EnforceGranularityValidation bool `yaml:"enforce_granularity_validation"`
+
+	// EnforceFileNamingValidation rejects proposed tasks that contain
+	// files matching their parent package name (P7 violation, e.g.,
+	// cmd/foo/foo.go). Default false (GH-2070).
+	EnforceFileNamingValidation bool `yaml:"enforce_file_naming_validation"`
 
 	// MaxMeasureRetries is the maximum number of retry attempts per iteration
 	// when EnforceMeasureValidation rejects the output. When 0 (default),
@@ -578,6 +598,13 @@ func (c *Config) applyDefaults() {
 	// weight exceeds the budget (GH-1951).
 	if c.Cobbler.MaxRequirementsPerTask > 0 && c.Cobbler.MaxWeightPerTask == 0 {
 		c.Cobbler.MaxWeightPerTask = c.Cobbler.MaxRequirementsPerTask
+	}
+	// Backward compatibility: enforce_measure_validation: true enables
+	// all three granular flags (GH-2070).
+	if c.Cobbler.EnforceMeasureValidation {
+		c.Cobbler.EnforceWeightValidation = true
+		c.Cobbler.EnforceGranularityValidation = true
+		c.Cobbler.EnforceFileNamingValidation = true
 	}
 }
 

--- a/pkg/orchestrator/config_test.go
+++ b/pkg/orchestrator/config_test.go
@@ -307,6 +307,68 @@ func TestLoadConfig_EnforceMeasureValidationDefaultsFalse(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_GranularValidationFlags(t *testing.T) {
+	t.Parallel()
+	yaml := `cobbler:
+  enforce_weight_validation: true
+  enforce_granularity_validation: false
+  enforce_file_naming_validation: false
+`
+	f := writeTemp(t, yaml)
+	cfg, err := LoadConfig(f)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.Cobbler.EnforceWeightValidation {
+		t.Error("EnforceWeightValidation: got false, want true")
+	}
+	if cfg.Cobbler.EnforceGranularityValidation {
+		t.Error("EnforceGranularityValidation: got true, want false")
+	}
+	if cfg.Cobbler.EnforceFileNamingValidation {
+		t.Error("EnforceFileNamingValidation: got true, want false")
+	}
+}
+
+func TestLoadConfig_EnforceMeasureValidationEnablesAllThree(t *testing.T) {
+	t.Parallel()
+	yaml := `cobbler:
+  enforce_measure_validation: true
+`
+	f := writeTemp(t, yaml)
+	cfg, err := LoadConfig(f)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if !cfg.Cobbler.EnforceWeightValidation {
+		t.Error("EnforceWeightValidation: got false, want true (backward compat)")
+	}
+	if !cfg.Cobbler.EnforceGranularityValidation {
+		t.Error("EnforceGranularityValidation: got false, want true (backward compat)")
+	}
+	if !cfg.Cobbler.EnforceFileNamingValidation {
+		t.Error("EnforceFileNamingValidation: got false, want true (backward compat)")
+	}
+}
+
+func TestLoadConfig_GranularFlagsDefaultFalse(t *testing.T) {
+	t.Parallel()
+	f := writeTemp(t, "project:\n  module_path: example.com/x\n")
+	cfg, err := LoadConfig(f)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if cfg.Cobbler.EnforceWeightValidation {
+		t.Error("EnforceWeightValidation default: got true, want false")
+	}
+	if cfg.Cobbler.EnforceGranularityValidation {
+		t.Error("EnforceGranularityValidation default: got true, want false")
+	}
+	if cfg.Cobbler.EnforceFileNamingValidation {
+		t.Error("EnforceFileNamingValidation default: got true, want false")
+	}
+}
+
 // --- LoadConfig: SeedFiles resolution ---
 
 func TestLoadConfig_SeedFilesResolved(t *testing.T) {

--- a/pkg/orchestrator/internal/generate/measure.go
+++ b/pkg/orchestrator/internal/generate/measure.go
@@ -41,13 +41,27 @@ type IssueDescItem struct {
 
 // ValidationResult holds the outcome of measure output validation.
 type ValidationResult struct {
-	Warnings []string // advisory issues (logged but do not block import)
-	Errors   []string // blocking issues (cause rejection in enforcing mode)
+	Warnings          []string // advisory issues (logged but do not block import)
+	Errors            []string // blocking issues not categorized below (e.g., completed R-items)
+	WeightErrors      []string // weight budget violations (GH-2070)
+	GranularityErrors []string // P9 requirement/AC/DD count range violations (GH-2070)
+	FileNamingErrors  []string // P7 file naming convention violations (GH-2070)
 }
 
-// HasErrors returns true if the validation found blocking issues.
+// HasErrors returns true if the validation found any blocking issues.
 func (v ValidationResult) HasErrors() bool {
-	return len(v.Errors) > 0
+	return len(v.Errors) > 0 || len(v.WeightErrors) > 0 || len(v.GranularityErrors) > 0 || len(v.FileNamingErrors) > 0
+}
+
+// AllErrors returns all error slices concatenated, for backward-compatible
+// callers that treat all errors uniformly.
+func (v ValidationResult) AllErrors() []string {
+	all := make([]string, 0, len(v.Errors)+len(v.WeightErrors)+len(v.GranularityErrors)+len(v.FileNamingErrors))
+	all = append(all, v.WeightErrors...)
+	all = append(all, v.GranularityErrors...)
+	all = append(all, v.FileNamingErrors...)
+	all = append(all, v.Errors...)
+	return all
 }
 
 // ProposedIssue is the minimal interface needed by validation and logging.
@@ -143,41 +157,41 @@ func ValidateMeasureOutput(issues []ProposedIssue, maxReqs, maxWeight int, subIt
 			if expandedWeight > maxWeight {
 				msg := fmt.Sprintf("[%d] %q: total weight is %d, max is %d", issue.Index, issue.Title, expandedWeight, maxWeight)
 				Log("validateMeasureOutput: %s", msg)
-				result.Errors = append(result.Errors, msg)
+				result.WeightErrors = append(result.WeightErrors, msg)
 			}
 		} else if maxReqs > 0 && expandedCount > maxReqs {
 			// Fall back to count-based enforcement when weight is not configured.
 			msg := fmt.Sprintf("[%d] %q: expanded sub-item count is %d, max is %d", issue.Index, issue.Title, expandedCount, maxReqs)
 			Log("validateMeasureOutput: %s", msg)
-			result.Errors = append(result.Errors, msg)
+			result.WeightErrors = append(result.WeightErrors, msg)
 		}
 
 		if desc.DeliverableType == "code" {
 			if rCount < 5 || rCount > 8 {
 				msg := fmt.Sprintf("[%d] %q: requirement count %d outside P9 range 5-8", issue.Index, issue.Title, rCount)
 				Log("validateMeasureOutput: %s", msg)
-				result.Errors = append(result.Errors, msg)
+				result.GranularityErrors = append(result.GranularityErrors, msg)
 			}
 			if acCount < 5 || acCount > 8 {
 				msg := fmt.Sprintf("[%d] %q: acceptance criteria count %d outside P9 range 5-8", issue.Index, issue.Title, acCount)
 				Log("validateMeasureOutput: %s", msg)
-				result.Errors = append(result.Errors, msg)
+				result.GranularityErrors = append(result.GranularityErrors, msg)
 			}
 			if dCount < 3 || dCount > 5 {
 				msg := fmt.Sprintf("[%d] %q: design decision count %d outside P9 range 3-5", issue.Index, issue.Title, dCount)
 				Log("validateMeasureOutput: %s", msg)
-				result.Errors = append(result.Errors, msg)
+				result.GranularityErrors = append(result.GranularityErrors, msg)
 			}
 		} else if desc.DeliverableType == "documentation" {
 			if rCount < 2 || rCount > 4 {
 				msg := fmt.Sprintf("[%d] %q: requirement count %d outside P9 doc range 2-4", issue.Index, issue.Title, rCount)
 				Log("validateMeasureOutput: %s", msg)
-				result.Errors = append(result.Errors, msg)
+				result.GranularityErrors = append(result.GranularityErrors, msg)
 			}
 			if acCount < 3 || acCount > 5 {
 				msg := fmt.Sprintf("[%d] %q: acceptance criteria count %d outside P9 doc range 3-5", issue.Index, issue.Title, acCount)
 				Log("validateMeasureOutput: %s", msg)
-				result.Errors = append(result.Errors, msg)
+				result.GranularityErrors = append(result.GranularityErrors, msg)
 			}
 		}
 
@@ -190,7 +204,7 @@ func ValidateMeasureOutput(issues []ProposedIssue, maxReqs, maxWeight int, subIt
 				if file == dir+".go" || file == dir+"_test.go" {
 					msg := fmt.Sprintf("[%d] %q: file %s matches package name (P7 violation)", issue.Index, issue.Title, f.Path)
 					Log("validateMeasureOutput: %s", msg)
-					result.Errors = append(result.Errors, msg)
+					result.FileNamingErrors = append(result.FileNamingErrors, msg)
 				}
 			}
 		}

--- a/pkg/orchestrator/internal/generate/measure_test.go
+++ b/pkg/orchestrator/internal/generate/measure_test.go
@@ -672,13 +672,13 @@ acceptance_criteria:
 
 	// Total weight = 1+4+3 = 8. Budget = 4 → should error.
 	result := ValidateMeasureOutput(issues, 0, 4, nil, reqStates)
-	if len(result.Errors) == 0 {
+	if len(result.WeightErrors) == 0 {
 		t.Error("expected weight budget error, got none")
 	}
 
 	// Budget = 10 → should pass.
 	result = ValidateMeasureOutput(issues, 0, 10, nil, reqStates)
-	for _, e := range result.Errors {
+	for _, e := range result.WeightErrors {
 		if contains(e, "total weight") {
 			t.Errorf("unexpected weight error with budget 10: %s", e)
 		}

--- a/pkg/orchestrator/measure.go
+++ b/pkg/orchestrator/measure.go
@@ -650,9 +650,27 @@ func (m *Measure) importIssuesImpl(yamlFile, repo, generation string, skipEnforc
 	if len(vr.Warnings) > 0 {
 		m.logf("importIssues: %d warning(s)", len(vr.Warnings))
 	}
-	if vr.HasErrors() && m.cfg.Cobbler.EnforceMeasureValidation && !skipEnforcement {
-		return nil, vr.Errors, fmt.Errorf("measure validation failed (%d error(s)): %s",
-			len(vr.Errors), strings.Join(vr.Errors, "; "))
+	// Collect enforced errors based on per-category flags (GH-2070).
+	if !skipEnforcement {
+		var enforced []string
+		if m.cfg.Cobbler.EnforceWeightValidation && len(vr.WeightErrors) > 0 {
+			enforced = append(enforced, vr.WeightErrors...)
+		}
+		if m.cfg.Cobbler.EnforceGranularityValidation && len(vr.GranularityErrors) > 0 {
+			enforced = append(enforced, vr.GranularityErrors...)
+		}
+		if m.cfg.Cobbler.EnforceFileNamingValidation && len(vr.FileNamingErrors) > 0 {
+			enforced = append(enforced, vr.FileNamingErrors...)
+		}
+		// Uncategorized errors (e.g., completed R-items) are always enforced
+		// when any enforcement flag is active.
+		if (m.cfg.Cobbler.EnforceWeightValidation || m.cfg.Cobbler.EnforceGranularityValidation || m.cfg.Cobbler.EnforceFileNamingValidation) && len(vr.Errors) > 0 {
+			enforced = append(enforced, vr.Errors...)
+		}
+		if len(enforced) > 0 {
+			return nil, enforced, fmt.Errorf("measure validation failed (%d error(s)): %s",
+				len(enforced), strings.Join(enforced, "; "))
+		}
 	}
 
 	// Deduplicate: fetch existing issues for this generation and skip any

--- a/pkg/orchestrator/measure_test.go
+++ b/pkg/orchestrator/measure_test.go
@@ -94,8 +94,8 @@ design_decisions:
 	if !vr.HasErrors() {
 		t.Error("expected errors for code task with 2 requirements (P9 range 5-8)")
 	}
-	if len(vr.Errors) != 1 {
-		t.Errorf("expected 1 error, got %d: %v", len(vr.Errors), vr.Errors)
+	if len(vr.GranularityErrors) != 1 {
+		t.Errorf("expected 1 granularity error, got %d: %v", len(vr.GranularityErrors), vr.GranularityErrors)
 	}
 }
 
@@ -258,14 +258,14 @@ design_decisions:
 		t.Error("expected errors for file named after package (P7 violation)")
 	}
 	found := false
-	for _, e := range vr.Errors {
+	for _, e := range vr.FileNamingErrors {
 		if contains(e, "P7 violation") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected P7 violation error, got: %v", vr.Errors)
+		t.Errorf("expected P7 violation error, got: %v", vr.FileNamingErrors)
 	}
 }
 
@@ -313,13 +313,13 @@ design_decisions:
 	// the file name does not match the parent directory name.
 	vr := validateMeasureOutput(issues, 0, 0, nil, nil)
 	p7Errors := 0
-	for _, e := range vr.Errors {
+	for _, e := range vr.FileNamingErrors {
 		if contains(e, "P7 violation") {
 			p7Errors++
 		}
 	}
 	if p7Errors > 0 {
-		t.Errorf("expected no P7 violation for difftest/runner.go, got %d: %v", p7Errors, vr.Errors)
+		t.Errorf("expected no P7 violation for difftest/runner.go, got %d: %v", p7Errors, vr.FileNamingErrors)
 	}
 }
 
@@ -430,7 +430,7 @@ func TestValidateMeasureOutput_MaxReqs_ZeroIsUnlimited(t *testing.T) {
 		Description: "deliverable_type: code\nrequirements:\n" + reqs,
 	}}
 	vr := validateMeasureOutput(issues, 0, 0, nil, nil)
-	for _, e := range vr.Errors {
+	for _, e := range vr.WeightErrors {
 		if contains(e, "max is") {
 			t.Errorf("maxReqs=0 should not produce max-requirements error, got: %s", e)
 		}
@@ -458,7 +458,7 @@ requirements:
 `,
 	}}
 	vr := validateMeasureOutput(issues, 5, 0, nil, nil)
-	for _, e := range vr.Errors {
+	for _, e := range vr.WeightErrors {
 		if contains(e, "max is") {
 			t.Errorf("5 requirements at maxReqs=5 should not error, got: %s", e)
 		}
@@ -489,14 +489,14 @@ requirements:
 	}}
 	vr := validateMeasureOutput(issues, 5, 0, nil, nil)
 	found := false
-	for _, e := range vr.Errors {
+	for _, e := range vr.WeightErrors {
 		if contains(e, "max is") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected max-requirements error for 6 reqs with limit 5, got errors: %v", vr.Errors)
+		t.Errorf("expected max-requirements error for 6 reqs with limit 5, got errors: %v", vr.WeightErrors)
 	}
 }
 
@@ -528,14 +528,14 @@ requirements:
 	}}
 	vr := validateMeasureOutput(issues, 5, 0, nil, nil)
 	found := false
-	for _, e := range vr.Errors {
+	for _, e := range vr.WeightErrors {
 		if contains(e, "8") && contains(e, "5") && contains(e, "Task Title") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("error should mention count (8), limit (5), and title; got: %v", vr.Errors)
+		t.Errorf("error should mention count (8), limit (5), and title; got: %v", vr.WeightErrors)
 	}
 }
 
@@ -658,14 +658,14 @@ design_decisions:
 	}}
 	vr := validateMeasureOutput(issues, 8, 0, subItems, nil)
 	found := false
-	for _, e := range vr.Errors {
+	for _, e := range vr.WeightErrors {
 		if contains(e, "expanded sub-item count") && contains(e, "max is") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected hard error for expanded count 13 > maxReqs 8, got errors: %v", vr.Errors)
+		t.Errorf("expected hard error for expanded count 13 > maxReqs 8, got errors: %v", vr.WeightErrors)
 	}
 }
 
@@ -712,7 +712,7 @@ design_decisions:
 	}}
 	// expanded = 2+4 = 6, maxReqs = 8 → no expanded-count error.
 	vr := validateMeasureOutput(issues, 8, 0, subItems, nil)
-	for _, e := range vr.Errors {
+	for _, e := range vr.WeightErrors {
 		if contains(e, "expanded sub-item count") {
 			t.Errorf("should not error when expanded count under limit, got: %s", e)
 		}
@@ -761,7 +761,7 @@ design_decisions:
 	}}
 	// 5 listed, expanded = 2+4 = 6. maxReqs = 8. Under limit — no error.
 	vr := validateMeasureOutput(issues, 8, 0, subItems, nil)
-	for _, e := range vr.Errors {
+	for _, e := range vr.WeightErrors {
 		if contains(e, "expanded sub-item count") {
 			t.Errorf("should not error when expanded count under limit, got: %s", e)
 		}
@@ -1440,6 +1440,103 @@ acceptance_criteria:
 	}
 	// ids will be empty because createCobblerIssue fails (no GitHub), but no error returned.
 	_ = ids
+}
+
+func TestImportIssuesImpl_WeightOnlyEnforcementPassesP9Violations(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlFile := filepath.Join(dir, "issues.yaml")
+
+	// Code issue with 1 requirement — violates P9 (5-8) but not weight.
+	issues := []proposedIssue{{
+		Index: 1,
+		Title: "Small task",
+		Description: `deliverable_type: code
+requirements:
+  - id: R1
+    text: req1
+acceptance_criteria:
+  - id: AC1
+    text: ac1
+`,
+	}}
+	data, _ := yaml.Marshal(issues)
+	os.WriteFile(yamlFile, data, 0o644)
+
+	cfg := Config{}
+	cfg.Cobbler.Dir = dir
+	cfg.Cobbler.EnforceWeightValidation = true
+	// Granularity and file naming enforcement OFF.
+	o := New(cfg)
+
+	// Should NOT fail: P9 violation is not enforced, weight is fine.
+	// Will fail at createCobblerIssue (no real GitHub), but should NOT
+	// fail at validation.
+	_, _, err := o.Measure.importIssuesImpl(yamlFile, "owner/repo", "gen", false, 0)
+	if err != nil {
+		t.Fatalf("expected no validation error with only weight enforcement, got: %v", err)
+	}
+}
+
+func TestImportIssuesImpl_WeightOnlyEnforcementRejectsWeightViolation(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	yamlFile := filepath.Join(dir, "issues.yaml")
+
+	// Code issue with valid P9 shape but exceeds weight budget.
+	issues := []proposedIssue{{
+		Index: 1,
+		Title: "Heavy task",
+		Description: `deliverable_type: code
+requirements:
+  - id: R1
+    text: req1
+  - id: R2
+    text: req2
+  - id: R3
+    text: req3
+  - id: R4
+    text: req4
+  - id: R5
+    text: req5
+  - id: R6
+    text: req6
+acceptance_criteria:
+  - id: AC1
+    text: ac1
+  - id: AC2
+    text: ac2
+  - id: AC3
+    text: ac3
+  - id: AC4
+    text: ac4
+  - id: AC5
+    text: ac5
+design_decisions:
+  - id: DD1
+    text: dd1
+  - id: DD2
+    text: dd2
+  - id: DD3
+    text: dd3
+`,
+	}}
+	data, _ := yaml.Marshal(issues)
+	os.WriteFile(yamlFile, data, 0o644)
+
+	cfg := Config{}
+	cfg.Cobbler.Dir = dir
+	cfg.Cobbler.EnforceWeightValidation = true
+	cfg.Cobbler.MaxRequirementsPerTask = 5 // 6 reqs exceeds limit
+	o := New(cfg)
+
+	_, validationErrs, err := o.Measure.importIssuesImpl(yamlFile, "owner/repo", "gen", false, 0)
+	if err == nil {
+		t.Error("expected validation error for weight violation")
+	}
+	if len(validationErrs) == 0 {
+		t.Error("expected non-empty validationErrs")
+	}
 }
 
 // --- importIssuesImpl upgrade path (GH-578) ---


### PR DESCRIPTION
## Summary

Splits the single `enforce_measure_validation` flag into three independent flags so weight enforcement can be enabled without the noisy P9 granularity and P7 file-naming checks that burn retries on violations Claude cannot fix.

## Changes

- Added `enforce_weight_validation`, `enforce_granularity_validation`, `enforce_file_naming_validation` config fields
- `enforce_measure_validation: true` enables all three (backward compatible)
- `ValidationResult` categorizes errors into `WeightErrors`, `GranularityErrors`, `FileNamingErrors` with `AllErrors()` helper
- `importIssuesImpl` rejects based on per-category flags instead of a single boolean
- 3 new config tests (granular flags, backward compat, defaults)
- 2 new integration tests (weight-only passes P9 violations, weight-only rejects weight violations)

## Stats

- go_loc_prod: 20498 (was 20750, delta -252 from reformatting/restructuring)
- go_loc_test: 36943 (was 36784, delta +159)
- `mage analyze` passes
- All 12 packages pass

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass (`go test ./pkg/orchestrator/... -count=1`)
- [x] New config tests for three flags, backward compat, and defaults
- [x] New validation tests for selective enforcement

Closes #2070