### PR TITLE
GH-2080: Remove weight from SRDs, make requirements.yaml the sole weight authority

### DIFF
--- a/pkg/orchestrator/internal/analysis/analyze.go
+++ b/pkg/orchestrator/internal/analysis/analyze.go
@@ -37,7 +37,7 @@ type AnalyzeResult struct {
 	UntracedSuccessCriteria        []string // S-items with no AC traces (warning)
 	UnreachableUCs                 []string // UCs whose touchpoint SRDs have no R-items (warning)
 	FailedRequirements             []string // R-items marked complete_with_failures (warning)
-	MissingWeights                 []string // R-items without explicit weight annotation (warning, GH-1946)
+	// MissingWeights removed — weights live in requirements.yaml, not SRDs (GH-2080).
 	BareTouchpoints                []string // Touchpoints citing SRDs without R-group references (warning, GH-1961)
 	UCIDPrefixMismatch             []string // Use case ID prefix doesn't match assigned release in roadmap (GH-1964)
 	BrokenInterfaceRefs            []string // implemented_by/used_by references non-existent architecture interface (GH-1968)
@@ -91,21 +91,8 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 				groups[groupKey] = true
 				for _, item := range group.Items {
 					if m, ok := item.(map[string]interface{}); ok {
-						for itemKey, val := range m {
+						for itemKey := range m {
 							srdRItems[id] = append(srdRItems[id], itemKey)
-							// Check for missing weight annotation (GH-1946).
-							// Simple string value = no weight; nested map with
-							// "weight" key = has weight.
-							hasWeight := false
-							if nested, ok := val.(map[string]interface{}); ok {
-								if _, ok := nested["weight"]; ok {
-									hasWeight = true
-								}
-							}
-							if !hasWeight {
-								result.MissingWeights = append(result.MissingWeights,
-									fmt.Sprintf("%s %s: no weight (defaults to 1)", id, itemKey))
-							}
 						}
 					}
 				}
@@ -597,8 +584,7 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 	}
 	deps.Log("analyze: failed requirements found %d (warning)", len(result.FailedRequirements))
 
-	sort.Strings(result.MissingWeights)
-	deps.Log("analyze: missing weights found %d (warning)", len(result.MissingWeights))
+	// MissingWeights check removed — weights live in requirements.yaml (GH-2080).
 
 	// Check 7: YAML schema validation.
 	result.SchemaErrors = deps.ValidateDocSchemas()
@@ -669,7 +655,7 @@ func (r AnalyzeResult) PrintReport(srdCount, ucCount, tsCount, smCount int) erro
 	PrintSection("Untraced success criteria (S-item with no AC trace — warning)", r.UntracedSuccessCriteria)
 	PrintSection("Unreachable UCs (touchpoint SRDs have no R-items — warning)", r.UnreachableUCs)
 	PrintSection("Failed requirements (R-items complete with test failures — warning)", r.FailedRequirements)
-	PrintSection("Missing weights (R-items without explicit weight annotation — warning)", r.MissingWeights)
+	// MissingWeights print removed — weights live in requirements.yaml (GH-2080).
 	PrintSection("Bare touchpoints (SRD cited without R-group references — warning)", r.BareTouchpoints)
 
 	if !hasIssues {

--- a/pkg/orchestrator/internal/generate/requirements.go
+++ b/pkg/orchestrator/internal/generate/requirements.go
@@ -71,7 +71,7 @@ func GenerateRequirementsFile(srdDir, cobblerDir string, preserveExisting bool) 
 
 	for _, path := range paths {
 		slug := strings.TrimSuffix(filepath.Base(path), filepath.Ext(path))
-		items := extractRItemsWeighted(path)
+		items := extractRItemsFromSRD(path)
 		if len(items) == 0 {
 			continue
 		}
@@ -80,14 +80,15 @@ func GenerateRequirementsFile(srdDir, cobblerDir string, preserveExisting bool) 
 			if existing != nil {
 				if prev, ok := existing[slug]; ok {
 					if st, ok := prev[item.ID]; ok {
-						// Preserve existing state but update weight from SRD.
-						st.Weight = item.Weight
+						// Preserve existing state and weight (GH-2080).
 						group[item.ID] = st
 						continue
 					}
 				}
 			}
-			group[item.ID] = RequirementState{Status: "ready", Weight: item.Weight}
+			// New items default to weight 1. Weights are managed in
+			// requirements.yaml, not in SRDs (GH-2080).
+			group[item.ID] = RequirementState{Status: "ready", Weight: 1}
 		}
 		allReqs[slug] = group
 	}
@@ -396,15 +397,16 @@ func extractTouchpointCitations(touchpoints []string) []touchpointCitation {
 	return citations
 }
 
-// rItemInfo holds an R-item ID and its weight from the SRD.
+// rItemInfo holds an R-item ID extracted from a SRD. Weight is not read
+// from SRDs — weights live only in requirements.yaml (GH-2080).
 type rItemInfo struct {
-	ID     string
-	Weight int
+	ID string
 }
 
-// extractRItems reads a SRD YAML file and returns all R-item IDs (e.g.
-// R1.1, R1.2, R2.1) with their weights, sorted by ID.
-func extractRItemsWeighted(path string) []rItemInfo {
+// extractRItemsFromSRD reads a SRD YAML file and returns all R-item IDs
+// (e.g. R1.1, R1.2, R2.1), sorted by ID. Weights are not extracted from
+// SRDs — they are managed in requirements.yaml (GH-2080).
+func extractRItemsFromSRD(path string) []rItemInfo {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -419,17 +421,8 @@ func extractRItemsWeighted(path string) []rItemInfo {
 		for _, item := range group.Items {
 			switch v := item.(type) {
 			case map[string]interface{}:
-				for k, val := range v {
-					w := 1
-					// Check for weighted format: {text: ..., weight: N}
-					if m, ok := val.(map[string]interface{}); ok {
-						if wv, ok := m["weight"]; ok {
-							if wi, ok := wv.(int); ok && wi > 0 {
-								w = wi
-							}
-						}
-					}
-					items = append(items, rItemInfo{ID: k, Weight: w})
+				for k := range v {
+					items = append(items, rItemInfo{ID: k})
 				}
 			}
 		}
@@ -440,9 +433,9 @@ func extractRItemsWeighted(path string) []rItemInfo {
 
 // extractRItems reads a SRD YAML file and returns all R-item IDs in sorted order.
 func extractRItems(path string) []string {
-	weighted := extractRItemsWeighted(path)
-	ids := make([]string, len(weighted))
-	for i, item := range weighted {
+	items := extractRItemsFromSRD(path)
+	ids := make([]string, len(items))
+	for i, item := range items {
 		ids[i] = item.ID
 	}
 	return ids

--- a/pkg/orchestrator/internal/generate/requirements_test.go
+++ b/pkg/orchestrator/internal/generate/requirements_test.go
@@ -1513,10 +1513,10 @@ func assertReqState(t *testing.T, rf RequirementsFile, srd, rItem, wantStatus st
 }
 
 // ---------------------------------------------------------------------------
-// Requirement weights (GH-1832)
+// Requirement weights (GH-2080: weights live in requirements.yaml, not SRDs)
 // ---------------------------------------------------------------------------
 
-func TestExtractRItemsWeighted_SimpleFormat(t *testing.T) {
+func TestExtractRItemsFromSRD_ExtractsIDsOnly(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()
 	srdPath := filepath.Join(dir, "srd001-test.yaml")
@@ -1530,73 +1530,34 @@ requirements:
     title: Basic
     items:
       - R1.1: Simple requirement
-      - R1.2: Another simple one
+      - R1.2:
+          text: Complex with SRD weight field
+          weight: 5
 non_goals: []
 acceptance_criteria: []
 `
 	os.WriteFile(srdPath, []byte(srd), 0o644)
 
-	items := extractRItemsWeighted(srdPath)
+	items := extractRItemsFromSRD(srdPath)
 	if len(items) != 2 {
 		t.Fatalf("expected 2 items, got %d", len(items))
 	}
+	ids := map[string]bool{}
 	for _, item := range items {
-		if item.Weight != 1 {
-			t.Errorf("%s: weight = %d, want 1 (default)", item.ID, item.Weight)
-		}
+		ids[item.ID] = true
+	}
+	if !ids["R1.1"] || !ids["R1.2"] {
+		t.Errorf("expected R1.1 and R1.2, got %v", ids)
 	}
 }
 
-func TestExtractRItemsWeighted_WithWeights(t *testing.T) {
-	t.Parallel()
-	dir := t.TempDir()
-	srdPath := filepath.Join(dir, "srd002-test.yaml")
-	srd := `id: srd002
-title: Test
-problem: test
-goals:
-  - G1: goal
-requirements:
-  R1:
-    title: Complex
-    items:
-      - R1.1: Simple thing
-      - R1.2:
-          text: Complex parser
-          weight: 4
-      - R1.3:
-          text: Very complex
-          weight: 10
-non_goals: []
-acceptance_criteria: []
-`
-	os.WriteFile(srdPath, []byte(srd), 0o644)
-
-	items := extractRItemsWeighted(srdPath)
-	if len(items) != 3 {
-		t.Fatalf("expected 3 items, got %d", len(items))
-	}
-	weights := map[string]int{}
-	for _, item := range items {
-		weights[item.ID] = item.Weight
-	}
-	if weights["R1.1"] != 1 {
-		t.Errorf("R1.1 weight = %d, want 1", weights["R1.1"])
-	}
-	if weights["R1.2"] != 4 {
-		t.Errorf("R1.2 weight = %d, want 4", weights["R1.2"])
-	}
-	if weights["R1.3"] != 10 {
-		t.Errorf("R1.3 weight = %d, want 10", weights["R1.3"])
-	}
-}
-
-func TestGenerateRequirementsFile_CarriesWeight(t *testing.T) {
+func TestGenerateRequirementsFile_NewItemsDefaultWeight1(t *testing.T) {
 	dir := t.TempDir()
 	srdDir := filepath.Join(dir, "docs", "specs", "software-requirements")
 	os.MkdirAll(srdDir, 0o755)
 	cobblerDir := filepath.Join(dir, ".cobbler")
 
+	// SRD has weight annotations but they should be ignored.
 	srd := `id: srd001
 title: Test
 problem: test
@@ -1608,7 +1569,7 @@ requirements:
     items:
       - R1.1: Simple
       - R1.2:
-          text: Weighted
+          text: Has SRD weight but should be ignored
           weight: 5
 non_goals: []
 acceptance_criteria: []
@@ -1630,10 +1591,69 @@ acceptance_criteria: []
 		t.Fatal("no states for srd001-test")
 	}
 
+	// Both items should default to weight 1 regardless of SRD weight field.
 	if w := srdStates["R1.1"].Weight; w != 1 {
 		t.Errorf("R1.1 weight = %d, want 1", w)
 	}
-	if w := srdStates["R1.2"].Weight; w != 5 {
-		t.Errorf("R1.2 weight = %d, want 5", w)
+	if w := srdStates["R1.2"].Weight; w != 1 {
+		t.Errorf("R1.2 weight = %d, want 1 (SRD weight should be ignored)", w)
+	}
+}
+
+func TestGenerateRequirementsFile_PreservesExistingWeight(t *testing.T) {
+	dir := t.TempDir()
+	srdDir := filepath.Join(dir, "docs", "specs", "software-requirements")
+	os.MkdirAll(srdDir, 0o755)
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+
+	srd := `id: srd001
+title: Test
+problem: test
+goals:
+  - G1: goal
+requirements:
+  R1:
+    title: Test
+    items:
+      - R1.1: Item one
+      - R1.2: Item two
+non_goals: []
+acceptance_criteria: []
+`
+	os.WriteFile(filepath.Join(srdDir, "srd001-test.yaml"), []byte(srd), 0o644)
+
+	// Pre-populate requirements.yaml with custom weights.
+	existing := `requirements:
+    srd001-test:
+        R1.1:
+            status: ready
+            weight: 4
+        R1.2:
+            status: complete
+            issue: 42
+            weight: 7
+`
+	os.WriteFile(filepath.Join(cobblerDir, "requirements.yaml"), []byte(existing), 0o644)
+
+	// Regenerate with preserveExisting=true.
+	_, err := GenerateRequirementsFile(srdDir, cobblerDir, true)
+	if err != nil {
+		t.Fatalf("GenerateRequirementsFile: %v", err)
+	}
+
+	states := LoadRequirementStates(cobblerDir)
+	srdStates := states["srd001-test"]
+
+	// Weights from existing requirements.yaml should be preserved.
+	if w := srdStates["R1.1"].Weight; w != 4 {
+		t.Errorf("R1.1 weight = %d, want 4 (preserved)", w)
+	}
+	if w := srdStates["R1.2"].Weight; w != 7 {
+		t.Errorf("R1.2 weight = %d, want 7 (preserved)", w)
+	}
+	// Status should also be preserved.
+	if s := srdStates["R1.2"].Status; s != "complete" {
+		t.Errorf("R1.2 status = %q, want complete", s)
 	}
 }


### PR DESCRIPTION
## Summary

SRDs define requirements, not scheduling metadata. Weights now live only in requirements.yaml: new R-items default to weight 1, existing weights are preserved during regeneration. The `mage analyze` missing-weights warning is removed since SRDs no longer carry weight fields.

## Changes

- Renamed `extractRItemsWeighted` → `extractRItemsFromSRD` (extracts IDs only, no weight)
- `GenerateRequirementsFile` no longer copies weight from SRDs; preserves existing weights from requirements.yaml
- Removed `MissingWeights` field and check from `mage analyze`
- Replaced 3 SRD-weight tests with 3 requirements.yaml-weight tests (default weight 1, preserve existing, SRD weight ignored)

## Stats

- 3 files changed, 90 insertions, 91 deletions
- `mage analyze` passes (no more missing-weight warnings)
- All tests pass

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] New items default to weight 1
- [x] Existing weights preserved during regeneration
- [x] SRD weight annotations ignored

Closes #2080