### PR TITLE
GH-2149: Add paper and experiments constitution templates

### DIFF
--- a/docs/constitutions/experiments.yaml
+++ b/docs/constitutions/experiments.yaml
@@ -1,0 +1,103 @@
+# Experiments Constitution
+#
+# This constitution governs sessions that propose, run, or analyze experiments.
+# Include it in a project that reports empirical results. Scaffold it alongside
+# the other constitutions; analyze activates its mechanical checks only when this
+# file is present.
+#
+# Each article records how it is enforced. An article marked "analyze" is checked
+# mechanically by mage analyze. An article marked "advisory" states a rule that a
+# human reviewer applies; analyze does not check it. These articles generalize
+# the lessons of an experiment program learned the expensive way.
+
+articles:
+  - id: E1
+    title: Instruments are deterministic
+    enforcement: advisory
+    rule: |
+      No judge model, learned classifier, or stochastic component sits anywhere
+      in a measurement pipeline. Two readers of the same artifacts reach the same
+      result. A measurement whose value depends on a sampled model output is not a
+      measurement.
+
+  - id: E2
+    title: Gate before numbers
+    enforcement: analyze
+    rule: |
+      Every experiment declares its question, its claims, its apparatus, and both
+      interpretations — the pass reading and the fail reading — in the evidence
+      manifest before any run. The gate is stated before data exists. An
+      experiment that holds a result without a complete gate is a violation. The
+      gate fields live in project_registry.
+
+  - id: E3
+    title: Artifact retention
+    enforcement: advisory
+    rule: |
+      Every run retains what re-derivation needs: traces, final states, seeds, and
+      configs. A result that cannot be re-derived from committed artifacts does not
+      exist. We commit the artifacts with the result, not a summary of them.
+
+  - id: E4
+    title: Determinism under seed
+    enforcement: advisory
+    rule: |
+      Generators and harnesses are reproducible under recorded seeds. The same
+      seed yields the same run. The seed is part of the retained artifacts named
+      in E3.
+
+  - id: E5
+    title: Negative results are recorded, not rerun
+    enforcement: analyze
+    rule: |
+      A failed gate produces a decision memo and a design revision, never a quiet
+      retry until green. A failed experiment with no memo in the memo directory is
+      a violation. The memo records what the fail reading meant and what the design
+      does about it. The memo directory lives in project_registry.
+
+  - id: E6
+    title: Manifest is the source of truth
+    enforcement: analyze
+    rule: |
+      Experiment status lives in the evidence manifest. Issues and papers
+      reference manifest ids. A reference to an experiment id that does not resolve
+      to a manifest entry is a violation. The manifest path lives in
+      project_registry.
+
+# project_registry holds the project-specific values the articles reference.
+# The template ships these with sensible defaults; the consuming project adjusts
+# them. analyze reads this block to run the E2, E5, and E6 checks.
+project_registry:
+  # E2, E5, E6: the evidence manifest, the source of truth for experiment status.
+  # Path is relative to the repository root.
+  manifest_path: docs/experiments/manifest.yaml
+
+  # E2: the fields every experiment declares before a run. An experiment holding
+  # a result must carry all of these.
+  gate_fields:
+    - question
+    - claims
+    - apparatus
+    - interpret_pass
+    - interpret_fail
+
+  # E5: the directory holding a decision memo for each failed gate. A failed
+  # experiment must have a memo here.
+  memo_dir: docs/experiments/decisions
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Six articles govern experiments: deterministic instruments that two readers
+      read alike, a gate declared before numbers exist, artifact retention that
+      makes every result re-derivable, determinism under a recorded seed, negative
+      results recorded in a memo rather than retried, and a manifest that holds the
+      single source of truth for experiment status.
+  - tag: project_registry
+    title: Project Registry
+    content: |
+      The registry holds the project-specific values the articles reference: the
+      manifest path, the gate fields, and the memo directory. Analyze reads the
+      registry to run the mechanical checks. A project without experiments leaves
+      this file unscaffolded.

--- a/docs/constitutions/paper.yaml
+++ b/docs/constitutions/paper.yaml
@@ -1,0 +1,113 @@
+# Paper Constitution
+#
+# This constitution governs sessions that touch publication prose: papers,
+# preprints, and the figures and tables that accompany them. Include it in a
+# project that produces a written publication (for example an AAAI or NeurIPS
+# submission). Scaffold it alongside the other constitutions; analyze activates
+# its mechanical checks only when this file is present.
+#
+# Each article records how it is enforced. An article marked "analyze" is
+# checked mechanically by mage analyze. An article marked "advisory" states a
+# rule that a human reviewer applies; analyze does not check it.
+
+articles:
+  - id: P1
+    title: Vocabulary registry
+    enforcement: analyze
+    rule: |
+      The project declares its fixed terms of art in one place, the vocabulary
+      block of project_registry. Publication prose uses registry terms and no
+      others for the concepts they name. Coined internal names — pattern-language
+      labels, codenames, working titles — never appear in publication prose. When
+      a concept earns a name in the paper, that name enters the registry first.
+
+  - id: P2
+    title: Verdict neutrality
+    enforcement: advisory
+    rule: |
+      No section asserts an experimental outcome that does not trace to a
+      committed decision memo. Pre-written verdict prose is a violation even when
+      a placeholder guards the number. We describe apparatus and method before
+      results exist; we state the outcome only after the memo that records it
+      lands in the repository.
+
+  - id: P3
+    title: Placeholder traceability
+    enforcement: analyze
+    rule: |
+      Every data placeholder names its source artifact. Filling a placeholder
+      requires that artifact to exist in the repository. A placeholder whose
+      artifact is absent is a violation. Zero placeholders is a release gate: the
+      paper does not ship while any placeholder remains. The placeholder pattern
+      lives in project_registry.
+
+  - id: P4
+    title: Citation integrity
+    enforcement: analyze
+    rule: |
+      Every citation key resolves against the bibliography. The build fails on an
+      unresolved key. A single-pass build that renders a bare marker in place of
+      a citation is a violation. The bibliography files live in project_registry.
+
+  - id: P5
+    title: Forbidden terms
+    enforcement: analyze
+    rule: |
+      The project declares a forbidden-terms list in project_registry. Analyze
+      greps publication prose and reports each occurrence. The list holds the
+      words the project has chosen to avoid — marketing adjectives, hedges, and
+      house style-guide bans.
+
+  - id: P6
+    title: Auditability
+    enforcement: advisory
+    rule: |
+      Every article in this constitution is either checked mechanically by
+      analyze or marked advisory. An article with no enforcement value is itself
+      a violation. Adding an article obliges the author to state how it is
+      enforced.
+
+# project_registry holds the project-specific values the articles reference.
+# The template ships these empty or with sensible defaults; the consuming
+# project fills them. analyze reads this block to run the P1, P3, P4, and P5
+# checks.
+project_registry:
+  # P1: term -> definition. The fixed terms of art. Prose uses these names for
+  # their concepts and no coined alternatives.
+  vocabulary: {}
+
+  # P5: terms analyze greps for in publication prose. Each occurrence is
+  # reported.
+  forbidden_terms: []
+
+  # P3: the regular expression that matches a data placeholder. The first
+  # capture group names the source artifact the placeholder depends on.
+  placeholder_pattern: '\{\{DATA:([^}]+)\}\}'
+
+  # P1, P3, P5: the files treated as publication prose. Globs are relative to
+  # the repository root.
+  prose_globs:
+    - paper/**/*.md
+    - paper/**/*.tex
+
+  # P4: the bibliography files whose keys a citation may resolve against.
+  bibliography:
+    - paper/references.bib
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Six articles govern publication prose: a vocabulary registry that fixes the
+      terms of art, verdict neutrality that forbids outcomes without a memo,
+      placeholder traceability that ties every number to an artifact, citation
+      integrity that fails the build on an unresolved key, a forbidden-terms list
+      the build enforces, and auditability that obliges every article to declare
+      how it is checked.
+  - tag: project_registry
+    title: Project Registry
+    content: |
+      The registry holds the project-specific values the articles reference: the
+      vocabulary, the forbidden-terms list, the placeholder pattern, the prose
+      globs, and the bibliography. Analyze reads the registry to run the
+      mechanical checks. A project without a paper leaves this file unscaffolded.

--- a/docs/engineering/eng03-project-initialization.yaml
+++ b/docs/engineering/eng03-project-initialization.yaml
@@ -59,6 +59,8 @@ sections:
             design.yaml                 — specification authoring rules (editable)
             planning.yaml               — measure phase rules (editable)
             execution.yaml              — stitch phase rules (editable)
+            paper.yaml                  — publication prose rules (editable)
+            experiments.yaml            — experiment program rules (editable)
         magefiles/
           orchestrator.go               — Mage targets (copied from orchestrator repo)
           version.go.tmpl               — version seed template (if main package found)
@@ -67,6 +69,15 @@ sections:
 
       The magefiles/ directory keeps build tooling dependencies separate from
       the project's own go.mod.
+
+      Scaffold delivers every constitution, but two of them apply only to some
+      projects. Include paper.yaml in a project that produces a written
+      publication; its articles govern vocabulary, citations, and placeholders in
+      publication prose. Include experiments.yaml in a project that reports
+      empirical results; its articles govern the experiment gate, artifact
+      retention, and the evidence manifest. A project that does neither may delete
+      both files. Analyze runs a constitution's mechanical checks only when its
+      file is present, so an unused constitution costs nothing.
 
   - title: Claude Execution Modes
     content: |

--- a/magefiles/magefile.go
+++ b/magefiles/magefile.go
@@ -49,6 +49,9 @@ type Validate mg.Namespace
 // Constitution groups constitution preview targets.
 type Constitution mg.Namespace
 
+// Paper groups the paper build and placeholder-report targets.
+type Paper mg.Namespace
+
 // baseCfg holds the configuration loaded from configuration.yaml.
 var baseCfg orchestrator.Config
 
