### PR TITLE
GH-2145: flag bare touchpoint entries with no SRD citation

### DIFF
--- a/pkg/orchestrator/internal/analysis/analyze.go
+++ b/pkg/orchestrator/internal/analysis/analyze.go
@@ -43,6 +43,7 @@ type AnalyzeResult struct {
 	BrokenInterfaceRefs            []string // implemented_by/used_by references non-existent architecture interface (GH-1968)
 	MissingSpecFiles               []string // spec_file declared in ARCHITECTURE.yaml but file does not exist (GH-1990)
 	MissingTestSuiteRefs           []string // Use cases whose test_suite field references a non-existent test suite (GH-2140 Gap 1)
+	BareTouchpointEntries          []string // Individual touchpoint entries with no SRD reference (warning, GH-2145)
 }
 
 // AnalyzeCounts holds the artifact counts discovered during analysis.
@@ -260,6 +261,20 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 			result.OrphanedSRDs = append(result.OrphanedSRDs, srdID)
 		}
 	}
+
+	// Check 1b: Per-entry touchpoint citation check (GH-2145).
+	// Use-case-level orphan checks see SRDs anywhere in a use case's touchpoints,
+	// so a single citation hides other entries that reference packages or files
+	// without tying back to a requirement. Flag each bare entry individually.
+	for ucID, tps := range ucTouchpoints {
+		for i, tp := range tps {
+			if !touchpointEntryCitesSRD(tp) {
+				result.BareTouchpointEntries = append(result.BareTouchpointEntries,
+					fmt.Sprintf("%s touchpoint[%d]: %q has no srd*-id reference", ucID, i, truncate(tp, 80)))
+			}
+		}
+	}
+	sort.Strings(result.BareTouchpointEntries)
 
 	// Check 2: Releases in road-map.yaml without a test suite file.
 	// Test suite IDs follow the dashed convention test-rel-<version> (GH-2140 Gap 2).
@@ -673,6 +688,7 @@ func (r AnalyzeResult) PrintReport(srdCount, ucCount, tsCount, smCount int) erro
 	PrintSection("Failed requirements (R-items complete with test failures — warning)", r.FailedRequirements)
 	// MissingWeights print removed — weights live in requirements.yaml (GH-2080).
 	PrintSection("Bare touchpoints (SRD cited without R-group references — warning)", r.BareTouchpoints)
+	PrintSection("Bare touchpoint entries (no SRD citation in this individual touchpoint — warning)", r.BareTouchpointEntries)
 
 	// GH-2140 Gap 4: warnings must be reflected in the headline. Errors still
 	// flip the exit code; warnings only change the message.
@@ -680,7 +696,8 @@ func (r AnalyzeResult) PrintReport(srdCount, ucCount, tsCount, smCount int) erro
 		len(r.UntracedSuccessCriteria) +
 		len(r.UnreachableUCs) +
 		len(r.FailedRequirements) +
-		len(r.BareTouchpoints)
+		len(r.BareTouchpoints) +
+		len(r.BareTouchpointEntries)
 
 	if hasIssues {
 		return fmt.Errorf("found consistency issues (see above)")
@@ -728,6 +745,32 @@ func ExtractID(path string) string {
 	base := filepath.Base(path)
 	ext := filepath.Ext(base)
 	return strings.TrimSuffix(base, ext)
+}
+
+// truncate returns s shortened to at most n runes, appending "..." when truncated.
+// Used to keep BareTouchpointEntries warning lines readable (GH-2145).
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 3 {
+		return s[:n]
+	}
+	return s[:n-3] + "..."
+}
+
+// touchpointEntryCitesSRD reports whether the prose touchpoint string contains
+// at least one srd*-prefixed token, matching the lenient rule used by
+// ExtractSRDsFromTouchpoints (GH-2145).
+func touchpointEntryCitesSRD(tp string) bool {
+	for _, part := range strings.Fields(tp) {
+		cleaned := strings.TrimLeft(part, "(")
+		cleaned = strings.TrimRight(cleaned, "),.")
+		if strings.HasPrefix(cleaned, "srd") {
+			return true
+		}
+	}
+	return false
 }
 
 // LoadUseCase loads a use case YAML file and extracts key fields.

--- a/pkg/orchestrator/internal/analysis/analyze_test.go
+++ b/pkg/orchestrator/internal/analysis/analyze_test.go
@@ -2551,3 +2551,88 @@ func TestCollectAnalyzeResult_UseCaseNoTestSuiteField(t *testing.T) {
 		t.Errorf("expected no missing test_suite refs when field absent, got %v", result.MissingTestSuiteRefs)
 	}
 }
