### PR TITLE
GH-2117: Preserve weights in requirements.yaml regardless of PreserveSources

### DIFF
--- a/pkg/orchestrator/internal/generate/requirements.go
+++ b/pkg/orchestrator/internal/generate/requirements.go
@@ -61,11 +61,10 @@ func GenerateRequirementsFile(srdDir, cobblerDir string, preserveExisting bool) 
 		return "", fmt.Errorf("globbing SRDs in %s: %w", srdDir, err)
 	}
 
-	// Load existing states when preserving.
-	var existing map[string]map[string]RequirementState
-	if preserveExisting {
-		existing = LoadRequirementStates(cobblerDir)
-	}
+	// Always load existing requirements.yaml to preserve weights.
+	// Weights are the sole authority in requirements.yaml (GH-2080) and
+	// must survive regeneration regardless of preserveExisting (GH-2117).
+	existing := LoadRequirementStates(cobblerDir)
 
 	allReqs := make(map[string]map[string]RequirementState)
 
@@ -77,13 +76,16 @@ func GenerateRequirementsFile(srdDir, cobblerDir string, preserveExisting bool) 
 		}
 		group := make(map[string]RequirementState, len(items))
 		for _, item := range items {
-			if existing != nil {
-				if prev, ok := existing[slug]; ok {
-					if st, ok := prev[item.ID]; ok {
-						// Preserve existing state and weight (GH-2080).
+			if prev, ok := existing[slug]; ok {
+				if st, ok := prev[item.ID]; ok {
+					if preserveExisting {
+						// Preserve both status and weight.
 						group[item.ID] = st
-						continue
+					} else {
+						// Reset status to "ready" but preserve weight (GH-2117).
+						group[item.ID] = RequirementState{Status: "ready", Weight: st.Weight}
 					}
+					continue
 				}
 			}
 			// New items default to weight 1. Weights are managed in

--- a/pkg/orchestrator/internal/generate/requirements_test.go
+++ b/pkg/orchestrator/internal/generate/requirements_test.go
@@ -1657,3 +1657,65 @@ acceptance_criteria: []
 		t.Errorf("R1.2 status = %q, want complete", s)
 	}
 }
+
+func TestGenerateRequirementsFile_PreserveFalseRetainsWeights(t *testing.T) {
+	dir := t.TempDir()
+	srdDir := filepath.Join(dir, "docs", "specs", "software-requirements")
+	os.MkdirAll(srdDir, 0o755)
+	cobblerDir := filepath.Join(dir, ".cobbler")
+	os.MkdirAll(cobblerDir, 0o755)
+
+	srd := `id: srd001
+title: Test
+problem: test
+goals:
+  - G1: goal
+requirements:
+  R1:
+    title: Test
+    items:
+      - R1.1: Item one
+      - R1.2: Item two
+non_goals: []
+acceptance_criteria: []
+`
+	os.WriteFile(filepath.Join(srdDir, "srd001-test.yaml"), []byte(srd), 0o644)
+
+	// Pre-populate requirements.yaml with custom weights and statuses.
+	existing := `requirements:
+    srd001-test:
+        R1.1:
+            status: complete
+            issue: 42
+            weight: 4
+        R1.2:
+            status: complete
+            issue: 43
+            weight: 7
+`
+	os.WriteFile(filepath.Join(cobblerDir, "requirements.yaml"), []byte(existing), 0o644)
+
+	// Regenerate with preserveExisting=false (full reset).
+	_, err := GenerateRequirementsFile(srdDir, cobblerDir, false)
+	if err != nil {
+		t.Fatalf("GenerateRequirementsFile: %v", err)
+	}
+
+	states := LoadRequirementStates(cobblerDir)
+	srdStates := states["srd001-test"]
+
+	// Weights must be preserved even with preserveExisting=false (GH-2117).
+	if w := srdStates["R1.1"].Weight; w != 4 {
+		t.Errorf("R1.1 weight = %d, want 4 (preserved despite preserveExisting=false)", w)
+	}
+	if w := srdStates["R1.2"].Weight; w != 7 {
+		t.Errorf("R1.2 weight = %d, want 7 (preserved despite preserveExisting=false)", w)
+	}
+	// Statuses should be reset to "ready" since preserveExisting=false.
+	if s := srdStates["R1.1"].Status; s != "ready" {
+		t.Errorf("R1.1 status = %q, want ready (reset)", s)
+	}
+	if s := srdStates["R1.2"].Status; s != "ready" {
+		t.Errorf("R1.2 status = %q, want ready (reset)", s)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes weight loss during `generator:start` when `PreserveSources=false`. `GenerateRequirementsFile` now always loads existing requirements.yaml to carry forward weights. Statuses reset to "ready" when `preserveExisting=false`, but weights survive.

## Changes

- `GenerateRequirementsFile` always loads existing requirements.yaml (not gated on `preserveExisting`)
- When `preserveExisting=false`: status resets to "ready", weight preserved
- When `preserveExisting=true`: both status and weight preserved (unchanged behavior)
- Added `TestGenerateRequirementsFile_PreserveFalseRetainsWeights`

## Stats

- 2 files changed, 74 insertions, 10 deletions
- `mage analyze` passes
- All 11 internal packages pass

## Test plan

- [x] `mage analyze` passes
- [x] All tests pass
- [x] New test verifies weights preserved with preserveExisting=false
- [x] Existing preserve test still passes

Closes #2117