### PR TITLE
Move srd-beads-tracker and srd-pi-agent-backend into docs/specs/software-requirements/ (GH-2132)

### DIFF
--- a/docs/specs/software-requirements/srd007-beads-tracker.yaml
+++ b/docs/specs/software-requirements/srd007-beads-tracker.yaml
@@ -1,0 +1,978 @@
+id: srd007-beads-tracker
+title: Beads (bd) Work Tracker Backend for Cobbler Orchestrator
+
+implemented_by:
+  - BeadsTracker (pkg/orchestrator/internal/beads/)
+  - WorkTracker interface (pkg/orchestrator/internal/github/issues.go)
+  - Orchestrator constructor (pkg/orchestrator/orchestrator.go)
+  - Config struct (pkg/orchestrator/config.go)
+used_by:
+  - Generator (pkg/orchestrator/generator.go)
+  - Measure (pkg/orchestrator/measure.go)
+  - Stitch (pkg/orchestrator/stitch.go)
+
+problem: |
+  The cobbler-scaffold orchestrator currently depends on GitHub Issues as its
+  sole work-tracking backend. All issue CRUD, label management, dependency
+  promotion, and lifecycle operations are performed via the gh CLI, wrapped by
+  the GitHubTracker struct that implements the WorkTracker interface.
+
+  This coupling creates several problems:
+
+  1. Rate limits. The GitHub REST API enforces per-hour rate limits. The
+     orchestrator already contains a WaitForIssuesVisible polling loop because
+     the label index lags after writes. Long generation runs with many
+     measure-stitch cycles frequently hit secondary rate limits, causing
+     backoff delays and wasted compute time.
+
+  2. Eventual consistency. GitHub's search index is eventually consistent.
+     After creating or labeling an issue, ListOpenCobblerIssues may return
+     stale results. The orchestrator works around this with polling, retries,
+     and defensive checks — all of which add complexity and latency.
+
+  3. Network dependency. Every issue operation requires an internet connection
+     and a valid gh authentication token. Offline development, air-gapped
+     environments, and CI runners without GitHub credentials cannot use the
+     orchestrator.
+
+  4. Manual DAG promotion. GitHub Issues have no native dependency concept.
+     The orchestrator encodes dependencies in YAML front-matter
+     (cobbler_depends_on) embedded in issue bodies, then implements its own
+     DAG promotion logic by toggling cobbler-ready and cobbler-in-progress
+     labels. This is fragile and requires multiple API calls per promotion.
+
+  5. Sub-issue linking complexity. Linking child issues to parent issues
+     requires two API calls per link: one to fetch the child's database ID,
+     another to POST to the sub_issues endpoint. This is brittle and fails
+     silently when the API schema changes.
+
+  Beads (bd) is a lightweight, local-first issue tracker with first-class
+  dependency support, a SQLite/Dolt backing store, structured query language,
+  and JSON output on every command. It eliminates rate limits, eventual
+  consistency, network dependency, and manual DAG logic. The WorkTracker
+  interface was explicitly designed for alternative backends (the source
+  comment reads: "Designed so a future crumbs/trails implementation can
+  satisfy it.").
+
+  This SRD specifies a BeadsTracker struct that implements the WorkTracker
+  interface using the bd CLI, enabling the orchestrator to use beads as an
+  alternative to GitHub Issues without modifying any calling code.
+
+goals:
+  - G1: Define a BeadsTracker struct that implements the full WorkTracker interface using the bd CLI
+  - G2: Map every GitHubTracker gh CLI operation to an equivalent bd CLI operation
+  - G3: Eliminate YAML front-matter encoding of dependencies in favor of native bd dependency primitives
+  - G4: Eliminate DAG promotion logic in favor of native bd ready-state computation
+  - G5: Eliminate API polling and eventual-consistency workarounds
+  - G6: Add a configuration option to select between github and beads backends
+  - G7: Preserve backward compatibility — the github backend must remain the default and must continue to work unchanged
+
+# ---------------------------------------------------------------------------
+# ANALYSIS: How gh Is Used in GitHubTracker
+# ---------------------------------------------------------------------------
+#
+# This section documents every gh CLI invocation in the GitHubTracker
+# implementation (pkg/orchestrator/internal/github/issues.go) and the
+# corresponding bd equivalent. The analysis is grouped by functional
+# category and references the GitHubTracker method that contains each
+# invocation.
+#
+# ---------------------------------------------------------------------------
+# A1: Repo Detection
+# ---------------------------------------------------------------------------
+#
+# GitHubTracker.DetectGitHubRepo(repoRoot) resolves the GitHub owner/repo
+# string used in all subsequent gh commands. Resolution order:
+#   1. t.Cfg.IssuesRepo if set (explicit override)
+#   2. gh repo view --json nameWithOwner -q .nameWithOwner (reads git remote)
+#   3. Strip "github.com/" from t.Cfg.ModulePath
+#
+# gh invocation:
+#   exec.Command(t.GhBin, "repo", "view", "--json", "nameWithOwner",
+#                "-q", ".nameWithOwner")
+#
+# bd equivalent: Not needed. bd auto-discovers its database from
+# .beads/*.db in the repository root. No repo identifier is required.
+# BeadsTracker.DetectGitHubRepo returns a synthetic identifier (the bd
+# database path) to satisfy the interface contract.
+#
+# ---------------------------------------------------------------------------
+# A2: Label Management
+# ---------------------------------------------------------------------------
+#
+# A2.1: EnsureCobblerLabels(repo)
+#   Creates cobbler-ready, cobbler-in-progress, and cobbler-skipped labels
+#   on the GitHub repo if they do not exist.
+#   gh invocation (per label):
+#     exec.Command(t.GhBin, "api", "repos/"+repo+"/labels",
+#                  "--method", "POST",
+#                  "--field", "name="+l.name,
+#                  "--field", "color="+l.color,
+#                  "--field", "description="+l.desc)
+#   bd equivalent: No-op. Labels in bd are created implicitly on first use.
+#   There is no API to pre-create labels. BeadsTracker.EnsureCobblerLabels
+#   is a no-op that returns nil.
+#
+# A2.2: EnsureCobblerGenLabel(repo, generation)
+#   Creates a generation-scoped label (cobbler-gen-{generation}) on the
+#   GitHub repo. Idempotent; ignores 422 errors.
+#   gh invocation:
+#     exec.Command(t.GhBin, "api", "repos/"+repo+"/labels",
+#                  "--method", "POST",
+#                  "--field", "name="+label,
+#                  "--field", "color=ededed",
+#                  "--field", "description=Cobbler generation "+generation)
+#   bd equivalent: No-op. Same as A2.1.
+#
+# A2.3: ListRepoLabels(repo)
+#   Returns all label names on the repo.
+#   gh invocation:
+#     exec.Command(t.GhBin, "label", "list", "--repo", repo,
+#                  "--json", "name", "--limit", "100")
+#   bd equivalent:
+#     exec.Command("bd", "label", "list-all", "--json")
+#   Parses JSON output to extract label names.
+#
+# A2.4: AddIssueLabel(repo, number, label)
+#   Adds a label to a specific issue.
+#   gh invocation:
+#     exec.Command(t.GhBin, "issue", "edit", "--repo", repo,
+#                  fmt.Sprintf("%d", number), "--add-label", label)
+#   bd equivalent:
+#     exec.Command("bd", "label", "add", issueID, label)
+#   where issueID is the bd issue identifier (e.g., "bd-42").
+#
+# A2.5: RemoveIssueLabel(repo, number, label)
+#   Removes a label from a specific issue.
+#   gh invocation:
+#     exec.Command(t.GhBin, "issue", "edit", "--repo", repo,
+#                  fmt.Sprintf("%d", number), "--remove-label", label)
+#   bd equivalent:
+#     exec.Command("bd", "label", "remove", issueID, label)
+#
+# ---------------------------------------------------------------------------
+# A3: Issue CRUD
+# ---------------------------------------------------------------------------
+#
+# A3.1: CreateCobblerIssue(repo, generation, issue)
+#   Creates a GitHub issue with title, body (YAML front-matter + description),
+#   and generation label.
+#   gh invocation:
+#     exec.Command(t.GhBin, "issue", "create",
+#                  "--repo", repo,
+#                  "--title", title,
+#                  "--body", body,
+#                  "--label", genLabel)
+#   The body includes FormatIssueFrontMatter which encodes cobbler_generation,
+#   cobbler_index, and cobbler_depends_on in YAML front-matter. The title is
+#   prefixed with "[measure] ".
+#   bd equivalent:
+#     exec.Command("bd", "create",
+#                  "--title", title,
+#                  "--description", issue.Description,
+#                  "--labels", genLabel,
+#                  "--metadata", metadataJSON,
+#                  "--silent")
+#   where metadataJSON is a JSON string encoding cobbler_generation,
+#   cobbler_index. Dependencies are created separately via bd dep add
+#   instead of embedding cobbler_depends_on in body text.
+#   The --silent flag outputs only the issue ID (e.g., "bd-a3f8e9").
+#
+# A3.2: CreateMeasuringPlaceholder(repo, generation, iteration)
+#   Creates a transient placeholder issue while measure is calling Claude.
+#   No cobbler labels are applied. Stitch ignores it.
+#   gh invocation:
+#     exec.Command(t.GhBin, "issue", "create",
+#                  "--repo", repo,
+#                  "--title", title,
+#                  "--body", body)
+#   bd equivalent:
+#     exec.Command("bd", "create",
+#                  "--title", title,
+#                  "--description", body,
+#                  "--ephemeral",
+#                  "--silent")
+#   The --ephemeral flag marks it as a short-lived issue subject to
+#   compaction, which is semantically correct for placeholders.
+#
+# A3.3: CloseMeasuringPlaceholder(repo, number)
+#   Closes the placeholder issue.
+#   gh invocation:
+#     exec.Command(t.GhBin, "issue", "close",
+#                  "--repo", repo,
+#                  fmt.Sprintf("%d", number))
+#   bd equivalent:
+#     exec.Command("bd", "close", issueID)
+#
+# A3.4: CloseMeasuringPlaceholderWithComment(repo, number, comment)
+#   Adds a comment then closes the placeholder.
+#   gh invocations:
+#     exec.Command(t.GhBin, "issue", "comment", "--repo", repo,
+#                  fmt.Sprintf("%d", number), "--body", comment)
+#     then CloseMeasuringPlaceholder (A3.3)
+#   bd equivalent:
+#     exec.Command("bd", "comment", issueID, comment)
+#     exec.Command("bd", "close", issueID)
+#
+# A3.5: FinalizeMeasurePlaceholder(repo, number, generation, comment, childIssues)
+#   Converts the measuring placeholder into a permanent [measure] issue:
+#   renames it, adds generation label, links child issues, comments, closes.
+#   gh invocations:
+#     exec.Command(t.GhBin, "issue", "edit", ..., "--title", title) — rename
+#     AddIssueLabel(repo, number, genLabel)                          — add gen label
+#     LinkSubIssue(repo, parentNumber, number)                       — link to parent
+#     For each child: LinkSubIssue(repo, number, child)              — link children
+#     exec.Command(t.GhBin, "issue", "comment", ..., "--body", comment) — comment
+#     CloseMeasuringPlaceholder(repo, number)                        — close
+#   bd equivalent:
+#     exec.Command("bd", "update", issueID,
+#                  "--title", title,
+#                  "--add-label", genLabel,
+#                  "--persistent")
+#     For each child: exec.Command("bd", "update", childID, "--parent", issueID)
+#     exec.Command("bd", "comment", issueID, comment)
+#     exec.Command("bd", "close", issueID)
+#   The --persistent flag promotes the ephemeral placeholder to a permanent
+#   issue. Parent-child linking uses bd's native --parent flag instead of the
+#   GitHub sub_issues API.
+#
+# A3.6: CloseCobblerIssue(repo, number, generation)
+#   Removes in-progress label, closes the issue, re-runs DAG promotion.
+#   gh invocations:
+#     RemoveIssueLabel(repo, number, LabelInProgress)
+#     exec.Command(t.GhBin, "issue", "close",
+#                  "--repo", repo,
+#                  fmt.Sprintf("%d", number))
+#     PromoteReadyIssues(repo, generation)
+#   bd equivalent:
+#     exec.Command("bd", "update", issueID,
+#                  "--remove-label", LabelInProgress)
+#     exec.Command("bd", "close", issueID)
+#   DAG promotion (PromoteReadyIssues) is not needed because bd natively
+#   computes ready state from dependency resolution.
+#
+# A3.7: EditIssueTitle(repo, number, title)
+#   Updates the title of a GitHub issue.
+#   gh invocation:
+#     exec.Command(t.GhBin, "issue", "edit",
+#                  "--repo", repo,
+#                  fmt.Sprintf("%d", number), "--title", title)
+#   bd equivalent:
+#     exec.Command("bd", "update", issueID, "--title", title)
+#
+# A3.8: CommentCobblerIssue(repo, number, body)
+#   Posts a comment on a GitHub issue. Best-effort; errors are logged.
+#   gh invocation:
+#     exec.Command(t.GhBin, "issue", "comment",
+#                  fmt.Sprintf("%d", number),
+#                  "--repo", repo,
+#                  "--body", body)
+#   bd equivalent:
+#     exec.Command("bd", "comment", issueID, body)
+#
+# A3.9: CloseGenerationIssues(repo, generation)
+#   Closes all open issues scoped to a generation. Used during reset or
+#   cleanup.
+#   gh invocations:
+#     ListOpenCobblerIssues(repo, generation) to get all open issues
+#     For each: exec.Command(t.GhBin, "issue", "close",
+#                            "--repo", repo,
+#                            fmt.Sprintf("%d", iss.Number))
+#   bd equivalent:
+#     List issues: exec.Command("bd", "list",
+#                               "--status", "open",
+#                               "--label", genLabel,
+#                               "--json")
+#     For each: exec.Command("bd", "close", issueID)
+#
+# A3.10: FileTargetRepoDefects(repo, defects)
+#   Files each defect as a bug issue in the target repo. Best-effort.
+#   gh invocation (per defect):
+#     exec.Command(t.GhBin, "issue", "create",
+#                  "--repo", repo,
+#                  "--title", title,
+#                  "--body", body,
+#                  "--label", "bug")
+#   bd equivalent:
+#     exec.Command("bd", "create",
+#                  "--title", title,
+#                  "--description", body,
+#                  "--labels", "bug",
+#                  "--type", "bug",
+#                  "--silent")
+#
+# ---------------------------------------------------------------------------
+# A4: Issue Queries
+# ---------------------------------------------------------------------------
+#
+# A4.1: ListOpenCobblerIssues(repo, generation)
+#   Returns all open issues for a generation. Uses the REST API endpoint
+#   (gh api repos/.../issues) instead of gh issue list because the search
+#   API is eventually consistent.
+#   gh invocation:
+#     exec.Command(t.GhBin, "api",
+#                  "--method", "GET",
+#                  fmt.Sprintf("repos/%s/issues", repo),
+#                  "-f", "state=open",
+#                  "-f", "labels="+label,
+#                  "-f", "per_page=100")
+#   Response is JSON parsed by ParseCobblerIssuesJSON which extracts
+#   Number, Title, State, Body (parsed for YAML front-matter), and Labels.
+#   bd equivalent:
+#     exec.Command("bd", "list",
+#                  "--status", "open",
+#                  "--label", genLabel,
+#                  "--limit", "0",
+#                  "--json")
+#   bd's writes are immediately visible (SQLite transactions), so no
+#   eventual-consistency workaround is needed.
+#
+# A4.2: ListAllCobblerIssues(repo, generation)
+#   Returns all issues (open + closed) for a generation. Used by stats.
+#   gh invocation:
+#     exec.Command(t.GhBin, "api",
+#                  "--method", "GET",
+#                  "--paginate",
+#                  fmt.Sprintf("repos/%s/issues", repo),
+#                  "-f", "state=all",
+#                  "-f", "labels="+label,
+#                  "-f", "per_page=100")
+#   bd equivalent:
+#     exec.Command("bd", "list",
+#                  "--all",
+#                  "--label", genLabel,
+#                  "--limit", "0",
+#                  "--json")
+#
+# A4.3: FetchIssueComments(repo, number)
+#   Returns the body text of all comments on a given issue.
+#   gh invocation:
+#     exec.Command(t.GhBin, "api",
+#                  fmt.Sprintf("repos/%s/issues/%d/comments", repo, number))
+#   bd equivalent:
+#     exec.Command("bd", "comments", "list", issueID, "--json")
+#
+# A4.4: ListActiveIssuesContext(repo, generation)
+#   Returns a JSON array of ContextIssue objects for all open issues in the
+#   generation, injected into the measure prompt so Claude sees existing work.
+#   Internally calls ListOpenCobblerIssues then IssuesContextJSON.
+#   bd equivalent: Same as A4.1, followed by the same IssuesContextJSON
+#   transformation applied to the parsed results.
+#
+# A4.5: GcStaleGenerationIssues(repo, generationPrefix)
+#   Fetches all open issues, filters locally for cobbler-gen-* labels,
+#   groups by generation, and closes issues whose generation branch no
+#   longer exists.
+#   gh invocation:
+#     exec.Command(t.GhBin, "api",
+#                  fmt.Sprintf("repos/%s/issues", repo),
+#                  "--method", "GET",
+#                  "-f", "state=open",
+#                  "-f", "per_page=100")
+#   bd equivalent:
+#     exec.Command("bd", "list",
+#                  "--status", "open",
+#                  "--label-pattern", "cobbler-gen-*",
+#                  "--limit", "0",
+#                  "--json")
+#   The --label-pattern flag supports glob matching, eliminating the need
+#   for local filtering.
+#
+# ---------------------------------------------------------------------------
+# A5: DAG / Dependency Management
+# ---------------------------------------------------------------------------
+#
+# A5.1: PromoteReadyIssues(repo, generation)
+#   Builds a DAG from open issues by reading cobbler_depends_on from YAML
+#   front-matter. Issues whose dependency is still open have cobbler-ready
+#   removed. Issues whose dependency is closed (or has no dependency) get
+#   cobbler-ready added.
+#   gh invocations: ListOpenCobblerIssues then for each issue:
+#     AddIssueLabel or RemoveIssueLabel (cobbler-ready)
+#   bd equivalent: Not needed. bd natively tracks dependencies and
+#   computes ready state. The bd ready command returns only unblocked
+#   issues. BeadsTracker.PromoteReadyIssues is a no-op returning nil.
+#
+# A5.2: PickReadyIssue(repo, generation)
+#   Calls PromoteReadyIssues, lists open issues, filters for cobbler-ready
+#   (excluding cobbler-in-progress and cobbler-skipped), sorts by number
+#   ascending, picks the first, adds cobbler-in-progress, removes
+#   cobbler-ready, renames [measure] to [stitch].
+#   gh invocations:
+#     PromoteReadyIssues (multiple API calls)
+#     ListOpenCobblerIssues
+#     AddIssueLabel(repo, picked.Number, LabelInProgress)
+#     RemoveIssueLabel(repo, picked.Number, LabelReady)
+#     EditIssueTitle(repo, picked.Number, newTitle)
+#   bd equivalent:
+#     exec.Command("bd", "list",
+#                  "--ready",
+#                  "--status", "open",
+#                  "--label", genLabel,
+#                  "--exclude-label", LabelSkipped,
+#                  "--sort", "id",
+#                  "--limit", "1",
+#                  "--json")
+#   Then claim the picked issue:
+#     exec.Command("bd", "update", issueID, "--claim",
+#                  "--add-label", LabelInProgress)
+#   And rename:
+#     exec.Command("bd", "update", issueID, "--title", newTitle)
+#   The --ready flag uses bd's native dependency resolution. The --claim
+#   flag atomically sets assignee and status to in_progress.
+#
+# ---------------------------------------------------------------------------
+# A6: WaitForIssuesVisible
+# ---------------------------------------------------------------------------
+#
+# A6.1: WaitForIssuesVisible(repo, generation, expected)
+#   Polls ListOpenCobblerIssues up to 15 seconds until at least expected
+#   issues appear. Needed because the GitHub REST API label index lags.
+#   bd equivalent: Not needed. bd uses SQLite transactions; writes are
+#   immediately visible. BeadsTracker.WaitForIssuesVisible is a no-op.
+#
+# ---------------------------------------------------------------------------
+# A7: Generic Escape Hatch
+# ---------------------------------------------------------------------------
+#
+# A7.1: GhExec(repoRoot, args...)
+#   Runs an arbitrary gh subcommand. Used as a generic escape hatch.
+#   bd equivalent:
+#     exec.Command("bd", args...)
+#   with cmd.Dir set to repoRoot.
+#
+# ---------------------------------------------------------------------------
+# A8: Sub-Issue Linking
+# ---------------------------------------------------------------------------
+#
+# A8.1: LinkSubIssue(repo, parentNumber, childNumber)
+#   Fetches the child issue's database ID (distinct from display number)
+#   via gh api, then POSTs to the parent's sub_issues endpoint.
+#   gh invocations:
+#     exec.Command(t.GhBin, "api",
+#                  fmt.Sprintf("repos/%s/issues/%d", repo, childNumber),
+#                  "--jq", ".id")
+#     exec.Command(t.GhBin, "api",
+#                  fmt.Sprintf("repos/%s/issues/%d/sub_issues", repo, parentNumber),
+#                  "--method", "POST",
+#                  "--field", fmt.Sprintf("sub_issue_id=%d", dbID))
+#   bd equivalent:
+#     exec.Command("bd", "update", childID, "--parent", parentID)
+#   bd has native parent-child hierarchy. A single command replaces two
+#   API calls.
+#
+# ---------------------------------------------------------------------------
+# A9: Defect Routing
+# ---------------------------------------------------------------------------
+#
+# A9.1: ResolveTargetRepo()
+#   Returns the GitHub owner/repo for the project being developed.
+#   Checks t.Cfg.TargetRepo, then strips "github.com/" from ModulePath.
+#   bd equivalent: Returns the bd database path or a configured
+#   identifier. When beads is the backend, defects are filed in the
+#   same local database with a "bug" type and "defect" label.
+#
+
+requirements:
+  R1:
+    title: Configuration and Backend Selection
+    items:
+      - "R1.1: CobblerConfig must include a Tracker field (string, default \"github\") with two valid values: \"github\" (use GitHubTracker, current behavior) and \"beads\" (use BeadsTracker)"
+      - "R1.2: CobblerConfig must include a BeadsBin field (string, default \"bd\") specifying the path to the bd binary"
+      - "R1.3: The Orchestrator constructor (New) must read Tracker from Config and instantiate either GitHubTracker or BeadsTracker accordingly"
+      - "R1.4: When Tracker is \"github\" or empty, the orchestrator must behave identically to the current implementation; no existing tests may fail"
+      - "R1.5: When Tracker is \"beads\", the orchestrator must instantiate a BeadsTracker and pass it as the WorkTracker dependency"
+      - "R1.6: applyDefaults must set Tracker to \"github\" when empty"
+      - "R1.7: applyDefaults must set BeadsBin to \"bd\" when empty"
+      - "R1.8: The configuration.yaml schema must document the tracker and beads_bin fields under the cobbler section"
+
+  R2:
+    title: BeadsTracker Struct and Construction
+    items:
+      - "R2.1: BeadsTracker must be defined in a new package pkg/orchestrator/internal/beads/"
+      - "R2.2: BeadsTracker must implement the full WorkTracker interface defined in pkg/orchestrator/internal/github/issues.go"
+      - "R2.3: BeadsTracker must hold a Log field (Logger function) for diagnostic output"
+      - "R2.4: BeadsTracker must hold a BdBin field (string) for the bd binary path"
+      - "R2.5: BeadsTracker must hold a BranchExists field (BranchChecker function) for verifying git branch existence during GC"
+      - "R2.6: BeadsTracker must hold a Cfg field (RepoConfig) for issues_repo, module_path, and target_repo overrides"
+      - "R2.7: NewBeadsTracker must accept Deps and RepoConfig (same types as NewGitHubTracker) and return a *BeadsTracker"
+      - "R2.8: BeadsTracker must define a helper method bdExec(args ...string) (string, error) that runs the bd binary with the given arguments and returns trimmed stdout; the method must set cmd.Dir to the repository root when available"
+
+  R3:
+    title: "BeadsTracker.DetectGitHubRepo — Repo Detection"
+    items:
+      - "R3.1: DetectGitHubRepo must return Cfg.IssuesRepo if it is non-empty (explicit override, same behavior as GitHubTracker)"
+      - "R3.2: When Cfg.IssuesRepo is empty, DetectGitHubRepo must run bd info --json and extract the database path as the repo identifier"
+      - "R3.3: If bd info fails, DetectGitHubRepo must fall back to the module path (stripping \"github.com/\" prefix) to maintain compatibility with callers that display the repo identifier in log messages"
+      - "R3.4: DetectGitHubRepo must never return an empty string; if all resolution methods fail, it must return an error"
+
+  R4:
+    title: "BeadsTracker Label Management — EnsureCobblerLabels, EnsureCobblerGenLabel, ListRepoLabels, AddIssueLabel, RemoveIssueLabel"
+    items:
+      - "R4.1: EnsureCobblerLabels must be a no-op that returns nil; bd creates labels implicitly on first use and does not require pre-creation"
+      - "R4.2: EnsureCobblerGenLabel must be a no-op that returns nil; same rationale as R4.1"
+      - "R4.3: ListRepoLabels must run bd label list-all --json and parse the JSON output to return a []string of label names"
+      - "R4.4: AddIssueLabel must run bd label add {issueID} {label} to add a label to the specified issue"
+      - "R4.5: AddIssueLabel must convert the GitHub issue number (int) to a bd issue ID string using the ID mapping maintained by BeadsTracker (see R6)"
+      - "R4.6: RemoveIssueLabel must run bd label remove {issueID} {label} to remove a label from the specified issue"
+      - "R4.7: RemoveIssueLabel must not fail if the label does not exist on the issue; errors from bd label remove for missing labels must be logged and swallowed"
+
+  R5:
+    title: "BeadsTracker Issue ID Mapping"
+    items:
+      - "R5.1: GitHub Issues are identified by sequential integers (e.g., 42). Beads issues are identified by prefixed hex strings (e.g., bd-a3f8e9). The BeadsTracker must maintain a bidirectional mapping between the integer namespace used by callers (via WorkTracker) and the string namespace used by bd."
+      - "R5.2: BeadsTracker must store cobbler_index as a metadata field on each bd issue using --metadata or --set-metadata"
+      - "R5.3: When creating an issue, BeadsTracker must parse the bd-issued ID from the --silent output and record it in an in-memory map keyed by a synthetic integer (the cobbler_index)"
+      - "R5.4: When looking up an issue by number, BeadsTracker must first check the in-memory map; if the number is not found, it must query bd show {number} --json to resolve the ID"
+      - "R5.5: The synthetic integer used as the GitHub-compatible issue number must be derived from the cobbler_index field in the issue metadata; if cobbler_index is not set, the BeadsTracker must generate a monotonically increasing integer within the generation"
+      - "R5.6: The in-memory map must be populated lazily from ListOpenCobblerIssues and ListAllCobblerIssues responses"
+      - "R5.7: BeadsTracker must store the GitHub-compatible number in bd metadata as cobbler_number so that it survives process restarts and can be recovered by querying bd list --json"
+
+  R6:
+    title: "BeadsTracker.CreateCobblerIssue — Issue Creation"
+    items:
+      - "R6.1: CreateCobblerIssue must run bd create with --title, --description, --labels, --metadata, and --silent flags"
+      - "R6.2: The title must be prefixed with \"[measure] \" after normalizing, matching GitHubTracker behavior"
+      - "R6.3: The generation must be stored as a label using the GenLabel function (cobbler-gen-{generation}), same as GitHubTracker"
+      - "R6.4: cobbler_generation and cobbler_index must be stored as bd metadata fields (--set-metadata cobbler_generation={generation} --set-metadata cobbler_index={index}) instead of YAML front-matter in the body"
+      - "R6.5: cobbler_depends_on must NOT be stored in the body or metadata; instead, when issue.Dependency >= 0, BeadsTracker must run bd dep add {newIssueID} {dependencyIssueID} to create a native blocking dependency"
+      - "R6.6: The issue description must be passed as the raw description text from ProposedIssue.Description without any front-matter wrapper"
+      - "R6.7: CreateCobblerIssue must parse the issue ID from the --silent output of bd create"
+      - "R6.8: CreateCobblerIssue must record the mapping from cobbler_index to bd issue ID in the in-memory map (R5.3)"
+      - "R6.9: CreateCobblerIssue must return the cobbler_index as the GitHub-compatible integer, matching the return type (int, error) of the WorkTracker interface"
+      - "R6.10: When the dependency index refers to an issue from the same measure batch, BeadsTracker must resolve it through the in-memory map populated during earlier iterations of the same importIssues call"
+
+  R7:
+    title: "BeadsTracker.CreateMeasuringPlaceholder — Placeholder Issue Creation"
+    items:
+      - "R7.1: CreateMeasuringPlaceholder must run bd create with --title, --description, --ephemeral, and --silent flags"
+      - "R7.2: The --ephemeral flag marks the issue as short-lived and subject to TTL compaction, matching the transient nature of measuring placeholders"
+      - "R7.3: No cobbler labels must be applied to the placeholder (matching GitHubTracker behavior where stitch ignores issues without a gen label)"
+      - "R7.4: The placeholder must store a cobbler_number in metadata for the ID mapping"
+      - "R7.5: CreateMeasuringPlaceholder must return (number, nil) where number is the cobbler_number assigned to the placeholder"
+
+  R8:
+    title: "BeadsTracker.CloseMeasuringPlaceholder and CloseMeasuringPlaceholderWithComment"
+    items:
+      - "R8.1: CloseMeasuringPlaceholder must run bd close {issueID} to close the placeholder issue"
+      - "R8.2: CloseMeasuringPlaceholder must be best-effort; errors are logged via t.Log and not returned"
+      - "R8.3: CloseMeasuringPlaceholderWithComment must run bd comment {issueID} {comment} followed by bd close {issueID}"
+      - "R8.4: Both methods must resolve the bd issue ID from the integer number via the ID mapping (R5)"
+
+  R9:
+    title: "BeadsTracker.FinalizeMeasurePlaceholder — Placeholder Promotion"
+    items:
+      - "R9.1: FinalizeMeasurePlaceholder must rename the placeholder issue via bd update {issueID} --title {newTitle}"
+      - "R9.2: FinalizeMeasurePlaceholder must add the generation label via bd label add {issueID} {genLabel}"
+      - "R9.3: FinalizeMeasurePlaceholder must promote the ephemeral placeholder to a permanent issue via bd update {issueID} --persistent"
+      - "R9.4: For each child issue number in childIssues, FinalizeMeasurePlaceholder must set the parent via bd update {childID} --parent {issueID}"
+      - "R9.5: If a parent generation issue number is extractable from the generation name (ExtractParentIssueNumber), FinalizeMeasurePlaceholder must set the measure issue's parent to that generation issue via bd update {issueID} --parent {parentID}"
+      - "R9.6: FinalizeMeasurePlaceholder must post the summary comment via bd comment {issueID} {comment}"
+      - "R9.7: FinalizeMeasurePlaceholder must close the issue via bd close {issueID}"
+      - "R9.8: All operations in FinalizeMeasurePlaceholder are best-effort; errors are logged and do not fail the caller"
+
+  R10:
+    title: "BeadsTracker.CloseCobblerIssue — Issue Closing"
+    items:
+      - "R10.1: CloseCobblerIssue must remove the cobbler-in-progress label via bd label remove {issueID} {LabelInProgress}"
+      - "R10.2: CloseCobblerIssue must close the issue via bd close {issueID}"
+      - "R10.3: CloseCobblerIssue must NOT call PromoteReadyIssues afterward; bd natively recomputes ready state when a blocking issue is closed"
+      - "R10.4: If bd close fails, CloseCobblerIssue must return the error"
+
+  R11:
+    title: "BeadsTracker.EditIssueTitle — Title Editing"
+    items:
+      - "R11.1: EditIssueTitle must run bd update {issueID} --title {title}"
+      - "R11.2: EditIssueTitle must resolve the bd issue ID from the integer number via the ID mapping (R5)"
+
+  R12:
+    title: "BeadsTracker.CommentCobblerIssue — Commenting"
+    items:
+      - "R12.1: CommentCobblerIssue must run bd comment {issueID} {body}"
+      - "R12.2: CommentCobblerIssue must be best-effort; errors are logged via t.Log and the method returns without error"
+      - "R12.3: CommentCobblerIssue must be a no-op when the issue ID is empty or the number is <= 0"
+
+  R13:
+    title: "BeadsTracker.CloseGenerationIssues — Bulk Close"
+    items:
+      - "R13.1: CloseGenerationIssues must list all open issues for the generation via bd list --status open --label {genLabel} --limit 0 --json"
+      - "R13.2: For each open issue returned, CloseGenerationIssues must run bd close {issueID}"
+      - "R13.3: CloseGenerationIssues must return nil when generation is empty (matching GitHubTracker behavior)"
+      - "R13.4: Individual close failures must be logged but must not stop the iteration over remaining issues"
+
+  R14:
+    title: "BeadsTracker.ListOpenCobblerIssues — Open Issue Query"
+    items:
+      - "R14.1: ListOpenCobblerIssues must run bd list --status open --label {genLabel} --limit 0 --json"
+      - "R14.2: ListOpenCobblerIssues must parse the JSON output into []CobblerIssue structs"
+      - "R14.3: For each issue in the JSON response, ListOpenCobblerIssues must populate Number (from cobbler_number metadata), Title, State, Index (from cobbler_index metadata), DependsOn (from bd dep list {issueID} --json), Generation (from cobbler_generation metadata), Description, and Labels"
+      - "R14.4: ListOpenCobblerIssues must populate the in-memory ID mapping (R5.6) as a side effect"
+      - "R14.5: The DependsOn field must be derived from the bd dependency graph; if the issue has a blocking dependency, DependsOn must be set to the cobbler_index of the blocker; if no dependency exists, DependsOn must be -1"
+
+  R15:
+    title: "BeadsTracker.ListAllCobblerIssues — All Issues Query"
+    items:
+      - "R15.1: ListAllCobblerIssues must run bd list --all --label {genLabel} --limit 0 --json"
+      - "R15.2: ListAllCobblerIssues must parse the JSON output identically to ListOpenCobblerIssues (R14.2-R14.5)"
+      - "R15.3: ListAllCobblerIssues must include both open and closed issues in the response"
+
+  R16:
+    title: "BeadsTracker.FetchIssueComments — Comment Retrieval"
+    items:
+      - "R16.1: FetchIssueComments must run bd comments list {issueID} --json"
+      - "R16.2: FetchIssueComments must parse the JSON output and return a []string of comment body texts"
+      - "R16.3: If the bd command fails, FetchIssueComments must return (nil, error)"
+
+  R17:
+    title: "BeadsTracker.ListActiveIssuesContext — Measure Prompt Context"
+    items:
+      - "R17.1: ListActiveIssuesContext must call ListOpenCobblerIssues to get open issues for the generation"
+      - "R17.2: ListActiveIssuesContext must sort issues by cobbler_index ascending"
+      - "R17.3: ListActiveIssuesContext must call IssuesContextJSON (the existing pure function) to produce the JSON string"
+      - "R17.4: ListActiveIssuesContext must return (\"\", nil) when no open issues exist"
+
+  R18:
+    title: "BeadsTracker.WaitForIssuesVisible — Consistency Wait"
+    items:
+      - "R18.1: WaitForIssuesVisible must be a no-op; bd uses SQLite transactions and writes are immediately visible to subsequent reads"
+      - "R18.2: WaitForIssuesVisible must log that the wait was skipped (for diagnostic visibility)"
+
+  R19:
+    title: "BeadsTracker.PromoteReadyIssues — DAG Promotion"
+    items:
+      - "R19.1: PromoteReadyIssues must be a no-op that returns nil; bd natively computes ready state from its dependency graph"
+      - "R19.2: PromoteReadyIssues must log that promotion was skipped because bd handles it natively (for diagnostic visibility)"
+
+  R20:
+    title: "BeadsTracker.PickReadyIssue — Task Selection"
+    items:
+      - "R20.1: PickReadyIssue must query for ready issues via bd list --ready --status open --label {genLabel} --exclude-label {LabelSkipped} --sort id --limit 1 --json"
+      - "R20.2: The --ready flag delegates dependency resolution to bd; no manual DAG traversal is required"
+      - "R20.3: If no ready issues are returned, PickReadyIssue must return (CobblerIssue{}, error) with an error message matching the format used by GitHubTracker"
+      - "R20.4: PickReadyIssue must claim the picked issue by running bd update {issueID} --claim --add-label {LabelInProgress}"
+      - "R20.5: PickReadyIssue must remove the cobbler-ready label (if present) via bd label remove {issueID} {LabelReady}; errors are logged but do not fail the method"
+      - "R20.6: If the picked issue title starts with \"[measure] \", PickReadyIssue must rename it to \"[stitch] \" via bd update {issueID} --title {newTitle}"
+      - "R20.7: PickReadyIssue must return the CobblerIssue with all fields populated from the bd JSON output and metadata"
+
+  R21:
+    title: "BeadsTracker.GcStaleGenerationIssues — Garbage Collection"
+    items:
+      - "R21.1: GcStaleGenerationIssues must list all open issues with a cobbler-gen-* label via bd list --status open --label-pattern cobbler-gen-* --limit 0 --json"
+      - "R21.2: For each issue, GcStaleGenerationIssues must read the cobbler_generation metadata field to determine which generation the issue belongs to"
+      - "R21.3: GcStaleGenerationIssues must group issues by generation name and check whether each generation's branch exists locally via the BranchExists function"
+      - "R21.4: For generations whose branch no longer exists, all open issues must be closed via bd close {issueID}"
+      - "R21.5: Individual close failures must be logged but must not stop the iteration"
+
+  R22:
+    title: "BeadsTracker.LinkSubIssue — Parent-Child Linking"
+    items:
+      - "R22.1: LinkSubIssue must run bd update {childID} --parent {parentID} to set the parent-child relationship"
+      - "R22.2: LinkSubIssue must resolve both parentNumber and childNumber to bd issue IDs via the ID mapping (R5)"
+      - "R22.3: LinkSubIssue must return an error if either issue ID cannot be resolved"
+
+  R23:
+    title: "BeadsTracker.FileTargetRepoDefects — Defect Filing"
+    items:
+      - "R23.1: FileTargetRepoDefects must be a no-op with a log warning when repo is empty (matching GitHubTracker behavior)"
+      - "R23.2: For each defect string, FileTargetRepoDefects must run bd create --title {title} --description {body} --labels bug,defect --type bug --silent"
+      - "R23.3: The title must be truncated to ~70 characters (matching GitHubTracker behavior)"
+      - "R23.4: Filing is best-effort; errors from bd create are logged and do not stop iteration"
+
+  R24:
+    title: "BeadsTracker.ResolveTargetRepo — Target Repo Resolution"
+    items:
+      - "R24.1: ResolveTargetRepo must return Cfg.TargetRepo if non-empty"
+      - "R24.2: If Cfg.TargetRepo is empty and Cfg.ModulePath starts with \"github.com/\", ResolveTargetRepo must strip the prefix and return the remainder"
+      - "R24.3: If neither yields a non-empty value, ResolveTargetRepo must return an empty string"
+      - "R24.4: The behavior must be identical to GitHubTracker.ResolveTargetRepo"
+
+  R25:
+    title: "BeadsTracker.GhExec — Generic Command Execution"
+    items:
+      - "R25.1: GhExec must run bd with the given arguments via exec.Command(t.BdBin, args...)"
+      - "R25.2: GhExec must set cmd.Dir to repoRoot"
+      - "R25.3: GhExec must return trimmed stdout and any error"
+
+  R26:
+    title: "Dependency Creation During Import"
+    items:
+      - "R26.1: When CreateCobblerIssue is called with an issue whose Dependency field is >= 0, BeadsTracker must create a blocking dependency via bd dep add {newIssueID} {blockerIssueID}"
+      - "R26.2: The blocker issue ID must be resolved from the cobbler_index-to-bdID mapping populated during earlier iterations of the same import batch"
+      - "R26.3: If the blocker issue ID cannot be resolved (e.g., the dependency refers to an issue from a prior generation), BeadsTracker must log a warning and skip the dependency creation"
+      - "R26.4: Dependencies must use the \"blocks\" type (bd's default), meaning the blocker must be closed before the dependent issue becomes ready"
+
+  R27:
+    title: "JSON Output Parsing"
+    items:
+      - "R27.1: BeadsTracker must define a bdIssueJSON struct that matches the JSON schema produced by bd list --json and bd show --json"
+      - "R27.2: bdIssueJSON must include at minimum: id (string), title (string), status (string), description (string), labels ([]string), metadata (map[string]interface{}), and created_at (string)"
+      - "R27.3: parseBdIssues must convert []bdIssueJSON into []CobblerIssue by extracting cobbler_number, cobbler_index, cobbler_generation, and cobbler_depends_on from the metadata map"
+      - "R27.4: The Number field in CobblerIssue must be populated from metadata.cobbler_number (int)"
+      - "R27.5: The State field must be mapped from bd status values: \"open\" and \"in_progress\" map to \"open\"; \"closed\" maps to \"closed\""
+      - "R27.6: The DependsOn field must be populated from the dependency graph; BeadsTracker must call bd dep list {issueID} --json if dependency information is not included in the bd list output"
+      - "R27.7: parseBdIssues must be tolerant of missing metadata fields; missing cobbler_number defaults to 0, missing cobbler_index defaults to 0, missing cobbler_generation defaults to \"\", missing cobbler_depends_on defaults to -1"
+
+  R28:
+    title: "Pure Function Reuse"
+    items:
+      - "R28.1: BeadsTracker must reuse the following pure functions from the github package without modification: GenLabel, NormalizeIssueTitle, ExtractDescriptionFiles, HasLabel, IssuesContextJSON, ExtractParentIssueNumber, ParseIssueFrontMatter (for backward compatibility with issues that may have been created by GitHubTracker before a backend switch)"
+      - "R28.2: The github package must export these functions (they are already exported)"
+      - "R28.3: BeadsTracker must import the github package for these functions; no code duplication"
+
+  R29:
+    title: "Error Handling and Logging"
+    items:
+      - "R29.1: All bd CLI invocations must capture stderr via cmd.CombinedOutput() or by reading exec.ExitError.Stderr"
+      - "R29.2: When a bd command fails, the error message logged must include the command arguments and stderr output for debugging"
+      - "R29.3: Best-effort operations (commenting, label manipulation, placeholder closing) must log errors and continue; they must not return errors to the caller"
+      - "R29.4: Critical operations (issue creation, issue listing, PickReadyIssue) must return errors to the caller"
+      - "R29.5: All log messages must include a \"beads:\" prefix to distinguish them from GitHubTracker log messages"
+
+  R30:
+    title: "bd Binary Verification"
+    items:
+      - "R30.1: When the orchestrator instantiates BeadsTracker, it must verify that the bd binary is available on PATH (or at the configured BdBin path) by running bd --version"
+      - "R30.2: If bd is not available, the constructor must return an error with a clear message: \"bd binary not found at {path}; install beads or set cobbler.beads_bin in configuration.yaml\""
+      - "R30.3: The bd version output must be logged at debug level for diagnostic purposes"
+
+  R31:
+    title: "bd Database Initialization"
+    items:
+      - "R31.1: When DetectGitHubRepo is called and no .beads/ directory exists in the repository root, BeadsTracker must run bd init to initialize the database"
+      - "R31.2: bd init must be run at most once per orchestrator lifetime; subsequent calls to DetectGitHubRepo must not re-initialize"
+      - "R31.3: If bd init fails, DetectGitHubRepo must return an error"
+
+non_goals:
+  - This SRD does not define migration tooling from GitHub Issues to beads; issues created by GitHubTracker remain in GitHub
+  - This SRD does not define simultaneous dual-backend operation; only one backend is active per orchestrator instance
+  - This SRD does not modify any GitHubTracker behavior or code
+  - This SRD does not define bd database schema, compaction, or TTL policies; those are governed by bd's own configuration
+  - This SRD does not define the prompt content or Claude behavior expectations
+  - This SRD does not define the generation lifecycle (see srd002)
+  - This SRD does not define the measure/stitch workflow logic (see srd003); it only defines the WorkTracker implementation they depend on
+  - This SRD does not define concurrent backend access; the orchestrator is single-threaded with respect to issue operations
+
+acceptance_criteria:
+  - id: AC1
+    criterion: Backend selection from configuration.yaml routes to the correct WorkTracker implementation
+    traces:
+      - R1.1
+      - R1.2
+      - R1.3
+      - R1.4
+      - R1.5
+      - R1.6
+      - R1.7
+      - R1.8
+
+  - id: AC2
+    criterion: BeadsTracker struct is constructable and satisfies the WorkTracker interface at compile time
+    traces:
+      - R2.1
+      - R2.2
+      - R2.3
+      - R2.4
+      - R2.5
+      - R2.6
+      - R2.7
+      - R2.8
+
+  - id: AC3
+    criterion: Repo detection works without a GitHub remote and initializes the bd database when absent
+    traces:
+      - R3.1
+      - R3.2
+      - R3.3
+      - R3.4
+      - R31.1
+      - R31.2
+      - R31.3
+
+  - id: AC4
+    criterion: Label operations are no-ops for creation and functional for add/remove/list
+    traces:
+      - R4.1
+      - R4.2
+      - R4.3
+      - R4.4
+      - R4.5
+      - R4.6
+      - R4.7
+
+  - id: AC5
+    criterion: Issue ID mapping correctly translates between integer and bd ID namespaces across creation, query, and close operations
+    traces:
+      - R5.1
+      - R5.2
+      - R5.3
+      - R5.4
+      - R5.5
+      - R5.6
+      - R5.7
+
+  - id: AC6
+    criterion: CreateCobblerIssue creates a bd issue with correct metadata, labels, and native dependencies instead of YAML front-matter
+    traces:
+      - R6.1
+      - R6.2
+      - R6.3
+      - R6.4
+      - R6.5
+      - R6.6
+      - R6.7
+      - R6.8
+      - R6.9
+      - R6.10
+
+  - id: AC7
+    criterion: Placeholder lifecycle (create, finalize, close) works with ephemeral issues and promotion
+    traces:
+      - R7.1
+      - R7.2
+      - R7.3
+      - R7.4
+      - R7.5
+      - R8.1
+      - R8.2
+      - R8.3
+      - R8.4
+      - R9.1
+      - R9.2
+      - R9.3
+      - R9.4
+      - R9.5
+      - R9.6
+      - R9.7
+      - R9.8
+
+  - id: AC8
+    criterion: Issue closing removes labels, closes via bd, and does not call PromoteReadyIssues
+    traces:
+      - R10.1
+      - R10.2
+      - R10.3
+      - R10.4
+
+  - id: AC9
+    criterion: Issue queries (open, all, comments, active context) return correctly populated CobblerIssue structs from bd JSON output
+    traces:
+      - R14.1
+      - R14.2
+      - R14.3
+      - R14.4
+      - R14.5
+      - R15.1
+      - R15.2
+      - R15.3
+      - R16.1
+      - R16.2
+      - R16.3
+      - R17.1
+      - R17.2
+      - R17.3
+      - R17.4
+
+  - id: AC10
+    criterion: DAG promotion and visibility polling are no-ops; ready-state computation is delegated to bd
+    traces:
+      - R18.1
+      - R18.2
+      - R19.1
+      - R19.2
+
+  - id: AC11
+    criterion: PickReadyIssue uses bd --ready flag for dependency resolution and claims the task atomically
+    traces:
+      - R20.1
+      - R20.2
+      - R20.3
+      - R20.4
+      - R20.5
+      - R20.6
+      - R20.7
+
+  - id: AC12
+    criterion: GC closes issues for generations whose branches no longer exist
+    traces:
+      - R21.1
+      - R21.2
+      - R21.3
+      - R21.4
+      - R21.5
+
+  - id: AC13
+    criterion: Parent-child linking uses bd native --parent flag instead of sub_issues API
+    traces:
+      - R22.1
+      - R22.2
+      - R22.3
+
+  - id: AC14
+    criterion: Defect filing creates bug-typed bd issues with best-effort semantics
+    traces:
+      - R23.1
+      - R23.2
+      - R23.3
+      - R23.4
+
+  - id: AC15
+    criterion: Dependencies are created via bd dep add during import instead of YAML front-matter encoding
+    traces:
+      - R26.1
+      - R26.2
+      - R26.3
+      - R26.4
+
+  - id: AC16
+    criterion: JSON output from bd is correctly parsed into CobblerIssue structs with tolerant defaults for missing fields
+    traces:
+      - R27.1
+      - R27.2
+      - R27.3
+      - R27.4
+      - R27.5
+      - R27.6
+      - R27.7
+
+  - id: AC17
+    criterion: Pure functions from the github package are reused without duplication
+    traces:
+      - R28.1
+      - R28.2
+      - R28.3
+
+  - id: AC18
+    criterion: Error handling follows best-effort semantics for non-critical operations and returns errors for critical ones
+    traces:
+      - R29.1
+      - R29.2
+      - R29.3
+      - R29.4
+      - R29.5
+
+  - id: AC19
+    criterion: bd binary is verified at construction time with a clear error when unavailable
+    traces:
+      - R30.1
+      - R30.2
+      - R30.3
+
+  - id: AC20
+    criterion: Title editing, commenting, bulk close, generic exec, and target repo resolution all delegate correctly to bd
+    traces:
+      - R11.1
+      - R11.2
+      - R12.1
+      - R12.2
+      - R12.3
+      - R13.1
+      - R13.2
+      - R13.3
+      - R13.4
+      - R24.1
+      - R24.2
+      - R24.3
+      - R24.4
+      - R25.1
+      - R25.2
+      - R25.3

--- a/docs/specs/software-requirements/srd008-pi-agent-backend.yaml
+++ b/docs/specs/software-requirements/srd008-pi-agent-backend.yaml
@@ -1,0 +1,1058 @@
+id: srd008-pi-agent-backend
+title: Pi Coding Agent Backend for Cobbler Orchestrator
+
+implemented_by:
+  - PiRunner (pkg/orchestrator/internal/pi/)
+  - Runner interface (pkg/orchestrator/internal/claude/runner.go)
+  - BuildDirectCmd refactoring (pkg/orchestrator/internal/claude/claude.go)
+  - Config struct (pkg/orchestrator/config.go)
+used_by:
+  - ClaudeRunner (pkg/orchestrator/cobbler.go)
+  - Measure (pkg/orchestrator/measure.go)
+  - Stitch (pkg/orchestrator/stitch.go)
+
+problem: |
+  The cobbler-scaffold orchestrator currently hard-codes Claude Code as
+  its sole code-generation backend.  All code-generation work — both
+  measure (task planning) and stitch (task execution) — is performed by
+  spawning the `claude` CLI binary as a subprocess.  The orchestrator
+  pipes a structured YAML prompt to stdin, captures NDJSON streaming
+  output on stdout, and parses a final `"type": "result"` event to
+  extract token usage and cost.
+
+  This coupling creates several problems:
+
+  1. Vendor lock-in.  The orchestrator is tied to a single closed-source
+     CLI binary (`claude`) whose output format, flag set, and
+     availability are controlled by Anthropic.  The `claude` binary is
+     not open-source, cannot be forked, and may be discontinued or
+     changed without notice.
+
+  2. Limited model support.  Claude Code supports only Anthropic models.
+     The orchestrator cannot use OpenAI, Google, DeepSeek, or local
+     models without rewriting the invocation layer.
+
+  3. Opaque execution.  The `--output-format stream-json` format is
+     undocumented and has changed across Claude Code versions.
+     ParseClaudeTokens and ProgressWriter contain format-specific
+     parsing logic that breaks on schema changes.
+
+  4. No extensibility.  Claude Code has no extension system.  The
+     orchestrator cannot inject custom tools, gate dangerous operations,
+     or add domain-specific capabilities without modifying Claude Code
+     itself.
+
+  5. Permission model.  The orchestrator uses
+     `--dangerously-skip-permissions` to bypass Claude Code's
+     interactive permission dialogs.  This is a security blunt
+     instrument — it grants unrestricted tool access with no
+     granularity.
+
+  Pi (github.com/earendil-works/pi) is an open-source, MIT-licensed
+  coding agent with a well-documented TypeScript extension system, a
+  structured JSON event stream, an RPC subprocess protocol, multi-
+  provider model support (30+ providers), and a Node.js SDK.  It
+  provides the same core tools as Claude Code (read, bash, edit, write,
+  grep, find, ls) and can be extended with custom tools, skills, and
+  prompt templates.
+
+  Cobbler-scaffold already has the Runner interface — a clean seam
+  designed for alternative backends.  This SRD specifies a PiRunner
+  that implements the Runner interface using the `pi` CLI or RPC
+  protocol, enabling the orchestrator to use Pi as a drop-in
+  replacement for Claude Code.
+
+goals:
+  - G1: Define a PiRunner struct that implements the Runner interface using the pi CLI
+  - G2: Map every Claude Code CLI flag to its Pi equivalent
+  - G3: Preserve identical orchestrator behavior — measure and stitch must produce equivalent results
+  - G4: Support Pi's JSON event stream for progress reporting and token tracking
+  - G5: Support Pi's RPC mode as an alternative to print mode for richer subprocess control
+  - G6: Enable multi-provider model selection through Pi's model abstraction
+  - G7: Add a configuration option to select between claude and pi backends
+  - G8: Preserve backward compatibility — claude must remain the default
+
+# ---------------------------------------------------------------------------
+# ANALYSIS: How Claude Code Is Invoked in Cobbler-Scaffold
+# ---------------------------------------------------------------------------
+#
+# This section documents every aspect of how the orchestrator invokes
+# Claude Code, and the corresponding Pi equivalent.  The analysis is
+# the foundation for all requirements below.
+#
+# ---------------------------------------------------------------------------
+# A1: Central Invocation Point
+# ---------------------------------------------------------------------------
+#
+# All Claude Code invocations flow through a single function:
+#
+#   BuildDirectCmd(ctx, workDir, model, claudeArgs, extraArgs...)
+#     → exec.CommandContext(ctx, "claude", args...)
+#
+# Located in: pkg/orchestrator/internal/claude/claude.go
+#
+# The function:
+#   1. Prepends --model <model> to args
+#   2. Appends default claudeArgs (from config or defaultClaudeArgs)
+#   3. Appends extraArgs (e.g. --max-turns 1)
+#   4. Creates exec.Cmd with cmd.Dir = workDir
+#   5. Strips CLAUDECODE= from environment
+#   6. Returns the *exec.Cmd (caller sets stdin/stdout)
+#
+# Call chain:
+#   Measure/Stitch → ClaudeRunner.runClaude()/runMeasureClaude()
+#     → claude.RunClaude() → runner.Run() → execRunner.run()
+#       → BuildDirectCmd()
+#
+# Pi equivalent: BuildPiCmd(ctx, workDir, model, piArgs, extraArgs...)
+#   → exec.CommandContext(ctx, "pi", args...)
+#   Same pattern, different binary and flags.
+#
+# ---------------------------------------------------------------------------
+# A2: Default CLI Flags
+# ---------------------------------------------------------------------------
+#
+# Claude Code default args (from commands.go):
+#
+#   var defaultClaudeArgs = []string{
+#       "--dangerously-skip-permissions",
+#       "-p",
+#       "--verbose",
+#       "--output-format", "stream-json",
+#   }
+#
+# Resulting invocation for stitch:
+#   claude --model claude-opus-4-6 \
+#     --dangerously-skip-permissions \
+#     -p \
+#     --verbose \
+#     --output-format stream-json
+#
+# For measure (adds --max-turns 1):
+#   claude --model claude-opus-4-6 \
+#     --dangerously-skip-permissions \
+#     -p \
+#     --verbose \
+#     --output-format stream-json \
+#     --max-turns 1
+#
+# Pi equivalents:
+#
+# | Claude Code Flag                    | Pi Equivalent                         | Notes                                          |
+# |-------------------------------------|---------------------------------------|-------------------------------------------------|
+# | --dangerously-skip-permissions      | (not needed)                          | Pi has no permission dialogs by default          |
+# | -p                                  | -p / --print                          | Identical flag, identical semantics              |
+# | --verbose                           | --verbose                             | Identical flag                                   |
+# | --output-format stream-json         | --mode json                           | Pi uses --mode json for NDJSON event stream      |
+# | --model <id>                        | --model <provider/id>                 | Pi supports provider/id syntax                   |
+# | --max-turns 1                       | (no direct equivalent)                | See A7 below for workaround                      |
+#
+# Default Pi args:
+#   var defaultPiArgs = []string{
+#       "-p",
+#       "--verbose",
+#       "--mode", "json",        // OR: drop -p, use only --mode json
+#       "--no-session",          // ephemeral, no session persistence
+#       "--no-context-files",    // orchestrator provides its own prompt
+#   }
+#
+# Note: Pi's -p (print) and --mode json are two different modes:
+#   - `-p` / `--print`: text output to stdout, exits after completion
+#   - `--mode json`: NDJSON event stream to stdout, exits after completion
+#   The orchestrator needs structured events for progress/tokens, so
+#   --mode json is the primary mode.  However, if using --mode json,
+#   the -p flag is implicit (non-interactive, single prompt, exit).
+#
+# ---------------------------------------------------------------------------
+# A3: Prompt Delivery
+# ---------------------------------------------------------------------------
+#
+# Claude Code receives the prompt via stdin:
+#   cmd.Stdin = strings.NewReader(prompt)
+#
+# The prompt is a YAML document marshaled from MeasurePromptDoc or
+# StitchPromptDoc.  It includes role, project context, constitutions,
+# task description, constraints, and output format instructions.
+#
+# Pi equivalent:
+#   - Print mode (-p) reads from stdin if no positional argument given:
+#     `cat README.md | pi -p "Summarize this text"`
+#   - JSON mode (--mode json) takes a positional prompt argument:
+#     `pi --mode json "Your prompt"`
+#   - Both support piped stdin merged with the prompt.
+#
+# For cobbler, the prompt should be passed as the positional argument
+# or via stdin pipe — either works.  Stdin pipe is simplest for
+# compatibility with the existing code.
+#
+# ---------------------------------------------------------------------------
+# A4: Stdout Capture and NDJSON Parsing
+# ---------------------------------------------------------------------------
+#
+# Claude Code with --output-format stream-json produces NDJSON lines.
+# The orchestrator:
+#   1. Wraps stdout in IdleTrackingWriter (idle watchdog)
+#   2. Optionally tees to os.Stdout via MultiWriter
+#   3. Captures full output in bytes.Buffer
+#   4. After exit, calls ParseClaudeTokens(rawOutput):
+#      - Scans lines BACKWARDS for "type": "result"
+#      - Extracts usage.input_tokens, output_tokens, cache_*_tokens, total_cost_usd
+#   5. ProgressWriter.LogLine() parses each line during execution:
+#      - "assistant" → log turn number, text snippet, tool calls
+#      - "user" → "tools done, waiting for LLM"
+#      - "rate_limit_event" → track wait time
+#      - "result" → log final counts
+#
+# Pi --mode json produces a DIFFERENT NDJSON schema:
+#   First line: {"type":"session","version":3,"id":"...","timestamp":"...","cwd":"..."}
+#   Events:     {"type":"agent_start"}
+#               {"type":"turn_start"}
+#               {"type":"message_start","message":{...}}
+#               {"type":"message_update","message":{...},"assistantMessageEvent":{...}}
+#               {"type":"message_end","message":{...}}
+#               {"type":"tool_execution_start","toolCallId":"...","toolName":"...","args":{...}}
+#               {"type":"tool_execution_update","toolCallId":"...","toolName":"...","partialResult":{...}}
+#               {"type":"tool_execution_end","toolCallId":"...","toolName":"...","result":{...},"isError":...}
+#               {"type":"turn_end","message":{...},"toolResults":[...]}
+#               {"type":"agent_end","messages":[...]}
+#
+# Token usage is in AssistantMessage.usage:
+#   {"role":"assistant","content":[...],"usage":{"input":N,"output":N,
+#    "cacheRead":N,"cacheWrite":N,"cost":{"input":F,"output":F,
+#    "cacheRead":F,"cacheWrite":F,"total":F}},...}
+#
+# A ParsePiTokens function must extract from the LAST message_end event
+# that contains an assistant message with usage data.  The mapping:
+#
+# | Claude Code field              | Pi field                               |
+# |--------------------------------|----------------------------------------|
+# | usage.input_tokens             | message.usage.input                    |
+# | usage.output_tokens            | message.usage.output                   |
+# | usage.cache_creation_input_tokens | message.usage.cacheWrite            |
+# | usage.cache_read_input_tokens  | message.usage.cacheRead                |
+# | total_cost_usd                 | message.usage.cost.total               |
+#
+# ---------------------------------------------------------------------------
+# A5: Measure Text Extraction
+# ---------------------------------------------------------------------------
+#
+# After measure completes, the orchestrator extracts the task plan:
+#   textOutput := claude.ExtractTextFromStreamJSON(tokens.RawOutput)
+#   yamlContent, _ := claude.ExtractYAMLBlock(textOutput)
+#
+# ExtractTextFromStreamJSON concatenates all text blocks from
+# assistant messages in the NDJSON stream.
+#
+# Pi equivalent: ExtractTextFromPiJSON must:
+#   1. Find all message_end events where message.role == "assistant"
+#   2. Extract content blocks where type == "text"
+#   3. Concatenate the text fields
+#
+# ExtractYAMLBlock is format-agnostic (regex for ```yaml fences).
+# It can be reused unchanged.
+#
+# ---------------------------------------------------------------------------
+# A6: Idle Watchdog
+# ---------------------------------------------------------------------------
+#
+# The orchestrator wraps stdout in IdleTrackingWriter.  A goroutine
+# polls every second; if LastWrite hasn't advanced for IdleTimeoutS
+# (stitch: 60s, measure: 1800s), the context is cancelled.
+#
+# Pi equivalent: Same pattern works unchanged.  Pi's --mode json
+# streams events to stdout, so the idle tracker sees writes whenever
+# the agent emits events (turn starts, tool output, text deltas).
+# No changes needed to IdleTrackingWriter.
+#
+# ---------------------------------------------------------------------------
+# A7: --max-turns 1 for Measure
+# ---------------------------------------------------------------------------
+#
+# Measure uses --max-turns 1 to restrict Claude Code to a single
+# assistant response with no tool calls.  This forces the model to
+# produce a task plan as text rather than trying to implement it.
+#
+# Pi has no --max-turns flag.  Alternatives:
+#
+#   Option A: Use --no-tools / -nt flag.
+#     Pi supports `--no-tools` which disables all tools.  Without tools,
+#     the model cannot make tool calls and will respond with text only.
+#     This is semantically equivalent to --max-turns 1 for planning.
+#     `pi --mode json --no-tools "plan the work..."`
+#
+#   Option B: Use --tools flag with empty list.
+#     Pi supports `--tools ""` which has the same effect.
+#
+#   Option C: Use system prompt instruction.
+#     Add "Do not use any tools. Respond with text only." to the
+#     measure prompt.  This is fragile and model-dependent.
+#
+#   Recommendation: Option A (--no-tools) is the cleanest equivalent.
+#   The measure prompt already instructs the model to produce a YAML
+#   plan, not to execute code.  Disabling tools enforces this.
+#
+# ---------------------------------------------------------------------------
+# A8: Environment Handling
+# ---------------------------------------------------------------------------
+#
+# BuildDirectCmd strips CLAUDECODE= from the environment:
+#   filtered := make([]string, 0, len(os.Environ()))
+#   for _, e := range os.Environ() {
+#       if !strings.HasPrefix(e, "CLAUDECODE=") {
+#           filtered = append(filtered, e)
+#       }
+#   }
+#   cmd.Env = filtered
+#
+# Pi equivalent: Strip PI_CODING_AGENT_DIR and similar Pi-specific
+# env vars if needed, or simply pass the full environment.  Pi uses
+# ANTHROPIC_API_KEY, OPENAI_API_KEY, etc. for authentication, which
+# are standard and should be inherited from the parent process.
+#
+# Pi env vars to consider:
+#   PI_CODING_AGENT_DIR — override config directory
+#   PI_OFFLINE — disable network checks
+#   PI_SKIP_VERSION_CHECK — skip version check
+#
+# For orchestrator use, set PI_SKIP_VERSION_CHECK=1 and
+# PI_OFFLINE=1 to avoid startup delays.
+#
+# ---------------------------------------------------------------------------
+# A9: Runner Interface
+# ---------------------------------------------------------------------------
+#
+# The existing Runner interface:
+#
+#   type Runner interface {
+#       Run(ctx context.Context, prompt, workDir string, silence bool,
+#           extraArgs ...string) (ClaudeResult, error)
+#   }
+#
+# ClaudeResult:
+#   type ClaudeResult struct {
+#       RawOutput  string
+#       InputTokens int
+#       OutputTokens int
+#       CacheCreationTokens int
+#       CacheReadTokens int
+#       CostUSD float64
+#   }
+#
+# The PiRunner must implement this same interface and return a
+# ClaudeResult with the same fields populated from Pi's event stream.
+# The field names are Claude-specific but the data is generic token
+# usage — Pi provides identical data in its AssistantMessage.usage.
+#
+# ---------------------------------------------------------------------------
+# A10: SDK/RPC Mode Alternative
+# ---------------------------------------------------------------------------
+#
+# Claude Code has two modes in cobbler:
+#   - "cli" (default): exec.Command spawns claude binary
+#   - "sdk": uses Go Agent SDK via JSONL --stdio protocol
+#
+# Pi has three non-interactive modes:
+#   - Print mode (-p): text output, single prompt, exits
+#   - JSON mode (--mode json): NDJSON event stream, single prompt, exits
+#   - RPC mode (--mode rpc): JSONL command/response protocol over stdin/stdout
+#
+# For cobbler integration:
+#   - JSON mode is the direct replacement for claude --output-format stream-json
+#   - RPC mode is the replacement for the SDK mode (richer control)
+#
+# RPC mode advantages over JSON mode:
+#   - Can send multiple prompts in sequence
+#   - Can abort mid-execution
+#   - Can query state (get_state, get_session_stats)
+#   - Better for stitch where the orchestrator may need to steer
+#   - Session stats include precise token/cost data
+#
+# However, JSON mode is simpler and closer to the existing CLI pattern.
+# Recommendation: Start with JSON mode for parity, add RPC mode later.
+#
+# ---------------------------------------------------------------------------
+# A11: Model Mapping
+# ---------------------------------------------------------------------------
+#
+# Claude Code uses bare model IDs: "claude-opus-4-6", "claude-sonnet-4-5"
+# Pi uses provider/id syntax: "anthropic/claude-opus-4-6"
+#
+# Pi also supports:
+#   --provider anthropic --model claude-opus-4-6
+#   --model anthropic/claude-opus-4-6
+#   --model anthropic/claude-opus-4-6:high  (with thinking level)
+#
+# For non-Anthropic models:
+#   --model openai/gpt-4o
+#   --model google/gemini-2.5-pro
+#   --model deepseek/deepseek-chat
+#
+# The orchestrator's DefaultModel = "claude-opus-4-6" maps to
+# "anthropic/claude-opus-4-6" in Pi.  The config must support
+# provider/id syntax when pi is selected as the backend.
+#
+# ---------------------------------------------------------------------------
+# A12: System Prompt and Context Files
+# ---------------------------------------------------------------------------
+#
+# Claude Code has no --system-prompt flag in cobbler's usage.  The
+# prompt is a structured YAML document piped to stdin.  Claude Code
+# uses its own default system prompt plus the user's prompt.
+#
+# Pi has several system prompt mechanisms:
+#   --system-prompt <text>   — replace default prompt
+#   --append-system-prompt   — append to default prompt
+#   --no-context-files       — disable AGENTS.md discovery
+#   SYSTEM.md files          — project-level override
+#
+# For cobbler, the orchestrator should:
+#   1. Use --no-context-files (-nc) to prevent Pi from loading
+#      AGENTS.md from the worktree (the orchestrator controls all context)
+#   2. Use --system-prompt with the role/constitution text
+#   3. Pipe the task-specific prompt (project context, task description)
+#      to stdin or as a positional argument
+#
+# Alternatively, the orchestrator can continue piping everything via
+# stdin and let Pi treat it as the user prompt.  The orchestrator's
+# prompts already contain role instructions, so this works without
+# a separate system prompt.
+#
+# ---------------------------------------------------------------------------
+# A13: Credential Management
+# ---------------------------------------------------------------------------
+#
+# Claude Code CLI mode: claude handles its own auth (API key from
+# env or keychain).  The orchestrator just checks LookPath("claude").
+#
+# Claude Code SDK mode: credentials from .secrets/claude.json with
+# optional keychain extraction.
+#
+# Pi: uses env vars (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.) or
+# its own auth storage (~/.pi/agent/auth.json).  The /login command
+# supports OAuth for subscription providers.
+#
+# For cobbler, the simplest approach is to rely on env vars that Pi
+# inherits from the parent process.  No credential extraction needed
+# if ANTHROPIC_API_KEY is set.  This is simpler than Claude Code's
+# credential management.
+#
+# CheckPi() should:
+#   1. exec.LookPath("pi") — verify binary exists
+#   2. Optionally exec pi --version to verify minimum version
+#   3. No credential extraction needed (env vars are inherited)
+#
+# ---------------------------------------------------------------------------
+# A14: Extension Opportunities
+# ---------------------------------------------------------------------------
+#
+# Unlike Claude Code, Pi's extension system enables cobbler-specific
+# behaviors without modifying the agent binary:
+#
+#   - Permission gating: an extension can intercept tool_call events
+#     and block specific operations (e.g., no rm -rf, no network access)
+#   - Progress reporting: an extension can emit custom messages for
+#     orchestrator consumption
+#   - Git safety: the git-checkpoint extension stashes at each turn
+#   - Custom tools: register bd, gh, or project-specific tools
+#   - Prompt injection: before_agent_start can modify system prompt
+#
+# These are future enhancements; the initial PiRunner should work
+# without any extensions.  Extension support can be added later via
+# --extension flags in the Pi args.
+
+requirements:
+
+  # =========================================================================
+  # R1: Configuration — Backend Selection
+  # =========================================================================
+  - id: R1
+    title: Backend selection configuration
+    description: |
+      Add a top-level configuration key `cobbler.agent_backend` that selects
+      the code-generation backend.  Valid values: "claude" (default), "pi".
+
+      When "pi" is selected, the orchestrator constructs a PiRunner instead
+      of a CLIRunner/SDKRunner for all Claude invocations.
+
+      The `claude` section of configuration.yaml continues to work for the
+      claude backend.  A new `pi` section is added for pi-specific config.
+    traced_to: [G7, G8]
+
+  # =========================================================================
+  # R2: Configuration — Pi Section
+  # =========================================================================
+  - id: R2
+    title: Pi configuration section
+    description: |
+      Add a `pi` configuration section in configuration.yaml:
+
+        pi:
+          model: ""                         # default: "anthropic/claude-sonnet-4-20250514"
+          provider: ""                      # optional: override provider
+          thinking: "medium"                # thinking level
+          args:                             # default pi CLI args
+            - --mode
+            - json
+            - --no-session
+            - --no-context-files
+            - --verbose
+          silence_agent: true               # suppress pi stdout (same as claude)
+          max_time_sec: 300                 # hard timeout per invocation
+          mode: "json"                      # "json" or "rpc"
+          extensions: []                    # extension paths to load
+
+      The model field uses Pi's provider/id syntax.  If provider is set
+      separately, it is prepended: provider/model.
+    traced_to: [G6, G7]
+
+  # =========================================================================
+  # R3: PiRunner Struct
+  # =========================================================================
+  - id: R3
+    title: PiRunner struct definition
+    description: |
+      Define a PiRunner struct in pkg/orchestrator/internal/pi/ that
+      implements the Runner interface:
+
+        type PiRunner struct {
+            Model         string
+            Provider      string
+            Thinking      string
+            PiArgs        []string
+            PiBin         string        // path to pi binary, default "pi"
+            Silence       bool
+            IdleTimeoutS  int
+            Timeout       time.Duration
+            Extensions    []string
+        }
+
+        func (r *PiRunner) Run(ctx context.Context, prompt, workDir string,
+            silence bool, extraArgs ...string) (claude.ClaudeResult, error)
+
+      The Run method:
+        1. Builds the exec.Cmd via BuildPiCmd
+        2. Sets cmd.Stdin to the prompt
+        3. Captures stdout with IdleTrackingWriter
+        4. Waits for exit
+        5. Parses Pi NDJSON output via ParsePiTokens
+        6. Returns ClaudeResult with token/cost data
+    traced_to: [G1, G3]
+
+  # =========================================================================
+  # R4: BuildPiCmd Function
+  # =========================================================================
+  - id: R4
+    title: BuildPiCmd command construction
+    description: |
+      Define BuildPiCmd analogous to BuildDirectCmd:
+
+        func BuildPiCmd(ctx context.Context, workDir string, model string,
+            provider string, thinking string, piArgs []string,
+            extensions []string, extraPiArgs ...string) *exec.Cmd
+
+      Argument construction order:
+        1. --model <provider/model> (or --provider <p> --model <m>)
+        2. --thinking <level> (if thinking != "")
+        3. piArgs (default: --mode json --no-session --no-context-files --verbose)
+        4. For each extension: -e <path>
+        5. extraPiArgs (e.g. --no-tools for measure)
+        6. A sentinel empty string or "--" to separate flags from prompt
+
+      Set cmd.Dir = workDir.
+      Set cmd.Env to os.Environ() plus:
+        PI_SKIP_VERSION_CHECK=1
+        PI_OFFLINE=1
+    traced_to: [G1, G2]
+
+  # =========================================================================
+  # R5: Flag Mapping
+  # =========================================================================
+  - id: R5
+    title: Claude Code to Pi flag mapping
+    description: |
+      The following flag mapping must be implemented:
+
+      | Claude Code Flag                     | Pi Flag                    | Required |
+      |--------------------------------------|----------------------------|----------|
+      | --dangerously-skip-permissions       | (omit)                     | No       |
+      | -p                                   | (implicit in --mode json)  | No       |
+      | --verbose                            | --verbose                  | Yes      |
+      | --output-format stream-json          | --mode json                | Yes      |
+      | --model <id>                         | --model <provider/id>      | Yes      |
+      | --max-turns 1                        | --no-tools                 | Yes      |
+      | (none)                               | --no-session               | Yes      |
+      | (none)                               | --no-context-files         | Yes      |
+      | (none)                               | --thinking <level>         | Optional |
+
+      The --no-session flag prevents Pi from persisting session state to disk.
+      The --no-context-files flag prevents Pi from loading AGENTS.md.
+      Both are required because the orchestrator controls all context.
+    traced_to: [G2]
+
+  # =========================================================================
+  # R6: NDJSON Event Parsing — ParsePiTokens
+  # =========================================================================
+  - id: R6
+    title: ParsePiTokens function
+    description: |
+      Define ParsePiTokens to extract token usage from Pi's NDJSON output:
+
+        func ParsePiTokens(rawOutput string) ClaudeResult
+
+      Algorithm:
+        1. Split rawOutput into lines
+        2. Scan BACKWARDS for a line containing "type":"message_end"
+           where the message has role "assistant" and a usage object
+        3. Extract:
+           - InputTokens  = message.usage.input
+           - OutputTokens = message.usage.output
+           - CacheCreationTokens = message.usage.cacheWrite
+           - CacheReadTokens = message.usage.cacheRead
+           - CostUSD = message.usage.cost.total
+        4. Set RawOutput = rawOutput
+        5. Return ClaudeResult
+
+      If no usage data is found, return zero values with RawOutput set.
+
+      The JSON structure to parse:
+        {"type":"message_end","message":{"role":"assistant",
+         "usage":{"input":N,"output":N,"cacheRead":N,"cacheWrite":N,
+         "cost":{"input":F,"output":F,"cacheRead":F,"cacheWrite":F,
+         "total":F}}}}
+    traced_to: [G4]
+
+  # =========================================================================
+  # R7: Text Extraction — ExtractTextFromPiJSON
+  # =========================================================================
+  - id: R7
+    title: ExtractTextFromPiJSON function
+    description: |
+      Define ExtractTextFromPiJSON to extract assistant text from Pi's
+      NDJSON output:
+
+        func ExtractTextFromPiJSON(rawOutput string) string
+
+      Algorithm:
+        1. Split rawOutput into lines
+        2. For each line, parse as JSON
+        3. If type == "message_end" and message.role == "assistant":
+           a. Iterate message.content array
+           b. For each block where type == "text", append block.text
+        4. Return concatenated text
+
+      This is used by measure to extract the YAML task plan.
+      ExtractYAMLBlock is reused unchanged on the result.
+    traced_to: [G3]
+
+  # =========================================================================
+  # R8: Progress Logging — PiProgressWriter
+  # =========================================================================
+  - id: R8
+    title: PiProgressWriter for live progress
+    description: |
+      Define a PiProgressWriter analogous to ProgressWriter that parses
+      Pi's NDJSON event stream and logs progress:
+
+      Event mapping:
+        | Pi Event                 | Log Action                              |
+        |--------------------------|-----------------------------------------|
+        | agent_start              | "Agent started"                         |
+        | turn_start               | "Turn N started"                        |
+        | message_update (text)    | Log text snippet (first 80 chars)       |
+        | tool_execution_start     | "Tool: <name> <args summary>"           |
+        | tool_execution_end       | "Tool done: <name> (error: <bool>)"     |
+        | turn_end                 | "Turn N complete"                       |
+        | message_end (assistant)  | Log token counts from usage             |
+        | agent_end                | "Agent complete, N messages"            |
+        | auto_retry_start         | "Retry attempt N after error"           |
+
+      When silence is true, use a compact progress indicator (dots/spinner).
+      When silence is false, tee raw output to os.Stdout.
+    traced_to: [G4]
+
+  # =========================================================================
+  # R9: Measure Integration
+  # =========================================================================
+  - id: R9
+    title: Measure uses PiRunner with --no-tools
+    description: |
+      When agent_backend is "pi", ClaudeRunner.runMeasureClaude must:
+        1. Select the PiRunner
+        2. Pass extraArgs = ["--no-tools"] instead of ["--max-turns", "1"]
+        3. Use the measure idle timeout (1800s)
+        4. After completion, call ExtractTextFromPiJSON instead of
+           ExtractTextFromStreamJSON
+        5. Call ExtractYAMLBlock on the result (unchanged)
+
+      The measure prompt document (YAML) is piped to stdin unchanged.
+      Pi treats it as the user prompt and responds with text.
+    traced_to: [G3]
+
+  # =========================================================================
+  # R10: Stitch Integration
+  # =========================================================================
+  - id: R10
+    title: Stitch uses PiRunner with full tools
+    description: |
+      When agent_backend is "pi", ClaudeRunner.runClaude must:
+        1. Select the PiRunner
+        2. Pass no extraArgs (Pi has all tools enabled by default)
+        3. Use the stitch idle timeout (60s)
+        4. Set workDir to task.WorktreeDir
+
+      Pi runs inside the git worktree with full tool access (read, bash,
+      edit, write, grep, find, ls).  The stitch prompt document (YAML) is
+      piped to stdin unchanged.
+    traced_to: [G3]
+
+  # =========================================================================
+  # R11: Idle Watchdog Compatibility
+  # =========================================================================
+  - id: R11
+    title: IdleTrackingWriter works with Pi output
+    description: |
+      IdleTrackingWriter wraps stdout and tracks the timestamp of the last
+      write.  A goroutine cancels the context if no output arrives for
+      IdleTimeoutS seconds.
+
+      Pi's --mode json streams events continuously during execution:
+        - text_delta events during LLM response
+        - tool_execution_update events during tool execution
+        - turn_start/turn_end events between turns
+
+      These events keep the idle tracker alive.  No changes needed to
+      IdleTrackingWriter.  The existing implementation works unchanged
+      with Pi's event stream.
+    traced_to: [G3]
+
+  # =========================================================================
+  # R12: CheckPi Binary Verification
+  # =========================================================================
+  - id: R12
+    title: CheckPi function for binary verification
+    description: |
+      Define CheckPi analogous to CheckClaude:
+
+        func CheckPi() error
+
+      Steps:
+        1. exec.LookPath("pi") — verify binary exists in PATH
+        2. Optionally: run `pi --version` and verify >= minimum version
+        3. Return nil on success, descriptive error on failure
+
+      Called at orchestrator startup when agent_backend is "pi".
+      No credential extraction is needed — Pi uses inherited env vars
+      (ANTHROPIC_API_KEY, OPENAI_API_KEY, etc.) or its own auth store.
+    traced_to: [G1]
+
+  # =========================================================================
+  # R13: Backend Selection in ClaudeRunner
+  # =========================================================================
+  - id: R13
+    title: ClaudeRunner selects runner by backend config
+    description: |
+      Modify ClaudeRunner (cobbler.go) to construct either a CLIRunner
+      or PiRunner based on cfg.AgentBackend:
+
+        switch cfg.AgentBackend {
+        case "pi":
+            runner = pi.NewPiRunner(pi.PiRunnerConfig{
+                Model:    cfg.Pi.Model,
+                Provider: cfg.Pi.Provider,
+                Thinking: cfg.Pi.Thinking,
+                PiArgs:   cfg.Pi.Args,
+                Silence:  cfg.Pi.SilenceAgent,
+                Timeout:  cfg.Pi.MaxTimeSec,
+                Extensions: cfg.Pi.Extensions,
+            })
+        default:  // "claude" or ""
+            runner = claude.NewCLIRunner(claude.CLIRunnerConfig{...})
+        }
+
+      The rest of ClaudeRunner (runClaude, runMeasureClaude) operates on
+      the Runner interface and is backend-agnostic.
+    traced_to: [G7, G8]
+
+  # =========================================================================
+  # R14: Text Extraction Dispatch
+  # =========================================================================
+  - id: R14
+    title: Backend-aware text extraction
+    description: |
+      After measure completes, the orchestrator extracts text.  The
+      extraction function must match the backend:
+
+        switch cfg.AgentBackend {
+        case "pi":
+            textOutput = pi.ExtractTextFromPiJSON(tokens.RawOutput)
+        default:
+            textOutput = claude.ExtractTextFromStreamJSON(tokens.RawOutput)
+        }
+
+      Alternatively, define an Extractor interface on Runner:
+        type TextExtractor interface {
+            ExtractText(rawOutput string) string
+        }
+
+      And have both CLIRunner and PiRunner implement it.
+    traced_to: [G3]
+
+  # =========================================================================
+  # R15: Model Provider Mapping
+  # =========================================================================
+  - id: R15
+    title: Model identifier mapping
+    description: |
+      When the pi backend is selected, model identifiers must include
+      the provider prefix.  Define a mapping function:
+
+        func MapModelToPi(claudeModel string) string
+
+      Default mappings:
+        "claude-opus-4-6"     → "anthropic/claude-opus-4-6"
+        "claude-sonnet-4-5"   → "anthropic/claude-sonnet-4-5"
+        "claude-haiku-4-5"    → "anthropic/claude-haiku-4-5"
+
+      If the model already contains "/" (provider/id format), pass through
+      unchanged.  This allows users to specify non-Anthropic models in
+      the pi config:
+        pi:
+          model: "openai/gpt-4o"
+          model: "google/gemini-2.5-pro"
+          model: "deepseek/deepseek-chat"
+    traced_to: [G6]
+
+  # =========================================================================
+  # R16: Error Handling
+  # =========================================================================
+  - id: R16
+    title: Error handling for Pi subprocess
+    description: |
+      The PiRunner.Run method must handle:
+
+      1. Non-zero exit code: return error with stderr content
+      2. Context cancellation (timeout): return error with "pi timed out"
+      3. Idle timeout: IdleTrackingWriter cancels context, same as claude
+      4. Signal handling: SIGTERM/SIGINT propagated to child process
+      5. Parse failure: if ParsePiTokens finds no usage data, return
+         ClaudeResult with zero token counts and log a warning
+
+      Error messages must include the backend name for debugging:
+        "pi exited with code %d: %s"
+        "pi timed out after %v"
+        "pi idle timeout after %ds"
+    traced_to: [G1, G3]
+
+  # =========================================================================
+  # R17: RPC Mode Runner (Future)
+  # =========================================================================
+  - id: R17
+    title: PiRPCRunner for RPC mode integration
+    description: |
+      Define a PiRPCRunner that uses Pi's RPC mode for richer control:
+
+        type PiRPCRunner struct {
+            // ... same fields as PiRunner plus:
+            proc    *exec.Cmd
+            stdin   io.WriteCloser
+            reader  *bufio.Scanner
+        }
+
+      The RPC runner:
+        1. Starts `pi --mode rpc --no-session --no-context-files`
+        2. Sends {"type":"prompt","message":"..."} via stdin
+        3. Reads events from stdout until agent_end
+        4. Sends {"type":"get_session_stats"} to get token usage
+        5. Returns ClaudeResult with data from session stats
+
+      Advantages over JSON mode:
+        - Can reuse a single Pi process for multiple prompts
+        - Can abort mid-execution via {"type":"abort"}
+        - Can query state and stats without parsing event stream
+        - Better for multi-turn stitch operations
+
+      This is a future enhancement.  JSON mode (R3-R8) is sufficient for
+      initial parity with Claude Code.
+    traced_to: [G5]
+
+  # =========================================================================
+  # R18: Extension Loading
+  # =========================================================================
+  - id: R18
+    title: Extension loading via configuration
+    description: |
+      When the pi backend is selected and pi.extensions is non-empty,
+      BuildPiCmd appends -e <path> for each extension:
+
+        for _, ext := range extensions {
+            args = append(args, "-e", ext)
+        }
+
+      This enables cobbler-specific extensions such as:
+        - bd-integration: custom tool for beads issue tracking
+        - git-safety: stash/restore on turn boundaries
+        - permission-gate: block dangerous operations
+
+      Extensions are loaded from absolute paths specified in config.
+      No extension is required for basic operation.
+    traced_to: [G1]
+
+  # =========================================================================
+  # R19: Prompt Compatibility
+  # =========================================================================
+  - id: R19
+    title: Prompt format compatibility
+    description: |
+      The orchestrator's prompt documents (MeasurePromptDoc,
+      StitchPromptDoc) are YAML-serialized structs piped to stdin.
+      These must work with Pi unchanged.
+
+      Validation:
+        - Pi in print/JSON mode reads stdin and treats it as the prompt
+        - The YAML document is valid text content — Pi processes it as
+          the user's request
+        - Role instructions, constitutions, project context, and task
+          descriptions embedded in the YAML work identically
+        - Pi's default system prompt ("You are an expert coding
+          assistant...") does not conflict with the embedded role
+
+      If the orchestrator wants to suppress Pi's default system prompt
+      to avoid redundancy with the embedded role, use:
+        --system-prompt ""  (empty string replaces default)
+      or
+        --system-prompt "Follow the instructions in the user prompt."
+    traced_to: [G3]
+
+  # =========================================================================
+  # R20: Output Format Abstraction
+  # =========================================================================
+  - id: R20
+    title: Output format abstraction
+    description: |
+      Create a backend-agnostic output parsing interface:
+
+        type OutputParser interface {
+            ParseTokens(rawOutput string) ClaudeResult
+            ExtractText(rawOutput string) string
+        }
+
+        type ClaudeOutputParser struct{}
+        type PiOutputParser struct{}
+
+      ClaudeOutputParser wraps ParseClaudeTokens and ExtractTextFromStreamJSON.
+      PiOutputParser wraps ParsePiTokens and ExtractTextFromPiJSON.
+
+      The Runner interface can optionally embed OutputParser, or the
+      orchestrator can select the parser based on config.AgentBackend.
+
+      This is a refactoring opportunity, not strictly required.  The
+      dispatch in R14 achieves the same result.
+    traced_to: [G3, G4]
+
+acceptance_criteria:
+
+  - id: AC1
+    description: |
+      When cobbler.agent_backend is "pi", the orchestrator uses PiRunner
+      for all code-generation invocations.
+    traces: [R1, R13]
+
+  - id: AC2
+    description: |
+      When cobbler.agent_backend is "" or "claude", behavior is identical
+      to the current implementation.  No existing tests break.
+    traces: [R1, R13]
+
+  - id: AC3
+    description: |
+      PiRunner implements the Runner interface.  It can be assigned to a
+      Runner variable and called with the same signature.
+    traces: [R3]
+
+  - id: AC4
+    description: |
+      BuildPiCmd produces a correctly constructed exec.Cmd with:
+        - pi binary
+        - --model with provider/id syntax
+        - --mode json
+        - --no-session
+        - --no-context-files
+        - --verbose
+        - --thinking level (if configured)
+        - Extensions via -e flags
+        - Extra args appended last
+        - cmd.Dir set to workDir
+        - PI_SKIP_VERSION_CHECK=1 in environment
+    traces: [R4, R5]
+
+  - id: AC5
+    description: |
+      ParsePiTokens correctly extracts InputTokens, OutputTokens,
+      CacheCreationTokens, CacheReadTokens, and CostUSD from Pi's
+      NDJSON event stream.
+    traces: [R6]
+
+  - id: AC6
+    description: |
+      ExtractTextFromPiJSON concatenates all text content from assistant
+      messages in Pi's NDJSON output.  ExtractYAMLBlock succeeds on the
+      result when the assistant produces a YAML-fenced code block.
+    traces: [R7]
+
+  - id: AC7
+    description: |
+      Measure with pi backend passes --no-tools instead of --max-turns 1.
+      The model responds with text only (no tool calls).
+    traces: [R9]
+
+  - id: AC8
+    description: |
+      Stitch with pi backend runs in the git worktree directory with all
+      tools enabled.  The agent can read, edit, write files, and run
+      bash commands in the worktree.
+    traces: [R10]
+
+  - id: AC9
+    description: |
+      IdleTrackingWriter correctly detects idle Pi processes.  If no
+      NDJSON events are written for IdleTimeoutS seconds, the context
+      is cancelled and Pi is killed.
+    traces: [R11]
+
+  - id: AC10
+    description: |
+      CheckPi returns nil when `pi` is in PATH and returns a descriptive
+      error when it is not.
+    traces: [R12]
+
+  - id: AC11
+    description: |
+      Model identifiers without a "/" prefix are automatically prepended
+      with "anthropic/" for the pi backend.  Identifiers with "/" are
+      passed through unchanged.
+    traces: [R15]
+
+  - id: AC12
+    description: |
+      Pi subprocess errors (non-zero exit, timeout, idle timeout) produce
+      descriptive error messages that identify "pi" as the backend.
+    traces: [R16]
+
+  - id: AC13
+    description: |
+      The orchestrator's YAML prompt documents (MeasurePromptDoc,
+      StitchPromptDoc) work with Pi's stdin processing without any
+      modification to the prompt format.
+    traces: [R19]
+
+  - id: AC14
+    description: |
+      PiProgressWriter logs meaningful progress during Pi execution:
+      turn numbers, tool calls, text snippets, and token counts.
+    traces: [R8]
+
+  - id: AC15
+    description: |
+      Non-Anthropic models (OpenAI, Google, DeepSeek) can be configured
+      via pi.model and are passed correctly to the pi CLI.
+    traces: [R2, R15]


### PR DESCRIPTION
## Summary

- Move two SRDs sitting at the repo root into the canonical \`docs/specs/software-requirements/\` directory.
- Renumber them to \`srd007-beads-tracker.yaml\` and \`srd008-pi-agent-backend.yaml\` to follow the \`srd[NNN]-[short-name]\` convention used by srd001-srd006.
- Update the \`id:\` field in each file to match the new filename. No content edits to \`problem\`, \`goals\`, \`requirements\`, or \`acceptance_criteria\` — substantive review and content fixes will be tracked in separate follow-up issues.

Closes #2132.

## Test plan

- [x] \`ls\` at repo root no longer shows \`srd-beads-tracker.yaml\` or \`srd-pi-agent-backend.yaml\`
- [x] \`ls docs/specs/software-requirements/\` lists \`srd007-beads-tracker.yaml\` and \`srd008-pi-agent-backend.yaml\` alongside srd001-srd006
- [x] \`grep -E '^id:' docs/specs/software-requirements/srd00{7,8}-*.yaml\` returns ids that match each filename
- [ ] \`mage analyze\` and \`go build ./...\` pass unchanged (these are documentation files; no build impact expected)

Generated with [Claude Code](https://claude.com/claude-code)