+
+// --- GH-2145: per-entry bare touchpoint detection ---
+
+func TestBareTouchpointEntriesFlagsNonCitingTouchpoints(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	os.WriteFile("docs/specs/software-requirements/srd001-foo.yaml",
+		[]byte("id: srd001-foo\ntitle: Foo\nrequirements:\n  R1:\n    title: Req 1\n    items:\n      - R1.1: Do X\n"), 0o644)
+	uc := `id: rel01.0-uc001-base32
+title: Base32
+touchpoints:
+  - T1: "cmd/foo — does things (srd001-foo R1)"
+  - T2: "pkg/testutils — RunDiffTests helper"
+  - T3: "pkg/sys — InstallSIGPIPEHandler"
+`
+	os.WriteFile("docs/specs/use-cases/rel01.0-uc001-base32.yaml", []byte(uc), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BareTouchpointEntries) != 2 {
+		t.Fatalf("expected 2 bare entries (T2 and T3), got %d: %v", len(result.BareTouchpointEntries), result.BareTouchpointEntries)
+	}
+	for _, entry := range result.BareTouchpointEntries {
+		if !strings.Contains(entry, "rel01.0-uc001-base32") {
+			t.Errorf("expected entry to name the use case, got %q", entry)
+		}
+		if !strings.Contains(entry, "touchpoint[") {
+			t.Errorf("expected entry to include indexed touchpoint label, got %q", entry)
+		}
+	}
+}
+
+func TestBareTouchpointEntriesEmptyWhenAllCite(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(orig)
+	setupMinimalAnalyzeDir(t)
+
+	os.WriteFile("docs/specs/software-requirements/srd001-foo.yaml",
+		[]byte("id: srd001-foo\ntitle: Foo\nrequirements:\n  R1:\n    title: Req 1\n    items:\n      - R1.1: Do X\n"), 0o644)
+	os.WriteFile("docs/specs/software-requirements/srd002-bar.yaml",
+		[]byte("id: srd002-bar\ntitle: Bar\nrequirements:\n  R1:\n    title: Req 1\n    items:\n      - R1.1: Do Y\n"), 0o644)
+	uc := `id: rel01.0-uc001-init
+title: Init
+touchpoints:
+  - T1: "cmd/foo (srd001-foo R1)"
+  - T2: "pkg/bar — srd002-bar R1"
+`
+	os.WriteFile("docs/specs/use-cases/rel01.0-uc001-init.yaml", []byte(uc), 0o644)
+
+	result, _, err := CollectAnalyzeResult(noopDeps())
+	if err != nil {
+		t.Fatalf("CollectAnalyzeResult: %v", err)
+	}
+	if len(result.BareTouchpointEntries) != 0 {
+		t.Errorf("expected no bare entries when every touchpoint cites an SRD, got %v", result.BareTouchpointEntries)
+	}
+}
+
+func TestPrintReportIncludesBareTouchpointEntries(t *testing.T) {
+	r := AnalyzeResult{
+		BareTouchpointEntries: []string{
+			`rel01.0-uc001-base32 touchpoint[1]: "pkg/testutils — RunDiffTests helper" has no srd*-id reference`,
+		},
+	}
+	out := captureStdout(t, func() {
+		err := r.PrintReport(1, 1, 1, 0)
+		if err != nil {
+			t.Errorf("expected nil error for warning-only report, got %v", err)
+		}
+	})
+	if !strings.Contains(out, "Bare touchpoint entries") {
+		t.Errorf("output missing bare-entries section header, got %q", out)
+	}
+	if !strings.Contains(out, "No hard errors (1 warnings") {
+		t.Errorf("expected bare entries to count toward warning total, got %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #2145. Adds a per-entry `mage analyze` check that warns when a single touchpoint string carries no `srd*`-prefixed token, even if other touchpoints on the same use case do cite an SRD. Closes the gap that let prose-form touchpoints like `pkg/testutils — RunDiffTests helper` slip past the use-case-level orphan check.

## Changes

- New `BareTouchpointEntries` slice on `AnalyzeResult` (warning, GH-2145).
- New Check 1b in `CollectAnalyzeResult` loops over each `(ucID, i, touchpoint)` and records a warning when the touchpoint has no `srd*` token.
- New helpers `truncate(s, n string)` and `touchpointEntryCitesSRD(tp string) bool` near `ExtractID` / `ExtractSRDsFromTouchpoints`.
- `PrintReport` prints a new section and adds the count to the `warningCount` sum used in the headline.
- Three new tests in `analyze_test.go`.

## Stats

```
Lines of code (Go, production): 20824 (+43)
Lines of code (Go, tests):      37976 (+85)
Words (documentation):          21010 (+0)
```

## Test plan

- [x] `go test ./...` passes
- [x] `mage analyze` on this repo now surfaces 8 bare-entry warnings (warning count 63 → 71); headline reads `✅ No hard errors (71 warnings — see above)`
- [ ] Regression on `petar-djukic/go-unix-utils @ ea1429b4`: expect roughly 2N new warnings where N = use cases, as predicted in the issue's Test Plan. Needs a separate cross-repo run.

Closes #2145