### PR TITLE
GH-2116: Remove mage credentials target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,6 @@ go.work.sum
 vscode-extension/**/node_modules/
 vscode-extension/out/
 vscode-extension/*.vsix
-.secrets/
 
 # Auto-generated config when mage runs from magefiles/
 magefiles/configuration.yaml

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -94,9 +94,6 @@ func Install() error { return newOrch().Builder.Install() }
 // Clean removes build artifacts.
 func Clean() error { return newOrch().Builder.Clean() }
 
-// Credentials extracts Claude credentials from the macOS Keychain.
-func Credentials() error { return newOrch().Builder.ExtractCredentials() }
-
 // Analyze performs cross-artifact consistency checks (PRDs, use cases, test suites, roadmap).
 func Analyze() error { return newOrch().Analyzer.Analyze() }
 

--- a/orchestrator.go.tmpl
+++ b/orchestrator.go.tmpl
@@ -81,9 +81,6 @@ func Install() error { return newOrch().Builder.Install() }
 // Clean removes build artifacts.
 func Clean() error { return newOrch().Builder.Clean() }
 
-// Credentials extracts Claude credentials from the macOS Keychain.
-func Credentials() error { return newOrch().Builder.ExtractCredentials() }
-
 // Analyze performs cross-artifact consistency checks (SRDs, use cases, test suites, roadmap).
 func Analyze() error { return newOrch().Analyzer.Analyze() }
 

--- a/pkg/orchestrator/internal/claude/claude.go
+++ b/pkg/orchestrator/internal/claude/claude.go
@@ -736,10 +736,14 @@ type CheckClaudeDeps struct {
 	EnsureCredentialsFn func() error
 }
 
-// CheckClaude verifies that Claude can be invoked.
+// CheckClaude verifies that Claude can be invoked. In CLI mode, the CLI
+// handles its own authentication so credential extraction is skipped (GH-2116).
 func CheckClaude(deps CheckClaudeDeps) error {
 	if _, err := exec.LookPath(BinClaude); err != nil {
 		return fmt.Errorf("claude not found on PATH; install the Claude CLI")
+	}
+	if deps.EffectiveMode == "cli" {
+		return nil
 	}
 	return deps.EnsureCredentialsFn()
 }


### PR DESCRIPTION
## Summary

Removes the unused `mage credentials` target and skips credential extraction in CLI mode. The CLI handles its own authentication; the credentials target created confusing `.secrets/claude.json` artifacts.

## Changes

- Removed `Credentials()` from `orchestrator.go.tmpl` (scaffold template)
- Removed `Credentials()` from `magefiles/magefile.go` (this repo's own magefile)
- `CheckClaude` skips `EnsureCredentials` when mode is "cli"
- Removed `.secrets/` from `.gitignore`

## Test plan

- [x] `mage analyze` passes
- [x] All internal package tests pass
- [x] `go build ./pkg/orchestrator/...` clean
- [x] Credentials function absent from template and magefile

Closes #2116