@@ -358,3 +361,13 @@ func (Validate) Weights(input string) error { return newOrch().ValidateTaskWeigh
 // Preview reads a constitution YAML file and prints its sections as markdown to stdout.
 // Pass the path to a constitution YAML file (e.g., mage constitution:preview pkg/orchestrator/constitutions/execution.yaml).
 func (Constitution) Preview(file string) error { return newOrch().ConstitutionPreviewFile(file) }
+
+// --- Paper targets ---
+
+// Pdf builds the paper PDF from paper/paper.md via pandoc + pdflatex + bibtex +
+// pdflatex + pdflatex. It requires pandoc and a LaTeX distribution on PATH and
+// returns a clear error naming the first missing binary.
+func (Paper) Pdf() error { return orchestrator.BuildPaperPDF("") }
+
+// Placeholders counts and reports the data placeholders remaining under paper/.
+func (Paper) Placeholders() error { return orchestrator.ReportPaperPlaceholders("") }

--- a/orchestrator.go.tmpl
+++ b/orchestrator.go.tmpl
@@ -28,6 +28,9 @@ type Prompt mg.Namespace
 // Stats groups the stats targets (LOC, tokens).
 type Stats mg.Namespace
 
+// Paper groups the paper build and placeholder-report targets.
+type Paper mg.Namespace
+
 // Tests: run directly with go test:
 //   go test -tags=usecase -v -count=1 -timeout 1800s ./tests/rel01.0/...          # all
 //   go test -tags=usecase -v ./tests/rel01.0/uc001/                               # one UC
@@ -143,6 +146,16 @@ func (Stats) Tokens() error { return newOrch().TokenStats() }
 
 // Generator prints a status report for the current generation run.
 func (Stats) Generator() error { return newOrch().Stats.GeneratorStats() }
+
+// --- Paper targets ---
+
+// Pdf builds the paper PDF from paper/paper.md via pandoc + pdflatex + bibtex +
+// pdflatex + pdflatex. It requires pandoc and a LaTeX distribution on PATH and
+// returns a clear error naming the first missing binary.
+func (Paper) Pdf() error { return orchestrator.BuildPaperPDF("") }
+
+// Placeholders counts and reports the data placeholders remaining under paper/.
+func (Paper) Placeholders() error { return orchestrator.ReportPaperPlaceholders("") }
 
 // --- Prompt targets ---
 

--- a/pkg/orchestrator/commands.go
+++ b/pkg/orchestrator/commands.go
@@ -21,6 +21,9 @@ const (
 	binLint     = "golangci-lint"
 	binMage     = "mage"
 	binSecurity = "security"
+	binPandoc   = "pandoc"
+	binPdflatex = "pdflatex"
+	binBibtex   = "bibtex"
 )
 
 // Directory and file path constants.

--- a/pkg/orchestrator/constitutions/experiments.yaml
+++ b/pkg/orchestrator/constitutions/experiments.yaml
@@ -1,0 +1,103 @@
+# Experiments Constitution
+#
+# This constitution governs sessions that propose, run, or analyze experiments.
+# Include it in a project that reports empirical results. Scaffold it alongside
+# the other constitutions; analyze activates its mechanical checks only when this
+# file is present.
+#
+# Each article records how it is enforced. An article marked "analyze" is checked
+# mechanically by mage analyze. An article marked "advisory" states a rule that a
+# human reviewer applies; analyze does not check it. These articles generalize
+# the lessons of an experiment program learned the expensive way.
+
+articles:
+  - id: E1
+    title: Instruments are deterministic
+    enforcement: advisory
+    rule: |
+      No judge model, learned classifier, or stochastic component sits anywhere
+      in a measurement pipeline. Two readers of the same artifacts reach the same
+      result. A measurement whose value depends on a sampled model output is not a
+      measurement.
+
+  - id: E2
+    title: Gate before numbers
+    enforcement: analyze
+    rule: |
+      Every experiment declares its question, its claims, its apparatus, and both
+      interpretations — the pass reading and the fail reading — in the evidence
+      manifest before any run. The gate is stated before data exists. An
+      experiment that holds a result without a complete gate is a violation. The
+      gate fields live in project_registry.
+
+  - id: E3
+    title: Artifact retention
+    enforcement: advisory
+    rule: |
+      Every run retains what re-derivation needs: traces, final states, seeds, and
+      configs. A result that cannot be re-derived from committed artifacts does not
+      exist. We commit the artifacts with the result, not a summary of them.
+
+  - id: E4
+    title: Determinism under seed
+    enforcement: advisory
+    rule: |
+      Generators and harnesses are reproducible under recorded seeds. The same
+      seed yields the same run. The seed is part of the retained artifacts named
+      in E3.
+
+  - id: E5
+    title: Negative results are recorded, not rerun
+    enforcement: analyze
+    rule: |
+      A failed gate produces a decision memo and a design revision, never a quiet
+      retry until green. A failed experiment with no memo in the memo directory is
+      a violation. The memo records what the fail reading meant and what the design
+      does about it. The memo directory lives in project_registry.
+
+  - id: E6
+    title: Manifest is the source of truth
+    enforcement: analyze
+    rule: |
+      Experiment status lives in the evidence manifest. Issues and papers
+      reference manifest ids. A reference to an experiment id that does not resolve
+      to a manifest entry is a violation. The manifest path lives in
+      project_registry.
+
+# project_registry holds the project-specific values the articles reference.
+# The template ships these with sensible defaults; the consuming project adjusts
+# them. analyze reads this block to run the E2, E5, and E6 checks.
+project_registry:
+  # E2, E5, E6: the evidence manifest, the source of truth for experiment status.
+  # Path is relative to the repository root.
+  manifest_path: docs/experiments/manifest.yaml
+
+  # E2: the fields every experiment declares before a run. An experiment holding
+  # a result must carry all of these.
+  gate_fields:
+    - question
+    - claims
+    - apparatus
+    - interpret_pass
+    - interpret_fail
+
+  # E5: the directory holding a decision memo for each failed gate. A failed
+  # experiment must have a memo here.
+  memo_dir: docs/experiments/decisions
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Six articles govern experiments: deterministic instruments that two readers
+      read alike, a gate declared before numbers exist, artifact retention that
+      makes every result re-derivable, determinism under a recorded seed, negative
+      results recorded in a memo rather than retried, and a manifest that holds the
+      single source of truth for experiment status.
+  - tag: project_registry
+    title: Project Registry
+    content: |
+      The registry holds the project-specific values the articles reference: the
+      manifest path, the gate fields, and the memo directory. Analyze reads the
+      registry to run the mechanical checks. A project without experiments leaves
+      this file unscaffolded.

--- a/pkg/orchestrator/constitutions/paper.yaml
+++ b/pkg/orchestrator/constitutions/paper.yaml
@@ -1,0 +1,113 @@
+# Paper Constitution
+#
+# This constitution governs sessions that touch publication prose: papers,
+# preprints, and the figures and tables that accompany them. Include it in a
+# project that produces a written publication (for example an AAAI or NeurIPS
+# submission). Scaffold it alongside the other constitutions; analyze activates
+# its mechanical checks only when this file is present.
+#
+# Each article records how it is enforced. An article marked "analyze" is
+# checked mechanically by mage analyze. An article marked "advisory" states a
+# rule that a human reviewer applies; analyze does not check it.
+
+articles:
+  - id: P1
+    title: Vocabulary registry
+    enforcement: analyze
+    rule: |
+      The project declares its fixed terms of art in one place, the vocabulary
+      block of project_registry. Publication prose uses registry terms and no
+      others for the concepts they name. Coined internal names — pattern-language
+      labels, codenames, working titles — never appear in publication prose. When
+      a concept earns a name in the paper, that name enters the registry first.
+
+  - id: P2
+    title: Verdict neutrality
+    enforcement: advisory
+    rule: |
+      No section asserts an experimental outcome that does not trace to a
+      committed decision memo. Pre-written verdict prose is a violation even when
+      a placeholder guards the number. We describe apparatus and method before
+      results exist; we state the outcome only after the memo that records it
+      lands in the repository.
+
+  - id: P3
+    title: Placeholder traceability
+    enforcement: analyze
+    rule: |
+      Every data placeholder names its source artifact. Filling a placeholder
+      requires that artifact to exist in the repository. A placeholder whose
+      artifact is absent is a violation. Zero placeholders is a release gate: the
+      paper does not ship while any placeholder remains. The placeholder pattern
+      lives in project_registry.
+
+  - id: P4
+    title: Citation integrity
+    enforcement: analyze
+    rule: |
+      Every citation key resolves against the bibliography. The build fails on an
+      unresolved key. A single-pass build that renders a bare marker in place of
+      a citation is a violation. The bibliography files live in project_registry.
+
+  - id: P5
+    title: Forbidden terms
+    enforcement: analyze
+    rule: |
+      The project declares a forbidden-terms list in project_registry. Analyze
+      greps publication prose and reports each occurrence. The list holds the
+      words the project has chosen to avoid — marketing adjectives, hedges, and
+      house style-guide bans.
+
+  - id: P6
+    title: Auditability
+    enforcement: advisory
+    rule: |
+      Every article in this constitution is either checked mechanically by
+      analyze or marked advisory. An article with no enforcement value is itself
+      a violation. Adding an article obliges the author to state how it is
+      enforced.
+
+# project_registry holds the project-specific values the articles reference.
+# The template ships these empty or with sensible defaults; the consuming
+# project fills them. analyze reads this block to run the P1, P3, P4, and P5
+# checks.
+project_registry:
+  # P1: term -> definition. The fixed terms of art. Prose uses these names for
+  # their concepts and no coined alternatives.
+  vocabulary: {}
+
+  # P5: terms analyze greps for in publication prose. Each occurrence is
+  # reported.
+  forbidden_terms: []
+
+  # P3: the regular expression that matches a data placeholder. The first
+  # capture group names the source artifact the placeholder depends on.
+  placeholder_pattern: '\{\{DATA:([^}]+)\}\}'
+
+  # P1, P3, P5: the files treated as publication prose. Globs are relative to
+  # the repository root.
+  prose_globs:
+    - paper/**/*.md
+    - paper/**/*.tex
+
+  # P4: the bibliography files whose keys a citation may resolve against.
+  bibliography:
+    - paper/references.bib
+
+sections:
+  - tag: articles
+    title: Core Principles
+    content: |
+      Six articles govern publication prose: a vocabulary registry that fixes the
+      terms of art, verdict neutrality that forbids outcomes without a memo,
+      placeholder traceability that ties every number to an artifact, citation
+      integrity that fails the build on an unresolved key, a forbidden-terms list
+      the build enforces, and auditability that obliges every article to declare
+      how it is checked.
+  - tag: project_registry
+    title: Project Registry
+    content: |
+      The registry holds the project-specific values the articles reference: the
+      vocabulary, the forbidden-terms list, the placeholder pattern, the prose
+      globs, and the bibliography. Analyze reads the registry to run the
+      mechanical checks. A project without a paper leaves this file unscaffolded.

--- a/pkg/orchestrator/internal/analysis/analyze.go
+++ b/pkg/orchestrator/internal/analysis/analyze.go
@@ -17,40 +17,40 @@ import (
 
 // AnalyzeResult holds the results of the Analyze operation.
 type AnalyzeResult struct {
-	OrphanedSRDs              []string // SRDs with no use cases referencing them
-	ReleasesWithoutTestSuites []string // Releases in road-map.yaml with no test-rel*.yaml file
-	OrphanedTestSuites        []string // Test suites whose traces don't match any known use case
-	BrokenTouchpoints         []string // Use case touchpoints referencing non-existent SRDs
-	UseCasesNotInRoadmap      []string // Use cases not listed in road-map.yaml
-	SchemaErrors              []string // YAML files with fields not matching typed structs
-	ConstitutionDrift         []string // Files in docs/constitutions/ that differ from embedded copies
-	BrokenCitations                []string // Touchpoints citing non-existent requirement groups in SRDs
-	InvalidReleases                []string // Configured releases not found in road-map.yaml
-	SRDsSpanningMultipleReleases   []string // SRDs referenced by use cases from more than one release
-	DependsOnViolations            []string // depends_on symbols not in referenced package_contract, or srd_id missing
-	DependencyRuleViolations       []string // component_dependencies violating an allowed=false dependency_rule
-	BrokenStructRefs               []string // struct_refs pointing to non-existent SRD or requirement group
-	ComponentDepViolations         []string // depends_on entries not reflected in component_dependencies
-	SemanticModelErrors            []string // semantic model validation errors (SM1, SM3, SM7)
-	UncoveredRItems                []string // R-items not covered by any acceptance criterion
-	UncoveredACs                   []string // ACs not covered by any test case (warning)
-	UntracedSuccessCriteria        []string // S-items with no AC traces (warning)
-	UnreachableUCs                 []string // UCs whose touchpoint SRDs have no R-items (warning)
-	FailedRequirements             []string // R-items marked complete_with_failures (warning)
+	OrphanedSRDs                 []string // SRDs with no use cases referencing them
+	ReleasesWithoutTestSuites    []string // Releases in road-map.yaml with no test-rel*.yaml file
+	OrphanedTestSuites           []string // Test suites whose traces don't match any known use case
+	BrokenTouchpoints            []string // Use case touchpoints referencing non-existent SRDs
+	UseCasesNotInRoadmap         []string // Use cases not listed in road-map.yaml
+	SchemaErrors                 []string // YAML files with fields not matching typed structs
+	ConstitutionDrift            []string // Files in docs/constitutions/ that differ from embedded copies
+	BrokenCitations              []string // Touchpoints citing non-existent requirement groups in SRDs
+	InvalidReleases              []string // Configured releases not found in road-map.yaml
+	SRDsSpanningMultipleReleases []string // SRDs referenced by use cases from more than one release
+	DependsOnViolations          []string // depends_on symbols not in referenced package_contract, or srd_id missing
+	DependencyRuleViolations     []string // component_dependencies violating an allowed=false dependency_rule
+	BrokenStructRefs             []string // struct_refs pointing to non-existent SRD or requirement group
+	ComponentDepViolations       []string // depends_on entries not reflected in component_dependencies
+	SemanticModelErrors          []string // semantic model validation errors (SM1, SM3, SM7)
+	UncoveredRItems              []string // R-items not covered by any acceptance criterion
+	UncoveredACs                 []string // ACs not covered by any test case (warning)
+	UntracedSuccessCriteria      []string // S-items with no AC traces (warning)
+	UnreachableUCs               []string // UCs whose touchpoint SRDs have no R-items (warning)
+	FailedRequirements           []string // R-items marked complete_with_failures (warning)
 	// MissingWeights removed — weights live in requirements.yaml, not SRDs (GH-2080).
-	BareTouchpoints                []string // Touchpoints citing SRDs without R-group references (warning, GH-1961)
-	UCIDPrefixMismatch             []string // Use case ID prefix doesn't match assigned release in roadmap (GH-1964)
-	BrokenInterfaceRefs            []string // implemented_by/used_by references non-existent architecture interface (GH-1968)
-	MissingSpecFiles               []string // spec_file declared in ARCHITECTURE.yaml but file does not exist (GH-1990)
-	MissingTestSuiteRefs           []string // Use cases whose test_suite field references a non-existent test suite (GH-2140 Gap 1)
-	BareTouchpointEntries          []string // Individual touchpoint entries with no SRD reference (warning, GH-2145)
-	PaperVocabularyIssues          []string // P1: prose exists but vocabulary registry empty (warning, GH-2149)
-	PaperPlaceholderErrors         []string // P3: placeholder names no artifact or artifact absent (GH-2149)
-	PaperBrokenCitations           []string // P4: citation key unresolved against bibliography (GH-2149)
-	PaperForbiddenTerms            []string // P5: forbidden term occurs in publication prose (warning, GH-2149)
-	ExperimentGateViolations       []string // E2: experiment missing a declared gate field (GH-2149)
-	ExperimentMissingMemos         []string // E5: failed experiment with no decision memo (warning, GH-2149)
-	ExperimentManifestErrors       []string // E6: manifest integrity or unresolved id reference (GH-2149)
+	BareTouchpoints          []string // Touchpoints citing SRDs without R-group references (warning, GH-1961)
+	UCIDPrefixMismatch       []string // Use case ID prefix doesn't match assigned release in roadmap (GH-1964)
+	BrokenInterfaceRefs      []string // implemented_by/used_by references non-existent architecture interface (GH-1968)
+	MissingSpecFiles         []string // spec_file declared in ARCHITECTURE.yaml but file does not exist (GH-1990)
+	MissingTestSuiteRefs     []string // Use cases whose test_suite field references a non-existent test suite (GH-2140 Gap 1)
+	BareTouchpointEntries    []string // Individual touchpoint entries with no SRD reference (warning, GH-2145)
+	PaperVocabularyIssues    []string // P1: prose exists but vocabulary registry empty (warning, GH-2149)
+	PaperPlaceholderErrors   []string // P3: placeholder names no artifact or artifact absent (GH-2149)
+	PaperBrokenCitations     []string // P4: citation key unresolved against bibliography (GH-2149)
+	PaperForbiddenTerms      []string // P5: forbidden term occurs in publication prose (warning, GH-2149)
+	ExperimentGateViolations []string // E2: experiment missing a declared gate field (GH-2149)
+	ExperimentMissingMemos   []string // E5: failed experiment with no decision memo (warning, GH-2149)
+	ExperimentManifestErrors []string // E6: manifest integrity or unresolved id reference (GH-2149)
 }
 
 // AnalyzeCounts holds the artifact counts discovered during analysis.
@@ -64,7 +64,7 @@ type AnalyzeCounts struct {
 // AnalyzeDeps holds dependencies for analysis operations.
 type AnalyzeDeps struct {
 	Log                    Logger
-	Releases               []string             // configured release versions
+	Releases               []string              // configured release versions
 	ValidateDocSchemas     func() []string       // schema validation (uses context types)
 	ValidatePromptTemplate func(string) []string // prompt template validation
 }
@@ -82,13 +82,13 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 		return result, AnalyzeCounts{}, fmt.Errorf("globbing SRDs: %w", err)
 	}
 	srdIDs := make(map[string]bool)
-	srdReqGroups := make(map[string]map[string]bool)    // SRD ID -> set of requirement group keys
-	srdExports := make(map[string]map[string]bool)       // SRD ID -> set of exported symbol names
-	srdDependsOn := make(map[string][]SRDDependsOn)      // SRD ID -> depends_on entries
-	srdStructRefs := make(map[string][]SRDStructRef)     // SRD ID -> struct_refs entries
-	srdACs := make(map[string][]AcceptanceCriterion)     // SRD ID -> acceptance criteria
-	srdRItems := make(map[string][]string)               // SRD ID -> all R-item IDs (R1.1, R1.2, etc.)
-	srdInterfaceRefs := make(map[string][]string)        // SRD ID -> all interface names from implemented_by + used_by
+	srdReqGroups := make(map[string]map[string]bool) // SRD ID -> set of requirement group keys
+	srdExports := make(map[string]map[string]bool)   // SRD ID -> set of exported symbol names
+	srdDependsOn := make(map[string][]SRDDependsOn)  // SRD ID -> depends_on entries
+	srdStructRefs := make(map[string][]SRDStructRef) // SRD ID -> struct_refs entries
+	srdACs := make(map[string][]AcceptanceCriterion) // SRD ID -> acceptance criteria
+	srdRItems := make(map[string][]string)           // SRD ID -> all R-item IDs (R1.1, R1.2, etc.)
+	srdInterfaceRefs := make(map[string][]string)    // SRD ID -> all interface names from implemented_by + used_by
 	for _, path := range srdFiles {
 		id := ExtractID(path)
 		if id != "" {
@@ -148,11 +148,11 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 		return result, AnalyzeCounts{}, fmt.Errorf("globbing use cases: %w", err)
 	}
 	ucIDs := make(map[string]bool)
-	ucToSRDs := make(map[string][]string)      // use case ID -> SRD IDs from touchpoints
-	ucTouchpoints := make(map[string][]string) // use case ID -> raw touchpoint strings
+	ucToSRDs := make(map[string][]string)                    // use case ID -> SRD IDs from touchpoints
+	ucTouchpoints := make(map[string][]string)               // use case ID -> raw touchpoint strings
 	ucSuccessCriteria := make(map[string][]SuccessCriterion) // use case ID -> success criteria
-	ucToTestSuite := make(map[string]string)   // use case ID -> declared test_suite reference (GH-2140 Gap 1)
-	srdToReleases := make(map[string]map[string]bool) // SRD ID -> set of releases that reference it
+	ucToTestSuite := make(map[string]string)                 // use case ID -> declared test_suite reference (GH-2140 Gap 1)
+	srdToReleases := make(map[string]map[string]bool)        // SRD ID -> set of releases that reference it
 	for _, path := range ucFiles {
 		uc, err := LoadUseCase(path)
 		if err != nil {
@@ -206,10 +206,10 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 
 	// 4. Load road-map.yaml — collect release IDs, use case IDs, and depends_on
 	roadmapUCs := make(map[string]bool)
-	roadmapUCToRelease := make(map[string]string)            // use case ID -> assigned release version
+	roadmapUCToRelease := make(map[string]string) // use case ID -> assigned release version
 	roadmapReleaseIDs := make(map[string]bool)
-	roadmapAllVersions := make(map[string]bool)             // all release versions (including those without UCs)
-	releaseDependsOn := make(map[string][]string)            // release version -> depends_on entries
+	roadmapAllVersions := make(map[string]bool)   // all release versions (including those without UCs)
+	releaseDependsOn := make(map[string][]string) // release version -> depends_on entries
 	if data, err := os.ReadFile("docs/road-map.yaml"); err == nil {
 		var roadmap struct {
 			Releases []struct {
@@ -762,9 +762,9 @@ type AnalyzeUseCase struct {
 // AnalyzeTestSuite holds the fields extracted from a test suite file
 // that are needed for cross-artifact consistency checks.
 type AnalyzeTestSuite struct {
-	ID        string              `yaml:"id"`
-	Traces    []string            `yaml:"traces"`
-	TestCases []AnalyzeTestCase   `yaml:"test_cases"`
+	ID        string            `yaml:"id"`
+	Traces    []string          `yaml:"traces"`
+	TestCases []AnalyzeTestCase `yaml:"test_cases"`
 }
 
 // AnalyzeTestCase holds the fields of a single test case within a

--- a/pkg/orchestrator/internal/analysis/analyze.go
+++ b/pkg/orchestrator/internal/analysis/analyze.go
@@ -44,6 +44,10 @@ type AnalyzeResult struct {
 	MissingSpecFiles               []string // spec_file declared in ARCHITECTURE.yaml but file does not exist (GH-1990)
 	MissingTestSuiteRefs           []string // Use cases whose test_suite field references a non-existent test suite (GH-2140 Gap 1)
 	BareTouchpointEntries          []string // Individual touchpoint entries with no SRD reference (warning, GH-2145)
+	PaperVocabularyIssues          []string // P1: prose exists but vocabulary registry empty (warning, GH-2149)
+	PaperPlaceholderErrors         []string // P3: placeholder names no artifact or artifact absent (GH-2149)
+	PaperBrokenCitations           []string // P4: citation key unresolved against bibliography (GH-2149)
+	PaperForbiddenTerms            []string // P5: forbidden term occurs in publication prose (warning, GH-2149)
 }
 
 // AnalyzeCounts holds the artifact counts discovered during analysis.
@@ -624,6 +628,16 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 	result.ConstitutionDrift = DetectConstitutionDrift(deps.Log)
 	deps.Log("analyze: constitution drift found %d file(s)", len(result.ConstitutionDrift))
 
+	// Check 8b: Paper constitution checks (P1, P3, P4, P5). No-op unless
+	// docs/constitutions/paper.yaml is scaffolded into the project.
+	paper := RunPaperChecks(deps.Log)
+	result.PaperVocabularyIssues = paper.VocabularyIssues
+	result.PaperPlaceholderErrors = paper.PlaceholderErrors
+	result.PaperBrokenCitations = paper.BrokenCitations
+	result.PaperForbiddenTerms = paper.ForbiddenTerms
+	deps.Log("analyze: paper checks found %d placeholder, %d citation error(s), %d forbidden-term, %d vocabulary warning(s)",
+		len(paper.PlaceholderErrors), len(paper.BrokenCitations), len(paper.ForbiddenTerms), len(paper.VocabularyIssues))
+
 	// Check 14: Semantic model validation.
 	smErrs, smCount := ValidateSemanticModels(srdFiles)
 	result.SemanticModelErrors = smErrs
@@ -682,6 +696,8 @@ func (r AnalyzeResult) PrintReport(srdCount, ucCount, tsCount, smCount int) erro
 	hasIssues = PrintSection("Broken interface refs (implemented_by/used_by references non-existent architecture interface)", r.BrokenInterfaceRefs) || hasIssues
 	hasIssues = PrintSection("Missing spec files (spec_file declared in ARCHITECTURE.yaml but file does not exist)", r.MissingSpecFiles) || hasIssues
 	hasIssues = PrintSection("Uncovered R-items (R-item not traced by any acceptance criterion)", r.UncoveredRItems) || hasIssues
+	hasIssues = PrintSection("Paper placeholder errors (placeholder names no artifact or artifact absent — P3)", r.PaperPlaceholderErrors) || hasIssues
+	hasIssues = PrintSection("Paper broken citations (citation key unresolved against bibliography — P4)", r.PaperBrokenCitations) || hasIssues
 	PrintSection("Uncovered ACs (AC not covered by any test case — warning)", r.UncoveredACs)
 	PrintSection("Untraced success criteria (S-item with no AC trace — warning)", r.UntracedSuccessCriteria)
 	PrintSection("Unreachable UCs (touchpoint SRDs have no R-items — warning)", r.UnreachableUCs)
@@ -689,6 +705,8 @@ func (r AnalyzeResult) PrintReport(srdCount, ucCount, tsCount, smCount int) erro
 	// MissingWeights print removed — weights live in requirements.yaml (GH-2080).
 	PrintSection("Bare touchpoints (SRD cited without R-group references — warning)", r.BareTouchpoints)
 	PrintSection("Bare touchpoint entries (no SRD citation in this individual touchpoint — warning)", r.BareTouchpointEntries)
+	PrintSection("Paper vocabulary registry empty (prose exists, no terms of art declared — P1 warning)", r.PaperVocabularyIssues)
+	PrintSection("Paper forbidden terms (declared forbidden term occurs in prose — P5 warning)", r.PaperForbiddenTerms)
 
 	// GH-2140 Gap 4: warnings must be reflected in the headline. Errors still
 	// flip the exit code; warnings only change the message.
@@ -697,7 +715,9 @@ func (r AnalyzeResult) PrintReport(srdCount, ucCount, tsCount, smCount int) erro
 		len(r.UnreachableUCs) +
 		len(r.FailedRequirements) +
 		len(r.BareTouchpoints) +
-		len(r.BareTouchpointEntries)
+		len(r.BareTouchpointEntries) +
+		len(r.PaperVocabularyIssues) +
+		len(r.PaperForbiddenTerms)
 
 	if hasIssues {
 		return fmt.Errorf("found consistency issues (see above)")

--- a/pkg/orchestrator/internal/analysis/analyze.go
+++ b/pkg/orchestrator/internal/analysis/analyze.go
@@ -48,6 +48,9 @@ type AnalyzeResult struct {
 	PaperPlaceholderErrors         []string // P3: placeholder names no artifact or artifact absent (GH-2149)
 	PaperBrokenCitations           []string // P4: citation key unresolved against bibliography (GH-2149)
 	PaperForbiddenTerms            []string // P5: forbidden term occurs in publication prose (warning, GH-2149)
+	ExperimentGateViolations       []string // E2: experiment missing a declared gate field (GH-2149)
+	ExperimentMissingMemos         []string // E5: failed experiment with no decision memo (warning, GH-2149)
+	ExperimentManifestErrors       []string // E6: manifest integrity or unresolved id reference (GH-2149)
 }
 
 // AnalyzeCounts holds the artifact counts discovered during analysis.
@@ -638,6 +641,15 @@ func CollectAnalyzeResult(deps AnalyzeDeps) (AnalyzeResult, AnalyzeCounts, error
 	deps.Log("analyze: paper checks found %d placeholder, %d citation error(s), %d forbidden-term, %d vocabulary warning(s)",
 		len(paper.PlaceholderErrors), len(paper.BrokenCitations), len(paper.ForbiddenTerms), len(paper.VocabularyIssues))
 
+	// Check 8c: Experiments constitution checks (E2, E5, E6). No-op unless
+	// docs/constitutions/experiments.yaml and its manifest are present.
+	experiments := RunExperimentChecks(deps.Log)
+	result.ExperimentGateViolations = experiments.GateViolations
+	result.ExperimentMissingMemos = experiments.MissingMemos
+	result.ExperimentManifestErrors = experiments.ManifestErrors
+	deps.Log("analyze: experiment checks found %d gate, %d manifest error(s), %d missing-memo warning(s)",
+		len(experiments.GateViolations), len(experiments.ManifestErrors), len(experiments.MissingMemos))
+
 	// Check 14: Semantic model validation.
 	smErrs, smCount := ValidateSemanticModels(srdFiles)
 	result.SemanticModelErrors = smErrs
@@ -698,6 +710,8 @@ func (r AnalyzeResult) PrintReport(srdCount, ucCount, tsCount, smCount int) erro
 	hasIssues = PrintSection("Uncovered R-items (R-item not traced by any acceptance criterion)", r.UncoveredRItems) || hasIssues
 	hasIssues = PrintSection("Paper placeholder errors (placeholder names no artifact or artifact absent — P3)", r.PaperPlaceholderErrors) || hasIssues
 	hasIssues = PrintSection("Paper broken citations (citation key unresolved against bibliography — P4)", r.PaperBrokenCitations) || hasIssues
+	hasIssues = PrintSection("Experiment gate violations (experiment missing a declared gate field — E2)", r.ExperimentGateViolations) || hasIssues
+	hasIssues = PrintSection("Experiment manifest errors (missing/duplicate id or unresolved exp:<id> reference — E6)", r.ExperimentManifestErrors) || hasIssues
 	PrintSection("Uncovered ACs (AC not covered by any test case — warning)", r.UncoveredACs)
 	PrintSection("Untraced success criteria (S-item with no AC trace — warning)", r.UntracedSuccessCriteria)
 	PrintSection("Unreachable UCs (touchpoint SRDs have no R-items — warning)", r.UnreachableUCs)
@@ -707,6 +721,7 @@ func (r AnalyzeResult) PrintReport(srdCount, ucCount, tsCount, smCount int) erro
 	PrintSection("Bare touchpoint entries (no SRD citation in this individual touchpoint — warning)", r.BareTouchpointEntries)
 	PrintSection("Paper vocabulary registry empty (prose exists, no terms of art declared — P1 warning)", r.PaperVocabularyIssues)
 	PrintSection("Paper forbidden terms (declared forbidden term occurs in prose — P5 warning)", r.PaperForbiddenTerms)
+	PrintSection("Experiment missing memos (failed gate has no decision memo — E5 warning)", r.ExperimentMissingMemos)
 
 	// GH-2140 Gap 4: warnings must be reflected in the headline. Errors still
 	// flip the exit code; warnings only change the message.
@@ -717,7 +732,8 @@ func (r AnalyzeResult) PrintReport(srdCount, ucCount, tsCount, smCount int) erro
 		len(r.BareTouchpoints) +
 		len(r.BareTouchpointEntries) +
 		len(r.PaperVocabularyIssues) +
-		len(r.PaperForbiddenTerms)
+		len(r.PaperForbiddenTerms) +
+		len(r.ExperimentMissingMemos)
 
 	if hasIssues {
 		return fmt.Errorf("found consistency issues (see above)")

--- a/pkg/orchestrator/internal/analysis/experiments.go
+++ b/pkg/orchestrator/internal/analysis/experiments.go
@@ -1,0 +1,253 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+// Experiments constitution checks. These enforce the mechanical articles of
+// docs/constitutions/experiments.yaml: E2 gate-before-numbers, E5
+// negative-results-recorded, and E6 manifest-as-truth. Every check is a no-op
+// unless the experiments constitution is scaffolded into the project and its
+// evidence manifest exists, mirroring how DetectConstitutionDrift gates on the
+// constitution files being present.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const experimentsConstitutionPath = "docs/constitutions/experiments.yaml"
+
+// experimentsRegistry mirrors the project_registry block of experiments.yaml.
+type experimentsRegistry struct {
+	ManifestPath string   `yaml:"manifest_path"`
+	GateFields   []string `yaml:"gate_fields"`
+	MemoDir      string   `yaml:"memo_dir"`
+}
+
+type experimentsConstitution struct {
+	ProjectRegistry experimentsRegistry `yaml:"project_registry"`
+}
+
+// experimentsManifest is the evidence manifest. Each experiment is a free-form
+// map so the configured gate_fields drive the E2 check rather than a fixed
+// struct. Recognized keys are id, status, memo, and the gate fields.
+type experimentsManifest struct {
+	Experiments []map[string]any `yaml:"experiments"`
+}
+
+// ExperimentChecks holds the results of the experiments constitution checks.
+type ExperimentChecks struct {
+	GateViolations []string // E2: experiment missing a declared gate field (error)
+	MissingMemos   []string // E5: failed experiment with no decision memo (warning)
+	ManifestErrors []string // E6: manifest integrity and unresolved id references (error)
+}
+
+// experimentRefGlobs are the document sets scanned for experiment id references
+// (E6). A reference is the token exp:<id>. The manifest itself is excluded.
+var experimentRefGlobs = []string{"docs/**/*.md", "docs/**/*.yaml"}
+
+// experimentRefRe matches an experiment id reference: exp:<id>.
+var experimentRefRe = regexp.MustCompile(`\bexp:([A-Za-z0-9_.\-]+)`)
+
+// RunExperimentChecks loads the experiments constitution and its manifest, then
+// runs the mechanical checks. It returns an empty result when the constitution
+// or manifest is absent, so projects without experiments pay nothing.
+func RunExperimentChecks(log Logger) ExperimentChecks {
+	reg := loadExperimentsRegistry(log)
+	if reg == nil {
+		return ExperimentChecks{}
+	}
+	manifest := loadExperimentsManifest(reg.ManifestPath, log)
+	if manifest == nil {
+		return ExperimentChecks{}
+	}
+	return ExperimentChecks{
+		GateViolations: reg.checkGates(manifest),
+		MissingMemos:   reg.checkMemos(manifest),
+		ManifestErrors: reg.checkManifestTruth(manifest),
+	}
+}
+
+// loadExperimentsRegistry reads the experiments constitution. It returns nil
+// when the file is absent, gating every check off.
+func loadExperimentsRegistry(log Logger) *experimentsRegistry {
+	data, err := os.ReadFile(experimentsConstitutionPath)
+	if err != nil {
+		return nil // constitution not scaffolded — checks are no-ops
+	}
+	var c experimentsConstitution
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		log("experiments: cannot parse %s: %v", experimentsConstitutionPath, err)
+		return nil
+	}
+	return &c.ProjectRegistry
+}
+
+// loadExperimentsManifest reads the evidence manifest. It returns nil when the
+// manifest is absent so a constitution without a manifest yet is a no-op.
+func loadExperimentsManifest(path string, log Logger) *experimentsManifest {
+	if strings.TrimSpace(path) == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var m experimentsManifest
+	if err := yaml.Unmarshal(data, &m); err != nil {
+		log("experiments: cannot parse manifest %s: %v", path, err)
+		return nil
+	}
+	return &m
+}
+
+// checkGates implements E2. Every experiment declares each configured gate field
+// with a non-empty value before any run.
+func (r *experimentsRegistry) checkGates(m *experimentsManifest) []string {
+	if len(r.GateFields) == 0 {
+		return nil
+	}
+	var out []string
+	for _, exp := range m.Experiments {
+		id := experimentID(exp)
+		for _, field := range r.GateFields {
+			if isEmptyValue(exp[field]) {
+				out = append(out, fmt.Sprintf("experiment %s: missing gate field %q before results exist (E2)", id, field))
+			}
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// checkMemos implements E5. A failed experiment must have a decision memo, named
+// by its memo field or living in the memo directory under its id.
+func (r *experimentsRegistry) checkMemos(m *experimentsManifest) []string {
+	var out []string
+	for _, exp := range m.Experiments {
+		if !strings.EqualFold(fmt.Sprint(exp["status"]), "failed") {
+			continue
+		}
+		if memoResolves(exp, r.MemoDir) {
+			continue
+		}
+		out = append(out, fmt.Sprintf("experiment %s: failed gate has no decision memo in %q (E5)", experimentID(exp), r.MemoDir))
+	}
+	sort.Strings(out)
+	return out
+}
+
+// memoResolves reports whether a failed experiment has a decision memo, either
+// through its memo field or a file in the memo directory bearing its id.
+func memoResolves(exp map[string]any, memoDir string) bool {
+	if memo := strings.TrimSpace(fmt.Sprint(exp["memo"])); memo != "" && memo != "<nil>" {
+		if _, err := os.Stat(memo); err == nil {
+			return true
+		}
+	}
+	id := experimentID(exp)
+	if memoDir == "" || id == "" {
+		return false
+	}
+	entries, err := os.ReadDir(memoDir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if strings.Contains(e.Name(), id) {
+			return true
+		}
+	}
+	return false
+}
+
+// checkManifestTruth implements E6. The manifest is the source of truth: every
+// experiment has a unique non-empty id, and every exp:<id> reference in the
+// documents resolves to a manifest entry.
+func (r *experimentsRegistry) checkManifestTruth(m *experimentsManifest) []string {
+	ids, dupErrs := manifestIDs(m)
+	out := dupErrs
+	for _, path := range referenceFiles(r.ManifestPath) {
+		out = append(out, unresolvedRefs(path, ids)...)
+	}
+	sort.Strings(out)
+	return dedupe(out)
+}
+
+// manifestIDs collects the experiment id set and reports missing or duplicate
+// ids.
+func manifestIDs(m *experimentsManifest) (map[string]bool, []string) {
+	ids := make(map[string]bool)
+	var errs []string
+	for i, exp := range m.Experiments {
+		id := experimentID(exp)
+		if id == "" {
+			errs = append(errs, fmt.Sprintf("manifest experiment[%d]: missing id (E6)", i))
+			continue
+		}
+		if ids[id] {
+			errs = append(errs, fmt.Sprintf("manifest experiment %s: duplicate id (E6)", id))
+		}
+		ids[id] = true
+	}
+	return ids, errs
+}
+
+// referenceFiles lists the documents scanned for experiment id references,
+// excluding the manifest itself.
+func referenceFiles(manifestPath string) []string {
+	var out []string
+	for _, p := range gatherProse(experimentRefGlobs) {
+		if filepath.Clean(p) != filepath.Clean(manifestPath) {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// unresolvedRefs reports exp:<id> references in one file absent from the
+// manifest id set.
+func unresolvedRefs(path string, ids map[string]bool) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, mtch := range experimentRefRe.FindAllStringSubmatch(string(data), -1) {
+		if !ids[mtch[1]] {
+			out = append(out, fmt.Sprintf("%s: reference exp:%s does not resolve to a manifest entry (E6)", path, mtch[1]))
+		}
+	}
+	return out
+}
+
+// experimentID returns the id of an experiment entry as a trimmed string.
+func experimentID(exp map[string]any) string {
+	id := strings.TrimSpace(fmt.Sprint(exp["id"]))
+	if id == "<nil>" {
+		return ""
+	}
+	return id
+}
+
+// isEmptyValue reports whether a YAML value counts as absent for the gate check:
+// nil, blank string, or an empty list or map.
+func isEmptyValue(v any) bool {
+	switch x := v.(type) {
+	case nil:
+		return true
+	case string:
+		return strings.TrimSpace(x) == ""
+	case []any:
+		return len(x) == 0
+	case map[string]any:
+		return len(x) == 0
+	}
+	return false
+}

--- a/pkg/orchestrator/internal/analysis/experiments_test.go
+++ b/pkg/orchestrator/internal/analysis/experiments_test.go
@@ -1,0 +1,193 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const defaultExpRegistry = `  manifest_path: docs/experiments/manifest.yaml
+  gate_fields:
+    - question
+    - claims
+    - apparatus
+    - interpret_pass
+    - interpret_fail
+  memo_dir: docs/experiments/decisions
+`
+
+// writeExperimentsProject builds a temp project with an experiments constitution
+// carrying defaultExpRegistry, the given manifest body, and extra files, then
+// chdirs into it.
+func writeExperimentsProject(t *testing.T, manifest string, files map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	consts := filepath.Join(dir, "docs", "constitutions")
+	if err := os.MkdirAll(consts, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "articles:\n  - id: E2\n    title: Gate before numbers\n    rule: x\nproject_registry:\n" + defaultExpRegistry
+	if err := os.WriteFile(filepath.Join(consts, "experiments.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	all := map[string]string{}
+	for k, v := range files {
+		all[k] = v
+	}
+	if manifest != "" {
+		all["docs/experiments/manifest.yaml"] = manifest
+	}
+	for name, content := range all {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+}
+
+func TestRunExperimentChecks_NoConstitutionIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(orig) })
+
+	got := RunExperimentChecks(noopLog)
+	if len(got.GateViolations)+len(got.MissingMemos)+len(got.ManifestErrors) != 0 {
+		t.Errorf("expected no findings without experiments.yaml, got %+v", got)
+	}
+}
+
+func TestRunExperimentChecks_NoManifestIsNoop(t *testing.T) {
+	writeExperimentsProject(t, "", nil)
+	got := RunExperimentChecks(noopLog)
+	if len(got.GateViolations)+len(got.MissingMemos)+len(got.ManifestErrors) != 0 {
+		t.Errorf("expected no findings without a manifest, got %+v", got)
+	}
+}
+
+func TestExperimentGates_E2(t *testing.T) {
+	complete := `experiments:
+  - id: exp001
+    question: does it work
+    claims: yes
+    apparatus: rig
+    interpret_pass: passes
+    interpret_fail: fails
+`
+	missing := `experiments:
+  - id: exp001
+    question: does it work
+    claims: yes
+`
+	t.Run("complete gate passes", func(t *testing.T) {
+		writeExperimentsProject(t, complete, nil)
+		if got := RunExperimentChecks(noopLog).GateViolations; len(got) != 0 {
+			t.Errorf("GateViolations = %v, want 0", got)
+		}
+	})
+	t.Run("missing gate fields flagged", func(t *testing.T) {
+		writeExperimentsProject(t, missing, nil)
+		// apparatus, interpret_pass, interpret_fail absent -> 3 violations
+		if got := RunExperimentChecks(noopLog).GateViolations; len(got) != 3 {
+			t.Errorf("GateViolations = %v, want 3", got)
+		}
+	})
+}
+
+func TestExperimentMemos_E5(t *testing.T) {
+	failed := `experiments:
+  - id: exp007
+    question: q
+    claims: c
+    apparatus: a
+    interpret_pass: p
+    interpret_fail: f
+    status: failed
+`
+	t.Run("failed without memo flagged", func(t *testing.T) {
+		writeExperimentsProject(t, failed, nil)
+		if got := RunExperimentChecks(noopLog).MissingMemos; len(got) != 1 {
+			t.Errorf("MissingMemos = %v, want 1", got)
+		}
+	})
+	t.Run("failed with memo in memo_dir passes", func(t *testing.T) {
+		writeExperimentsProject(t, failed, map[string]string{
+			"docs/experiments/decisions/exp007-memo.md": "why it failed\n",
+		})
+		if got := RunExperimentChecks(noopLog).MissingMemos; len(got) != 0 {
+			t.Errorf("MissingMemos = %v, want 0", got)
+		}
+	})
+}
+
+func TestExperimentManifest_E6(t *testing.T) {
+	manifest := `experiments:
+  - id: exp001
+    question: q
+    claims: c
+    apparatus: a
+    interpret_pass: p
+    interpret_fail: f
+`
+	t.Run("resolved reference passes", func(t *testing.T) {
+		writeExperimentsProject(t, manifest, map[string]string{
+			"docs/paper.md": "See exp:exp001 for details.\n",
+		})
+		if got := RunExperimentChecks(noopLog).ManifestErrors; len(got) != 0 {
+			t.Errorf("ManifestErrors = %v, want 0", got)
+		}
+	})
+	t.Run("unresolved reference flagged", func(t *testing.T) {
+		writeExperimentsProject(t, manifest, map[string]string{
+			"docs/paper.md": "See exp:exp999 which does not exist.\n",
+		})
+		if got := RunExperimentChecks(noopLog).ManifestErrors; len(got) != 1 {
+			t.Errorf("ManifestErrors = %v, want 1", got)
+		}
+	})
+	t.Run("duplicate id flagged", func(t *testing.T) {
+		dup := manifest + `  - id: exp001
+    question: q
+    claims: c
+    apparatus: a
+    interpret_pass: p
+    interpret_fail: f
+`
+		writeExperimentsProject(t, dup, nil)
+		if got := RunExperimentChecks(noopLog).ManifestErrors; len(got) != 1 {
+			t.Errorf("ManifestErrors = %v, want 1 (duplicate id)", got)
+		}
+	})
+}
+
+func TestIsEmptyValue(t *testing.T) {
+	cases := []struct {
+		v    any
+		want bool
+	}{
+		{nil, true},
+		{"", true},
+		{"  ", true},
+		{"x", false},
+		{[]any{}, true},
+		{[]any{1}, false},
+		{map[string]any{}, true},
+		{42, false},
+	}
+	for _, tc := range cases {
+		if got := isEmptyValue(tc.v); got != tc.want {
+			t.Errorf("isEmptyValue(%v) = %v, want %v", tc.v, got, tc.want)
+		}
+	}
+}

--- a/pkg/orchestrator/internal/analysis/paper.go
+++ b/pkg/orchestrator/internal/analysis/paper.go
@@ -1,0 +1,307 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+// Paper constitution checks. These enforce the mechanical articles of
+// docs/constitutions/paper.yaml: P1 vocabulary registry, P3 placeholder
+// traceability, P4 citation integrity, and P5 forbidden terms. Every check is a
+// no-op unless the paper constitution is scaffolded into the project, mirroring
+// how DetectConstitutionDrift gates on the constitution files being present.
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const paperConstitutionPath = "docs/constitutions/paper.yaml"
+
+// paperRegistry mirrors the project_registry block of paper.yaml. Analyze reads
+// it to run the P1, P3, P4, and P5 checks.
+type paperRegistry struct {
+	Vocabulary         map[string]any `yaml:"vocabulary"`
+	ForbiddenTerms     []string       `yaml:"forbidden_terms"`
+	PlaceholderPattern string         `yaml:"placeholder_pattern"`
+	ProseGlobs         []string       `yaml:"prose_globs"`
+	Bibliography       []string       `yaml:"bibliography"`
+}
+
+type paperConstitution struct {
+	ProjectRegistry paperRegistry `yaml:"project_registry"`
+}
+
+// PaperChecks holds the results of the paper constitution checks.
+type PaperChecks struct {
+	VocabularyIssues  []string // P1: prose exists but the vocabulary registry is empty (warning)
+	PlaceholderErrors []string // P3: placeholder names no artifact, or the artifact is absent (error)
+	BrokenCitations   []string // P4: citation key unresolved against the bibliography (error)
+	ForbiddenTerms    []string // P5: forbidden term occurs in publication prose (warning)
+}
+
+// RunPaperChecks loads the paper constitution and runs the mechanical checks.
+// When docs/constitutions/paper.yaml is absent, it returns an empty result so
+// projects without a paper pay nothing.
+func RunPaperChecks(log Logger) PaperChecks {
+	reg := loadPaperRegistry(log)
+	if reg == nil {
+		return PaperChecks{}
+	}
+	prose := gatherProse(reg.ProseGlobs)
+	return PaperChecks{
+		VocabularyIssues:  reg.checkVocabulary(prose),
+		PlaceholderErrors: reg.checkPlaceholders(prose, log),
+		BrokenCitations:   reg.checkCitations(prose),
+		ForbiddenTerms:    reg.checkForbiddenTerms(prose),
+	}
+}
+
+// loadPaperRegistry reads the paper constitution. It returns nil when the file
+// is absent, which gates every check off.
+func loadPaperRegistry(log Logger) *paperRegistry {
+	data, err := os.ReadFile(paperConstitutionPath)
+	if err != nil {
+		return nil // constitution not scaffolded — checks are no-ops
+	}
+	var c paperConstitution
+	if err := yaml.Unmarshal(data, &c); err != nil {
+		log("paper: cannot parse %s: %v", paperConstitutionPath, err)
+		return nil
+	}
+	return &c.ProjectRegistry
+}
+
+// checkVocabulary implements P1. Full enforcement (prose uses registry terms and
+// no coined alternatives) needs a synonym map we do not have; the mechanical
+// slice we check is that a project with publication prose declares its terms of
+// art at all.
+func (r *paperRegistry) checkVocabulary(prose []string) []string {
+	if len(prose) == 0 || len(r.Vocabulary) > 0 {
+		return nil
+	}
+	return []string{fmt.Sprintf("vocabulary registry is empty but %d prose file(s) exist — declare terms of art in paper.yaml (P1)", len(prose))}
+}
+
+// placeholderRe compiles the registry's placeholder pattern. A nil result means
+// the check is skipped.
+func (r *paperRegistry) placeholderRe(log Logger) *regexp.Regexp {
+	if strings.TrimSpace(r.PlaceholderPattern) == "" {
+		return nil
+	}
+	re, err := regexp.Compile(r.PlaceholderPattern)
+	if err != nil {
+		log("paper: invalid placeholder_pattern %q: %v", r.PlaceholderPattern, err)
+		return nil
+	}
+	return re
+}
+
+// checkPlaceholders implements P3. Every placeholder must name a source artifact
+// that exists in the repository.
+func (r *paperRegistry) checkPlaceholders(prose []string, log Logger) []string {
+	re := r.placeholderRe(log)
+	if re == nil {
+		return nil
+	}
+	var out []string
+	for _, path := range prose {
+		out = append(out, placeholderViolations(path, re)...)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// placeholderViolations reports each placeholder in one file whose named
+// artifact is missing or unnamed.
+func placeholderViolations(path string, re *regexp.Regexp) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var out []string
+	for _, m := range re.FindAllStringSubmatch(string(data), -1) {
+		artifact := ""
+		if len(m) > 1 {
+			artifact = strings.TrimSpace(m[1])
+		}
+		if artifact == "" {
+			out = append(out, fmt.Sprintf("%s: placeholder %q names no source artifact (P3)", path, m[0]))
+			continue
+		}
+		if _, err := os.Stat(artifact); err != nil {
+			out = append(out, fmt.Sprintf("%s: placeholder cites missing artifact %q (P3)", path, artifact))
+		}
+	}
+	return out
+}
+
+// citeRe matches LaTeX citation commands (\cite, \citep, \citet, with optional
+// bracket arguments); citeKeyRe matches markdown-style @keys.
+var citeRe = regexp.MustCompile(`\\cite[a-zA-Z]*(?:\[[^\]]*\])*\{([^}]*)\}`)
+var citeKeyRe = regexp.MustCompile(`@([A-Za-z0-9_:.\-]+)`)
+
+// checkCitations implements P4. Every citation key must resolve against a
+// bibliography file. With no bibliography configured, the check is skipped.
+func (r *paperRegistry) checkCitations(prose []string) []string {
+	if len(r.Bibliography) == 0 {
+		return nil
+	}
+	keys := r.bibKeys()
+	var out []string
+	for _, path := range prose {
+		out = append(out, unresolvedCitations(path, keys)...)
+	}
+	sort.Strings(out)
+	return dedupe(out)
+}
+
+// bibKeyRe matches a BibTeX entry key: @type{key,
+var bibKeyRe = regexp.MustCompile(`(?m)^\s*@\w+\s*\{\s*([^,\s]+)\s*,`)
+
+// bibKeys collects the defined citation keys from every bibliography file.
+func (r *paperRegistry) bibKeys() map[string]bool {
+	keys := make(map[string]bool)
+	for _, bib := range r.Bibliography {
+		data, err := os.ReadFile(bib)
+		if err != nil {
+			continue
+		}
+		for _, m := range bibKeyRe.FindAllStringSubmatch(string(data), -1) {
+			keys[m[1]] = true
+		}
+	}
+	return keys
+}
+
+// unresolvedCitations reports citation keys in one file absent from the
+// bibliography.
+func unresolvedCitations(path string, keys map[string]bool) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	text := string(data)
+	var out []string
+	for _, key := range extractCiteKeys(text) {
+		if !keys[key] {
+			out = append(out, fmt.Sprintf("%s: unresolved citation key %q (P4)", path, key))
+		}
+	}
+	return out
+}
+
+// extractCiteKeys pulls citation keys from LaTeX \cite commands and markdown
+// @keys in one document.
+func extractCiteKeys(text string) []string {
+	var keys []string
+	for _, m := range citeRe.FindAllStringSubmatch(text, -1) {
+		for _, k := range strings.Split(m[1], ",") {
+			if k = strings.TrimSpace(k); k != "" {
+				keys = append(keys, k)
+			}
+		}
+	}
+	for _, m := range citeKeyRe.FindAllStringSubmatch(text, -1) {
+		keys = append(keys, m[1])
+	}
+	return keys
+}
+
+// checkForbiddenTerms implements P5. Each declared forbidden term is reported
+// wherever it occurs in publication prose.
+func (r *paperRegistry) checkForbiddenTerms(prose []string) []string {
+	if len(r.ForbiddenTerms) == 0 {
+		return nil
+	}
+	var out []string
+	for _, path := range prose {
+		out = append(out, forbiddenTermHits(path, r.ForbiddenTerms)...)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// forbiddenTermHits reports each forbidden term found in one file, matched
+// case-insensitively on a word boundary.
+func forbiddenTermHits(path string, terms []string) []string {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	lower := strings.ToLower(string(data))
+	var out []string
+	for _, term := range terms {
+		t := strings.ToLower(strings.TrimSpace(term))
+		if t != "" && strings.Contains(lower, t) {
+			out = append(out, fmt.Sprintf("%s: forbidden term %q occurs in prose (P5)", path, term))
+		}
+	}
+	return out
+}
+
+// gatherProse expands the prose globs to a sorted, de-duplicated file list. It
+// supports a single ** segment (for example paper/**/*.md) in addition to the
+// patterns filepath.Glob understands.
+func gatherProse(globs []string) []string {
+	seen := make(map[string]bool)
+	for _, g := range globs {
+		for _, p := range expandGlob(g) {
+			seen[p] = true
+		}
+	}
+	out := make([]string, 0, len(seen))
+	for p := range seen {
+		out = append(out, p)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// expandGlob resolves one glob. Patterns without ** defer to filepath.Glob;
+// a pattern with a ** segment walks the directory before it and matches the
+// trailing pattern against each file's base name.
+func expandGlob(pattern string) []string {
+	if !strings.Contains(pattern, "**") {
+		matches, _ := filepath.Glob(pattern)
+		return matches
+	}
+	root, tail, ok := strings.Cut(pattern, "**")
+	if !ok {
+		return nil
+	}
+	root = strings.TrimSuffix(root, string(filepath.Separator))
+	if root == "" {
+		root = "."
+	}
+	trailing := strings.TrimPrefix(tail, string(filepath.Separator))
+	var out []string
+	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if ok, _ := filepath.Match(trailing, filepath.Base(p)); ok {
+			out = append(out, p)
+		}
+		return nil
+	})
+	return out
+}
+
+// dedupe removes duplicate strings from a sorted slice.
+func dedupe(in []string) []string {
+	if len(in) == 0 {
+		return in
+	}
+	out := in[:1]
+	for _, s := range in[1:] {
+		if s != out[len(out)-1] {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/pkg/orchestrator/internal/analysis/paper_test.go
+++ b/pkg/orchestrator/internal/analysis/paper_test.go
@@ -1,0 +1,159 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func noopLog(string, ...any) {}
+
+// writePaperProject builds a temp project with a paper.yaml carrying the given
+// project_registry body and the supplied files, then chdirs into it. The
+// working directory is restored on cleanup.
+func writePaperProject(t *testing.T, registry string, files map[string]string) {
+	t.Helper()
+	dir := t.TempDir()
+	consts := filepath.Join(dir, "docs", "constitutions")
+	if err := os.MkdirAll(consts, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	body := "articles:\n  - id: P1\n    title: Vocabulary registry\n    rule: x\nproject_registry:\n" + registry
+	if err := os.WriteFile(filepath.Join(consts, "paper.yaml"), []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for name, content := range files {
+		p := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	orig, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.Chdir(orig) })
+}
+
+func TestRunPaperChecks_NoConstitutionIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(orig) })
+
+	got := RunPaperChecks(noopLog)
+	if len(got.VocabularyIssues)+len(got.PlaceholderErrors)+len(got.BrokenCitations)+len(got.ForbiddenTerms) != 0 {
+		t.Errorf("expected no findings without paper.yaml, got %+v", got)
+	}
+}
+
+func TestPaperVocabulary_P1(t *testing.T) {
+	cases := []struct {
+		name     string
+		registry string
+		want     int
+	}{
+		{
+			name:     "empty registry with prose flagged",
+			registry: "  vocabulary: {}\n  prose_globs:\n    - paper/*.md\n",
+			want:     1,
+		},
+		{
+			name:     "populated registry passes",
+			registry: "  vocabulary:\n    spindle: the state-machine engine\n  prose_globs:\n    - paper/*.md\n",
+			want:     0,
+		},
+		{
+			name:     "no prose passes",
+			registry: "  vocabulary: {}\n  prose_globs:\n    - paper/*.md\n",
+			want:     0,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			files := map[string]string{}
+			if tc.name != "no prose passes" {
+				files["paper/intro.md"] = "The system works.\n"
+			}
+			writePaperProject(t, tc.registry, files)
+			got := RunPaperChecks(noopLog)
+			if len(got.VocabularyIssues) != tc.want {
+				t.Errorf("VocabularyIssues = %v, want %d", got.VocabularyIssues, tc.want)
+			}
+		})
+	}
+}
+
+func TestPaperPlaceholders_P3(t *testing.T) {
+	registry := "  placeholder_pattern: '\\{\\{DATA:([^}]+)\\}\\}'\n  prose_globs:\n    - paper/*.md\n"
+
+	t.Run("missing artifact fails", func(t *testing.T) {
+		writePaperProject(t, registry, map[string]string{
+			"paper/results.md": "Accuracy was {{DATA:results/run1.json}}.\n",
+		})
+		got := RunPaperChecks(noopLog)
+		if len(got.PlaceholderErrors) != 1 {
+			t.Fatalf("PlaceholderErrors = %v, want 1", got.PlaceholderErrors)
+		}
+	})
+
+	t.Run("present artifact passes", func(t *testing.T) {
+		writePaperProject(t, registry, map[string]string{
+			"paper/results.md":  "Accuracy was {{DATA:results/run1.json}}.\n",
+			"results/run1.json": "{}\n",
+		})
+		got := RunPaperChecks(noopLog)
+		if len(got.PlaceholderErrors) != 0 {
+			t.Errorf("PlaceholderErrors = %v, want 0", got.PlaceholderErrors)
+		}
+	})
+}
+
+func TestPaperCitations_P4(t *testing.T) {
+	registry := "  prose_globs:\n    - paper/*.tex\n  bibliography:\n    - paper/refs.bib\n"
+	files := map[string]string{
+		"paper/refs.bib":  "@article{known2020, title={A}}\n",
+		"paper/paper.tex": "As shown \\cite{known2020} and \\citep{missing2021}.\n",
+	}
+	writePaperProject(t, registry, files)
+	got := RunPaperChecks(noopLog)
+	if len(got.BrokenCitations) != 1 {
+		t.Fatalf("BrokenCitations = %v, want 1 (missing2021)", got.BrokenCitations)
+	}
+}
+
+func TestPaperForbiddenTerms_P5(t *testing.T) {
+	registry := "  forbidden_terms:\n    - novel\n    - groundbreaking\n  prose_globs:\n    - paper/*.md\n"
+	files := map[string]string{
+		"paper/intro.md": "We present a novel approach that works.\n",
+	}
+	writePaperProject(t, registry, files)
+	got := RunPaperChecks(noopLog)
+	if len(got.ForbiddenTerms) != 1 {
+		t.Errorf("ForbiddenTerms = %v, want 1 (novel)", got.ForbiddenTerms)
+	}
+}
+
+func TestExpandGlob_DoubleStar(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "paper", "sections")
+	os.MkdirAll(nested, 0o755)
+	os.WriteFile(filepath.Join(dir, "paper", "top.md"), []byte("x"), 0o644)
+	os.WriteFile(filepath.Join(nested, "deep.md"), []byte("x"), 0o644)
+	os.WriteFile(filepath.Join(nested, "skip.tex"), []byte("x"), 0o644)
+
+	orig, _ := os.Getwd()
+	os.Chdir(dir)
+	t.Cleanup(func() { os.Chdir(orig) })
+
+	got := expandGlob("paper/**/*.md")
+	if len(got) != 2 {
+		t.Errorf("expandGlob matched %v, want 2 .md files", got)
+	}
+}

--- a/pkg/orchestrator/paper.go
+++ b/pkg/orchestrator/paper.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package orchestrator
+
+// Paper build namespace. BuildPaperPDF compiles a paper from markdown to PDF via
+// pandoc and the LaTeX toolchain; ReportPaperPlaceholders counts the data
+// placeholders still open in the paper source. These are build and reporting
+// utilities only — the paper constitution's consistency gates (P1, P3, P4, P5)
+// live in mage analyze, not here.
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+const (
+	defaultPaperSource   = "paper/paper.md"
+	defaultPaperDir      = "paper"
+	paperPlaceholderExpr = `\{\{DATA:([^}]+)\}\}`
+	latexNonstop         = "-interaction=nonstopmode"
+)
+
+// paperProseExts are the source extensions scanned for placeholders.
+var paperProseExts = map[string]bool{".md": true, ".tex": true}
+
+// paperPlaceholderRe matches a data placeholder in paper source.
+var paperPlaceholderRe = regexp.MustCompile(paperPlaceholderExpr)
+
+// paperCommand is one step of the build: a binary and its arguments.
+type paperCommand struct {
+	bin  string
+	args []string
+}
+
+// paperToolchain is the ordered set of binaries paper:pdf requires on PATH.
+var paperToolchain = []string{binPandoc, binPdflatex, binBibtex}
+
+// paperCommands returns the ordered build sequence for a source document. It
+// converts markdown to LaTeX with pandoc, then runs the standard
+// pdflatex/bibtex/pdflatex/pdflatex cycle to resolve references.
+func paperCommands(source string) []paperCommand {
+	stem := strings.TrimSuffix(source, filepath.Ext(source))
+	tex := stem + ".tex"
+	return []paperCommand{
+		{binPandoc, []string{source, "-o", tex}},
+		{binPdflatex, []string{latexNonstop, tex}},
+		{binBibtex, []string{stem}},
+		{binPdflatex, []string{latexNonstop, tex}},
+		{binPdflatex, []string{latexNonstop, tex}},
+	}
+}
+
+// checkPaperToolchain returns an error naming the first required binary missing
+// from PATH. paper:pdf hard-requires the full toolchain.
+func checkPaperToolchain() error {
+	for _, bin := range paperToolchain {
+		if _, err := exec.LookPath(bin); err != nil {
+			return fmt.Errorf("paper:pdf requires %q on PATH; install pandoc and a LaTeX distribution (for example texlive)", bin)
+		}
+	}
+	return nil
+}
+
+// BuildPaperPDF compiles the paper at source (default paper/paper.md) to PDF. It
+// hard-requires the toolchain: a missing binary is a clear error, not a skip.
+func BuildPaperPDF(source string) error {
+	if strings.TrimSpace(source) == "" {
+		source = defaultPaperSource
+	}
+	if err := checkPaperToolchain(); err != nil {
+		return err
+	}
+	if _, err := os.Stat(source); err != nil {
+		return fmt.Errorf("paper source %q not found: %w", source, err)
+	}
+	for _, c := range paperCommands(source) {
+		cmd := exec.Command(c.bin, c.args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("paper build step %s %s: %w", c.bin, strings.Join(c.args, " "), err)
+		}
+	}
+	return nil
+}
+
+// ReportPaperPlaceholders counts the data placeholders under dir (default
+// paper/) and prints a per-file and total report. It is a reporting aid, not a
+// gate, so it returns nil even when placeholders remain; the P3 release gate in
+// mage analyze enforces zero.
+func ReportPaperPlaceholders(dir string) error {
+	if strings.TrimSpace(dir) == "" {
+		dir = defaultPaperDir
+	}
+	if _, err := os.Stat(dir); err != nil {
+		fmt.Printf("paper:placeholders: no paper directory at %q — nothing to report\n", dir)
+		return nil
+	}
+	total := 0
+	for _, file := range paperSourceFiles(dir) {
+		n := countPlaceholders(file)
+		if n > 0 {
+			fmt.Printf("  %s: %d placeholder(s)\n", file, n)
+			total += n
+		}
+	}
+	fmt.Printf("paper:placeholders: %d placeholder(s) remaining under %q\n", total, dir)
+	return nil
+}
+
+// paperSourceFiles walks dir and returns the markdown and LaTeX source files.
+func paperSourceFiles(dir string) []string {
+	var out []string
+	_ = filepath.WalkDir(dir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return nil
+		}
+		if paperProseExts[strings.ToLower(filepath.Ext(p))] {
+			out = append(out, p)
+		}
+		return nil
+	})
+	return out
+}
+
+// countPlaceholders returns the number of data placeholders in one file.
+func countPlaceholders(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	return len(paperPlaceholderRe.FindAllStringIndex(string(data), -1))
+}

--- a/pkg/orchestrator/paper_test.go
+++ b/pkg/orchestrator/paper_test.go
@@ -1,0 +1,86 @@
+// Copyright (c) 2026 Petar Djukic. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+package orchestrator
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPaperCommands_Sequence(t *testing.T) {
+	got := paperCommands("paper/paper.md")
+	want := []paperCommand{
+		{binPandoc, []string{"paper/paper.md", "-o", "paper/paper.tex"}},
+		{binPdflatex, []string{latexNonstop, "paper/paper.tex"}},
+		{binBibtex, []string{"paper/paper"}},
+		{binPdflatex, []string{latexNonstop, "paper/paper.tex"}},
+		{binPdflatex, []string{latexNonstop, "paper/paper.tex"}},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("paperCommands returned %d steps, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].bin != want[i].bin || strings.Join(got[i].args, " ") != strings.Join(want[i].args, " ") {
+			t.Errorf("step %d = %s %v, want %s %v", i, got[i].bin, got[i].args, want[i].bin, want[i].args)
+		}
+	}
+}
+
+func TestCheckPaperToolchain_MissingBinaryNamed(t *testing.T) {
+	t.Setenv("PATH", t.TempDir()) // empty dir on PATH: no binaries resolve
+	err := checkPaperToolchain()
+	if err == nil {
+		t.Fatal("expected an error when the toolchain is absent")
+	}
+	if !strings.Contains(err.Error(), binPandoc) {
+		t.Errorf("error %q should name the missing binary %q", err.Error(), binPandoc)
+	}
+}
+
+func TestBuildPaperPDF_HardRequiresToolchain(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	err := BuildPaperPDF("")
+	if err == nil {
+		t.Fatal("expected BuildPaperPDF to fail without the toolchain")
+	}
+	if !strings.Contains(err.Error(), "paper:pdf requires") {
+		t.Errorf("error %q should explain the toolchain requirement", err.Error())
+	}
+}
+
+func TestCountPlaceholders(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sec.md")
+	os.WriteFile(path, []byte("A {{DATA:x.json}} and {{DATA:y.csv}} here.\n"), 0o644)
+	if n := countPlaceholders(path); n != 2 {
+		t.Errorf("countPlaceholders = %d, want 2", n)
+	}
+	if n := countPlaceholders(filepath.Join(dir, "missing.md")); n != 0 {
+		t.Errorf("countPlaceholders(missing) = %d, want 0", n)
+	}
+}
+
+func TestReportPaperPlaceholders(t *testing.T) {
+	dir := t.TempDir()
+	paperDir := filepath.Join(dir, "paper")
+	os.MkdirAll(paperDir, 0o755)
+	os.WriteFile(filepath.Join(paperDir, "a.md"), []byte("{{DATA:one}} {{DATA:two}}\n"), 0o644)
+	os.WriteFile(filepath.Join(paperDir, "b.tex"), []byte("{{DATA:three}}\n"), 0o644)
+	os.WriteFile(filepath.Join(paperDir, "notes.txt"), []byte("{{DATA:ignored}}\n"), 0o644)
+
+	if got := paperSourceFiles(paperDir); len(got) != 2 {
+		t.Errorf("paperSourceFiles matched %v, want 2 (.md and .tex only)", got)
+	}
+	if err := ReportPaperPlaceholders(paperDir); err != nil {
+		t.Errorf("ReportPaperPlaceholders returned error: %v", err)
+	}
+}
+
+func TestReportPaperPlaceholders_NoDirIsNoError(t *testing.T) {
+	if err := ReportPaperPlaceholders(filepath.Join(t.TempDir(), "absent")); err != nil {
+		t.Errorf("expected nil for a missing paper dir, got %v", err)
+	}
+}

--- a/pkg/orchestrator/scaffold.go
+++ b/pkg/orchestrator/scaffold.go
@@ -41,6 +41,12 @@ var interfaceConstitution string
 //go:embed constitutions/semantic-model.yaml
 var semanticModelConstitution string
 
+//go:embed constitutions/paper.yaml
+var paperConstitution string
+
+//go:embed constitutions/experiments.yaml
+var experimentsConstitution string
+
 // scaffoldedConstitutions maps the file names written into the consumer's
 // docs/constitutions/ directory to their embedded contents. Every constitution
 // authored as a default template lives here; new ones must be added to this
@@ -48,9 +54,11 @@ var semanticModelConstitution string
 var scaffoldedConstitutions = map[string]string{
 	"design.yaml":         designConstitution,
 	"execution.yaml":      executionConstitution,
+	"experiments.yaml":    experimentsConstitution,
 	"go-style.yaml":       goStyleConstitution,
 	"interface.yaml":      interfaceConstitution,
 	"issue-format.yaml":   issueFormatConstitution,
+	"paper.yaml":          paperConstitution,
 	"planning.yaml":       planningConstitution,
 	"semantic-model.yaml": semanticModelConstitution,
 	"testing.yaml":        testingConstitution,

--- a/pkg/orchestrator/scaffold_test.go
+++ b/pkg/orchestrator/scaffold_test.go
@@ -233,9 +233,11 @@ func TestScaffoldedConstitutions_CoversAllEmbeddedConstitutions(t *testing.T) {
 	want := []string{
 		"design.yaml",
 		"execution.yaml",
+		"experiments.yaml",
 		"go-style.yaml",
 		"interface.yaml",
 		"issue-format.yaml",
+		"paper.yaml",
 		"planning.yaml",
 		"semantic-model.yaml",
 		"testing.yaml",


### PR DESCRIPTION
## Summary

Two new constitution templates — paper.yaml (P1–P6) and experiments.yaml (E1–E6) — extracted from operational experience, scaffolded into consuming projects alongside the existing eight. Their mechanical articles are enforced by mage analyze (gated on the constitution being present), and a build-only Paper mage namespace compiles the paper and reports open placeholders. Consistency checks land in analyze; no parallel "audit" target is introduced.

## Changes

- docs/constitutions/paper.yaml and experiments.yaml in the article format, each article carrying an enforcement value (analyze or advisory) to satisfy P6, plus a project_registry block analyze reads. Byte-identical embedded copies under pkg/orchestrator/constitutions/, wired into the //go:embed block and scaffoldedConstitutions map so scaffold:push delivers them. eng03 documents when to include each.
- analyze paper checks (paper.go): P1 vocabulary registry, P3 placeholder traceability, P4 citation integrity, P5 forbidden terms. P3/P4 are errors; P1/P5 warnings. No-op unless paper.yaml is scaffolded.
- analyze experiments checks (experiments.go): E2 gate-before-numbers, E5 negative-results-recorded, E6 manifest-as-truth. E2/E6 errors; E5 warning. No-op unless experiments.yaml and its manifest exist.
- Paper mage namespace: paper:pdf (pandoc + pdflatex + bibtex + pdflatex + pdflatex, hard-requiring the toolchain) and paper:placeholders (count/report), mirrored into orchestrator.go.tmpl for consumers.

## Scope notes

- Maximum-mechanizable analyze scope was chosen: P1 and E5 are implemented at their honestly-checkable slice (P1 requires a paper with prose to declare its terms of art; E5 requires a memo for a failed gate), with the limits documented in code. Full P1 synonym enforcement is out of reach without a synonym map.
- paper:pdf hard-requires the toolchain (clear error naming the first missing binary); tests exercise only argv assembly and the requirement error via an empty PATH, so the suite passes on toolchain-less machines.

## Stats

Epic deltas from main (mage stats:loc):

    Lines of code (Go, production): 20824 -> 21569 (+745)
    Lines of code (Go, tests):      37976 -> 38416 (+440)
    Constitution YAML templates:    ~430 lines (not counted by stats:loc)

Estimated LOC across sub-issues: 1500. Delivered ~1615 lines (Go + YAML).

## Test plan

- [x] mage analyze passes (paper/experiment checks report 0 on this repo; no hard errors)
- [x] Full pkg/orchestrator and internal/analysis test suites pass (orchestrator: ok, 256s in isolation)
- [x] New table-driven tests cover pass/fail for P1/P3/P4/P5, E2/E5/E6, and the paper:pdf toolchain hard-require
- [x] go build ./... and go vet clean; gofmt clean; E8 (<=40-line funcs) and E9 (<=500-line files) respected
- [x] mage -l lists paper:pdf and paper:placeholders
- [x] Documentation reviewed for consistency

Closes #2149
Closes #2150
Closes #2151
Closes #2152
Closes #2153